### PR TITLE
fix: align issue-to-pr with scafld spec schema

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-34a1409919df",
-    "digest": "e3156a2ed390db8d9b3138891c9e313ecf005f37868fba131c960dc6ff2374b4"
+    "version": "sha-2a10bed3ed7c",
+    "digest": "52d8f07ead5d6db296688fa77cfcdf2a3746d3ee56d90e7b7ed171d4b73cca04"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -60,9 +60,10 @@ The document must preserve front matter with:
 - `task_id`
 - `created`: ISO-8601 timestamp
 - `updated`: ISO-8601 timestamp
+- `title`: non-empty task title, normally `thread_title`
 - `status: draft`
 - `harden_status: not_run`
-- `size`
+- `size`: one of `small`, `medium`, or `large`
 - `risk_level`
 
 The body must include the standard scafld 2 sections: Current State, Summary,
@@ -92,7 +93,7 @@ merge-base comparisons.
 - `repo_snapshot`: compact structured snapshot of the target repo.
 - `repo_snapshot_path`: optional path to a fuller repo snapshot artifact.
 - `repo_context`: textual summary of repo shape and validation hooks.
-- `size`: scafld size, default `micro`.
+- `size`: scafld size, default `small`.
 - `risk`: scafld risk, default `low`.
 - `base`: base ref for PR packaging, default `main`.
 - `fixture`: workspace root containing `.scafld`.

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -14,7 +14,7 @@ harness:
         thread_title: Fixture smoke test
         thread_body: Minimal thread body for the harness.
         thread_locator: local://fixtures/issue-to-pr-smoke
-        size: micro
+        size: small
         risk: low
         scafld_bin: ./fixtures/issue-to-pr-harness-scafld.mjs
       expect:
@@ -26,7 +26,7 @@ harness:
         thread_title: Fix-boundary harness reach
         thread_body: Canned markdown spec lets the graph progress to the fix authoring boundary.
         thread_locator: local://fixtures/issue-to-pr-reach-fix
-        size: micro
+        size: small
         risk: low
         scafld_bin: ./fixtures/issue-to-pr-harness-scafld.mjs
       caller:
@@ -38,9 +38,10 @@ harness:
               task_id: issue-to-pr-reach-fix
               created: '2026-05-04T00:00:00Z'
               updated: '2026-05-04T00:00:00Z'
+              title: Fix-boundary harness reach
               status: draft
               harden_status: not_run
-              size: micro
+              size: small
               risk_level: low
               ---
 
@@ -256,7 +257,7 @@ runners:
       size:
         type: string
         required: false
-        default: "micro"
+        default: "small"
         description: "Size passed to scafld plan."
       risk:
         type: string
@@ -328,7 +329,8 @@ runners:
             repo_snapshot_path, and repo_context to keep the spec grounded in
             the actual request and repository. Preserve the front matter shape:
             spec_version '2.0', task_id, created, updated, status: draft,
-            harden_status: not_run, size, and risk_level. The body must include
+            title: non-empty thread title, harden_status: not_run, size as one
+            of small, medium, or large, and risk_level. The body must include
             Current State, Summary, Context, Objectives, Scope, Dependencies,
             Assumptions, Touchpoints, Risks, Acceptance, at least one Phase
             section, Rollback, Review, Self Eval, Deviations, Metadata, Origin,


### PR DESCRIPTION
## Summary
- adds the required scafld `title` frontmatter guidance for issue-to-pr generated specs
- replaces stale `micro` size defaults with current scafld `small|medium|large` sizing
- refreshes the official skills lock for the updated issue-to-pr package

## Validation
- `pnpm verify:fast`
- `git diff --check`