### PR TITLE
fix: pin issue-to-pr scafld harden status

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-6edae481eaf8",
-    "digest": "2bce206cf6f1b72599783db7393c1932fd372851fc156d0c2cee64ec208c3477"
+    "version": "sha-34a1409919df",
+    "digest": "e3156a2ed390db8d9b3138891c9e313ecf005f37868fba131c960dc6ff2374b4"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -58,10 +58,10 @@ The document must preserve front matter with:
 
 - `spec_version: '2.0'`
 - `task_id`
-- `created`
-- `updated`
-- `status`
-- `harden_status`
+- `created`: ISO-8601 timestamp
+- `updated`: ISO-8601 timestamp
+- `status: draft`
+- `harden_status: not_run`
 - `size`
 - `risk_level`
 

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -327,11 +327,12 @@ runners:
             thread, outbox_entry, target_repo, repo_snapshot,
             repo_snapshot_path, and repo_context to keep the spec grounded in
             the actual request and repository. Preserve the front matter shape:
-            spec_version '2.0', task_id, created, updated, status, harden_status,
-            size, and risk_level. The body must include Current State, Summary,
-            Context, Objectives, Scope, Dependencies, Assumptions, Touchpoints,
-            Risks, Acceptance, at least one Phase section, Rollback, Review,
-            Self Eval, Deviations, Metadata, Origin, Harden Rounds, and
+            spec_version '2.0', task_id, created, updated, status: draft,
+            harden_status: not_run, size, and risk_level. The body must include
+            Current State, Summary, Context, Objectives, Scope, Dependencies,
+            Assumptions, Touchpoints, Risks, Acceptance, at least one Phase
+            section, Rollback, Review, Self Eval, Deviations, Metadata, Origin,
+            Harden Rounds, and
             Planning Log. Declare changed repo files in Context / Files
             impacted and Phase / Changes using concrete repo-relative paths in
             backticks. Do not declare scafld-managed control-plane artifacts


### PR DESCRIPTION
## Summary
- pins the issue-to-pr scafld authoring instructions to `harden_status: not_run`
- keeps the SKILL.md contract and X.yaml agent-step prompt aligned with scafld 2.x validation

## Validation
- `git diff --check`
- `pnpm test:fast -- --runInBand`
