### PR TITLE
fix: normalize issue-to-pr scafld specs

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-2a10bed3ed7c",
-    "digest": "52d8f07ead5d6db296688fa77cfcdf2a3746d3ee56d90e7b7ed171d4b73cca04"
+    "version": "sha-58e00c1966bc",
+    "digest": "c71eaaf9ed7132b9e37ca1cd02b52a032ef3d306449459d0825e3eb97cd05c49"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/packages/cli/tools/spec/normalize_scafld_frontmatter/fixtures/basic.yaml
+++ b/packages/cli/tools/spec/normalize_scafld_frontmatter/fixtures/basic.yaml
@@ -1,0 +1,35 @@
+name: spec-normalize-scafld-frontmatter-basic
+lane: deterministic
+target:
+  kind: tool
+  ref: spec.normalize_scafld_frontmatter
+inputs:
+  task_id: issue-91-docs
+  thread_title: Dogfood checklist docs
+  size: small
+  risk: low
+  spec_contents: |
+    ---
+    spec_version: '2.0'
+    task_id: issue-91-docs
+    created: 2026-05-12T00:00:00Z
+    updated: 2026-05-12T00:00:00Z
+    status: draft
+    harden_status: not_run
+    size: micro
+    risk_level: low
+    ---
+
+    ## Current State
+
+    A generated spec omitted title.
+expect:
+  status: success
+  output:
+    matches_packet: runx.spec.normalized_scafld_spec.v1
+    subset:
+      frontmatter:
+        task_id: issue-91-docs
+        title: Dogfood checklist docs
+        size: small
+      changed: true

--- a/packages/cli/tools/spec/normalize_scafld_frontmatter/manifest.json
+++ b/packages/cli/tools/spec/normalize_scafld_frontmatter/manifest.json
@@ -1,0 +1,60 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "spec.normalize_scafld_frontmatter",
+  "description": "Normalize scafld 2 markdown frontmatter before writing an agent-authored spec.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": [
+      "./run.mjs"
+    ]
+  },
+  "inputs": {
+    "spec_contents": {
+      "type": "string",
+      "required": true,
+      "description": "Agent-authored scafld markdown spec contents."
+    },
+    "task_id": {
+      "type": "string",
+      "required": false,
+      "description": "Expected scafld task id."
+    },
+    "thread_title": {
+      "type": "string",
+      "required": false,
+      "description": "Expected non-empty scafld title."
+    },
+    "size": {
+      "type": "string",
+      "required": false,
+      "description": "Expected scafld size: small, medium, or large."
+    },
+    "risk": {
+      "type": "string",
+      "required": false,
+      "description": "Expected scafld risk: low, medium, or high."
+    }
+  },
+  "output": {
+    "packet": "runx.spec.normalized_scafld_spec.v1",
+    "wrap_as": "normalized_spec"
+  },
+  "scopes": [
+    "spec.normalize_scafld_frontmatter"
+  ],
+  "runx": {
+    "artifacts": {
+      "wrap_as": "normalized_spec"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": [
+      "./run.mjs"
+    ]
+  },
+  "source_hash": "sha256:5194f1cbe85fcab7e9dae67f494e175ef6cea251e64ab71dc9bcea3c739d4141",
+  "schema_hash": "sha256:5572fff6a0dfb3f3965e2f6f91b62b5957cd1df6f5d4c568102b8f3a74dab389",
+  "toolkit_version": "0.1.3"
+}

--- a/packages/cli/tools/spec/normalize_scafld_frontmatter/run.mjs
+++ b/packages/cli/tools/spec/normalize_scafld_frontmatter/run.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, "../../../");
+const relativeToolDir = path.relative(packageRoot, here);
+const sourceEntry = path.join(here, "src", "index.ts");
+const distEntry = path.join(packageRoot, "dist", relativeToolDir, "src", "index.js");
+const runningFromInstalledPackage = fileURLToPath(import.meta.url).includes(`${path.sep}node_modules${path.sep}`);
+const entry = (runningFromInstalledPackage || !fs.existsSync(sourceEntry)) && fs.existsSync(distEntry)
+  ? distEntry
+  : sourceEntry;
+const tool = (await import(pathToFileURL(entry).href)).default;
+await tool.main();

--- a/packages/cli/tools/spec/normalize_scafld_frontmatter/src/index.ts
+++ b/packages/cli/tools/spec/normalize_scafld_frontmatter/src/index.ts
@@ -1,0 +1,145 @@
+import {
+  defineTool,
+  stringInput,
+} from "@runxhq/authoring";
+
+const validSizes = new Set(["small", "medium", "large"]);
+const validRisks = new Set(["low", "medium", "high"]);
+
+export default defineTool({
+  name: "spec.normalize_scafld_frontmatter",
+  description: "Normalize scafld 2 markdown frontmatter before writing an agent-authored spec.",
+  inputs: {
+    spec_contents: stringInput({ description: "Agent-authored scafld markdown spec contents." }),
+    task_id: stringInput({ optional: true, description: "Expected scafld task id." }),
+    thread_title: stringInput({ optional: true, description: "Expected non-empty scafld title." }),
+    size: stringInput({ optional: true, description: "Expected scafld size: small, medium, or large." }),
+    risk: stringInput({ optional: true, description: "Expected scafld risk: low, medium, or high." }),
+  },
+  output: {
+    packet: "runx.spec.normalized_scafld_spec.v1",
+    wrap_as: "normalized_spec",
+  },
+  scopes: ["spec.normalize_scafld_frontmatter"],
+  run: runNormalizeScafldFrontmatter,
+});
+
+function runNormalizeScafldFrontmatter({ inputs }) {
+  const original = String(inputs.spec_contents ?? "");
+  const parsed = parseFrontmatter(original);
+  const existing = parsed.frontmatter;
+  const repairs: string[] = [];
+
+  const taskId = firstNonEmpty(inputs.task_id, existing.task_id) ?? "issue-to-pr";
+  const title = firstNonEmpty(existing.title, inputs.thread_title, taskId) ?? taskId;
+  const size = normalizeSize(firstNonEmpty(inputs.size, existing.size));
+  const risk = normalizeRisk(firstNonEmpty(inputs.risk, existing.risk_level));
+  const created = firstNonEmpty(existing.created, new Date(0).toISOString());
+  const updated = firstNonEmpty(existing.updated, created);
+
+  const required = {
+    spec_version: "'2.0'",
+    task_id: taskId,
+    created,
+    updated,
+    title,
+    status: "draft",
+    harden_status: "not_run",
+    size,
+    risk_level: risk,
+  };
+
+  for (const [key, value] of Object.entries(required)) {
+    if (existing[key] !== value) {
+      repairs.push(key);
+    }
+  }
+
+  const contents = [
+    "---",
+    ...Object.entries(required).map(([key, value]) => `${key}: ${quoteYamlIfNeeded(value)}`),
+    "---",
+    "",
+    parsed.body.replace(/^\s+/, ""),
+  ].join("\n").replace(/\n*$/u, "\n");
+
+  return {
+    contents,
+    frontmatter: required,
+    changed: contents !== original,
+    repairs,
+  };
+}
+
+function parseFrontmatter(contents: string): {
+  readonly frontmatter: Record<string, string>;
+  readonly body: string;
+} {
+  const normalized = contents.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return { frontmatter: {}, body: normalized };
+  }
+  const end = normalized.indexOf("\n---", 4);
+  if (end === -1) {
+    return { frontmatter: {}, body: normalized };
+  }
+  const rawFrontmatter = normalized.slice(4, end);
+  const bodyStart = normalized.indexOf("\n", end + 4);
+  const body = bodyStart === -1 ? "" : normalized.slice(bodyStart + 1);
+  const frontmatter: Record<string, string> = {};
+  for (const line of rawFrontmatter.split("\n")) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*?)\s*$/u);
+    if (!match) {
+      continue;
+    }
+    frontmatter[match[1]] = stripYamlQuotes(match[2]);
+  }
+  return { frontmatter, body };
+}
+
+function normalizeSize(value: string | undefined): string {
+  const normalized = String(value || "small").trim().toLowerCase();
+  if (validSizes.has(normalized)) {
+    return normalized;
+  }
+  return "small";
+}
+
+function normalizeRisk(value: string | undefined): string {
+  const normalized = String(value || "low").trim().toLowerCase();
+  if (validRisks.has(normalized)) {
+    return normalized;
+  }
+  return "low";
+}
+
+function firstNonEmpty(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function stripYamlQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function quoteYamlIfNeeded(value: string | undefined): string {
+  const text = String(value ?? "");
+  if (/^'.*'$/u.test(text)) {
+    return text;
+  }
+  if (!text || /[:#\n\r]/u.test(text)) {
+    return JSON.stringify(text);
+  }
+  return text;
+}

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -71,6 +71,10 @@ Context, Objectives, Scope, Dependencies, Assumptions, Touchpoints, Risks,
 Acceptance, at least one Phase section, Rollback, Review, Self Eval,
 Deviations, Metadata, Origin, Harden Rounds, and Planning Log.
 
+The graph normalizes the front matter before writing the spec so current scafld
+schema fields such as `title` and size stay deterministic even if the authoring
+boundary omits or stales them.
+
 All changed-file declarations must use concrete repo-relative paths in
 backticks under Context / Files impacted and Phase / Changes. Do not declare
 scafld-managed control-plane artifacts under `.scafld/specs`,

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -351,6 +351,13 @@ runners:
           context:
             spec_path: scafld-plan.result.path
             scafld_plan: scafld-plan.result
+        - id: normalize-spec
+          label: normalize scafld frontmatter
+          tool: spec.normalize_scafld_frontmatter
+          scopes:
+            - spec.normalize_scafld_frontmatter
+          context:
+            spec_contents: author-spec.spec_contents
         - id: write-spec
           label: write markdown spec
           tool: fs.write
@@ -359,7 +366,7 @@ runners:
           mutation: true
           context:
             path: scafld-plan.result.path
-            contents: author-spec.spec_contents
+            contents: normalize-spec.normalized_spec.data.contents
         - id: read-draft-spec
           label: read draft spec
           tool: fs.read


### PR DESCRIPTION
## Summary
- adds `spec.normalize_scafld_frontmatter` as a deterministic tool
- routes issue-to-pr generated specs through the normalizer before `fs.write`
- ensures required scafld fields such as `title`, `size`, and `risk_level` are valid before `scafld validate`

## Validation
- `pnpm verify:fast`
- `git diff --check --cached`