### PR TITLE
fix(issue-to-pr): normalize scafld title heading

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,7 +41,7 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-2c74000ab15f",
+    "version": "sha-df0b18554251",
     "digest": "c71eaaf9ed7132b9e37ca1cd02b52a032ef3d306449459d0825e3eb97cd05c49"
   },
   {

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -38,14 +38,11 @@ harness:
               task_id: issue-to-pr-reach-fix
               created: '2026-05-04T00:00:00Z'
               updated: '2026-05-04T00:00:00Z'
-              title: Fix-boundary harness reach
               status: draft
               harden_status: not_run
               size: small
               risk_level: low
               ---
-
-              # Fix Boundary Harness
 
               ## Current State
 

--- a/skills/scafld/fixtures/issue-to-pr-harness-scafld.mjs
+++ b/skills/scafld/fixtures/issue-to-pr-harness-scafld.mjs
@@ -31,6 +31,7 @@ switch (command) {
     break;
   case "validate":
     ensure(taskId, "task_id is required for validate");
+    validateSpec();
     emit({
       ok: true,
       command,
@@ -153,6 +154,27 @@ function readTitle() {
 function replaceStatus(status) {
   const contents = existsSync(specPath) ? readFileSync(specPath, "utf8") : renderSpec({ status });
   writeFileSync(specPath, contents.replace(/^status:\s*.+$/m, `status: ${status}`));
+}
+
+function validateSpec() {
+  const contents = existsSync(specPath) ? readFileSync(specPath, "utf8") : "";
+  const errors = [];
+  if (!/^#\s+\S+/m.test(contents)) {
+    errors.push("title is required");
+  }
+  if (errors.length === 0) {
+    return;
+  }
+  emit({
+    ok: false,
+    command,
+    error: {
+      code: "validation_failed",
+      message: errors.join("; "),
+      exit_code: 3,
+    },
+  });
+  process.exit(3);
 }
 
 function renderSpec({ status }) {

--- a/tools/spec/normalize_scafld_frontmatter/fixtures/basic.yaml
+++ b/tools/spec/normalize_scafld_frontmatter/fixtures/basic.yaml
@@ -28,6 +28,24 @@ expect:
   output:
     matches_packet: runx.spec.normalized_scafld_spec.v1
     subset:
+      contents: |
+        ---
+        spec_version: '2.0'
+        task_id: issue-91-docs
+        created: "2026-05-12T00:00:00Z"
+        updated: "2026-05-12T00:00:00Z"
+        title: Dogfood checklist docs
+        status: draft
+        harden_status: not_run
+        size: small
+        risk_level: low
+        ---
+
+        # Dogfood checklist docs
+
+        ## Current State
+
+        A generated spec omitted title.
       frontmatter:
         task_id: issue-91-docs
         title: Dogfood checklist docs

--- a/tools/spec/normalize_scafld_frontmatter/manifest.json
+++ b/tools/spec/normalize_scafld_frontmatter/manifest.json
@@ -54,7 +54,7 @@
       "./run.mjs"
     ]
   },
-  "source_hash": "sha256:5194f1cbe85fcab7e9dae67f494e175ef6cea251e64ab71dc9bcea3c739d4141",
+  "source_hash": "sha256:6de6e0976cddb0c021beeb9518025125b3699d2a90aa030927a3c4e63517b643",
   "schema_hash": "sha256:5572fff6a0dfb3f3965e2f6f91b62b5957cd1df6f5d4c568102b8f3a74dab389",
   "toolkit_version": "0.1.3"
 }

--- a/tools/spec/normalize_scafld_frontmatter/src/index.ts
+++ b/tools/spec/normalize_scafld_frontmatter/src/index.ts
@@ -55,12 +55,17 @@ function runNormalizeScafldFrontmatter({ inputs }) {
     }
   }
 
+  const body = ensureTitleHeading(parsed.body, title);
+  if (body !== parsed.body.replace(/^\s+/, "")) {
+    repairs.push("title_heading");
+  }
+
   const contents = [
     "---",
     ...Object.entries(required).map(([key, value]) => `${key}: ${quoteYamlIfNeeded(value)}`),
     "---",
     "",
-    parsed.body.replace(/^\s+/, ""),
+    body,
   ].join("\n").replace(/\n*$/u, "\n");
 
   return {
@@ -120,6 +125,27 @@ function firstNonEmpty(...values: unknown[]): string | undefined {
     }
   }
   return undefined;
+}
+
+function ensureTitleHeading(body: string, title: string): string {
+  const trimmed = body.replace(/^\s+/, "");
+  const lines = trimmed.split("\n");
+  let inFence = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      continue;
+    }
+    if (line.startsWith("# ")) {
+      lines[index] = `# ${title}`;
+      return lines.join("\n").replace(/^\n+/, "");
+    }
+  }
+  return [`# ${title}`, "", trimmed].join("\n").replace(/\n*$/u, "\n");
 }
 
 function stripYamlQuotes(value: string): string {


### PR DESCRIPTION
## Summary
- make the scafld spec normalizer ensure a real top-level Markdown heading exists
- harden the issue-to-pr harness by omitting title/heading in the canned author output
- refresh the normalizer manifest and official skills lock

## Root Cause
scafld validates `Title` from the Markdown `# Heading`, not from frontmatter. issue-to-pr normalized frontmatter title but could still write an agent-authored spec with no H1, which made real `scafld validate` fail with `title is required`.

## Validation
- `pnpm verify:fast`
- `pnpm exec runx harness skills/issue-to-pr --json`
- `git diff --check`
