### PR TITLE
fix(issue-to-pr): avoid empty docs fix bundles

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-df0b18554251",
-    "digest": "c71eaaf9ed7132b9e37ca1cd02b52a032ef3d306449459d0825e3eb97cd05c49"
+    "version": "sha-136473071c35",
+    "digest": "928b281fe1d52f60ac81722ee249582bfff36d6165c6a6e7087aa35d6b3408b0"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -46,8 +46,9 @@ the native review boundary.
   claim must trace to the thread, repo snapshot, scafld state, or actual
   working-tree change.
 - Stop conditions: return `needs_resolution` when authoring evidence is
-  missing; return a blocked fix bundle when declared file context is
-  insufficient.
+  missing; return a blocked fix bundle only when no concrete repo-relative
+  target is declared, a required existing file cannot be read, or the requested
+  behavior cannot be inferred without inventing requirements.
 
 ## Spec Authoring Contract
 
@@ -81,9 +82,33 @@ scafld-managed control-plane artifacts under `.scafld/specs`,
 `.scafld/reviews`, `.scafld/runs`, or old `.ai` governance paths as repo-change
 scope.
 
+Documentation and process requests still need a concrete repo file. Prefer
+existing docs surfaces supplied by `repo_snapshot.existing_files` or
+`repo_context`, and declare at least one non-governance repo file for an
+approved `issue-to-pr` lane. Do not leave the repo-change scope empty after the
+triage layer has approved a PR.
+
 Validation commands must run against the current workspace state after the fix
 bundle is written. Do not depend on git history ranges such as `HEAD~1` or
 merge-base comparisons.
+
+## Fix Authoring Contract
+
+The `issue-to-pr-apply-fix` boundary must emit a bounded `fix_bundle` with
+`files: [{ path, contents }]` for every repo file needed to satisfy the approved
+spec. For documentation or process changes, the approved spec, source thread,
+repo snapshot, repo context, and declared file contents are sufficient when they
+identify a narrow edit.
+
+If a declared file has `exists: false` and the approved spec intentionally
+creates it, write the new file when the desired contents are inferable from the
+spec and thread. Do not block solely because the file has no prior contents.
+
+Return `fix_bundle.status: blocked` with `files: []` only when no concrete
+repo-relative target is declared, a required existing file cannot be read, or
+the requested behavior cannot be inferred. The blocked reason must name the
+missing evidence and path because an empty file bundle is a terminal policy
+denial before `write-fix`.
 
 ## Inputs
 

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -277,7 +277,7 @@ runners:
       provider:
         type: string
         required: false
-        description: "Optional scafld review provider, such as local, claude, or codex."
+        description: "Optional scafld review provider, such as command, claude, or codex."
       provider_command:
         type: string
         required: false
@@ -341,7 +341,11 @@ runners:
             Do not depend on git history ranges such as HEAD~1. If a required
             file path cannot be grounded from the thread or repository evidence,
             keep the scope narrow and state the assumption instead of inventing
-            a file.
+            a file. When the approved lane is documentation or process work,
+            prefer existing documentation surfaces from repo_snapshot.existing_files
+            or repo_context, and declare at least one non-governance repo file;
+            issue-to-pr is a PR lane, so an approved spec must not leave the
+            repo-change scope empty.
           allowed_tools:
             - fs.read
             - git.status
@@ -414,11 +418,20 @@ runners:
             approved spec contents, current thread context, and
             declared_file_context. Review declared_file_context.files before
             deciding what to edit. fix_bundle.files must be an array of
-            { path, contents } entries covering every tracked repo file needed
-            to satisfy the approved spec. Do not widen scope. Do not hand-edit
-            scafld lifecycle files. If the declared context is insufficient,
-            return fix_bundle.status: blocked with a reason and files: []
-            instead of guessing.
+            { path, contents } entries covering every repo file needed to satisfy
+            the approved spec. For documentation or process changes, the
+            approved spec, thread, repo_snapshot, repo_context, and current
+            declared file contents are sufficient when they identify a narrow
+            edit; do not return an empty bundle when one scoped docs edit is
+            possible. If a declared file has exists: false and the approved spec
+            intentionally creates it, write the new file when the desired
+            contents are inferable from the spec and thread. Do not widen scope.
+            Do not hand-edit scafld lifecycle files. Return
+            fix_bundle.status: blocked with a reason and files: [] only when no
+            concrete repo-relative target is declared, a required existing file
+            cannot be read, or the requested behavior cannot be inferred without
+            inventing requirements; name the missing evidence and path in the
+            reason because an empty bundle is a terminal policy denial.
           allowed_tools:
             - fs.read
             - git.status

--- a/tests/issue-to-pr-graph.test.ts
+++ b/tests/issue-to-pr-graph.test.ts
@@ -10,6 +10,7 @@ import { parseRunnerManifestYaml, validateRunnerManifest } from "@runxhq/core/pa
 import { runLocalSkill, type Caller } from "@runxhq/runtime-local";
 
 const scafldBin = process.env.SCAFLD_BIN ?? "scafld";
+const passingReviewCommand = `printf '{"verdict":"pass","mode":"discover","summary":"fixture clean","findings":[],"attack_log":[{"target":"diff","attack":"fixture","result":"clean"}],"budget":{"actual_attack_angles":1}}'`;
 const caller: Caller = {
   resolve: async () => undefined,
   report: () => undefined,
@@ -31,6 +32,7 @@ describe("issue-to-PR composite skill", () => {
     expect(graph.steps.map((step) => step.id)).toEqual([
       "scafld-plan",
       "author-spec",
+      "normalize-spec",
       "write-spec",
       "read-draft-spec",
       "scafld-validate",
@@ -61,7 +63,12 @@ describe("issue-to-PR composite skill", () => {
       "handoff",
     ]);
     expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("scafld 2.0 markdown spec");
+    expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("repo-change scope empty");
     expect(graph.steps.find((step) => step.id === "author-fix")?.instructions).toContain("fix_bundle.status: blocked");
+    expect(graph.steps.find((step) => step.id === "author-fix")?.instructions).toContain("one scoped docs edit is possible");
+    expect(graph.steps.find((step) => step.id === "normalize-spec")).toMatchObject({
+      tool: "spec.normalize_scafld_frontmatter",
+    });
     expect(graph.steps.find((step) => step.id === "package-pull-request")).toMatchObject({
       tool: "outbox.build_pull_request",
       context: {
@@ -109,7 +116,8 @@ describe("issue-to-PR composite skill", () => {
           size: "micro",
           risk: "low",
           base: "main",
-          provider: "local",
+          provider: "command",
+          provider_command: passingReviewCommand,
           scafld_bin: scafldBin,
         },
         caller,
@@ -171,6 +179,7 @@ describe("issue-to-PR composite skill", () => {
       expect(result.receipt.steps.map((step) => [step.step_id, step.status])).toEqual([
         ["scafld-plan", "success"],
         ["author-spec", "success"],
+        ["normalize-spec", "success"],
         ["write-spec", "success"],
         ["read-draft-spec", "success"],
         ["scafld-validate", "success"],

--- a/tests/recognizable-work-lanes.test.ts
+++ b/tests/recognizable-work-lanes.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { runCli } from "../packages/cli/src/index.js";
 
 const scafldBin = process.env.SCAFLD_BIN ?? "scafld";
+const passingReviewCommand = `printf '{"verdict":"pass","mode":"discover","summary":"fixture clean","findings":[],"attack_log":[{"target":"diff","attack":"fixture","result":"clean"}],"budget":{"actual_attack_angles":1}}'`;
 
 describe("recognizable work lanes", () => {
   it("runs request-triage through the local CLI with a bounded next-lane packet", async () => {
@@ -179,7 +180,9 @@ describe("recognizable work lanes", () => {
           "--risk",
           "low",
           "--provider",
-          "local",
+          "command",
+          "--provider-command",
+          passingReviewCommand,
           "--scafld-bin",
           scafldBin,
           "--answers",

--- a/tests/scafld-issue-to-pr-parser.test.ts
+++ b/tests/scafld-issue-to-pr-parser.test.ts
@@ -22,6 +22,7 @@ describe("scafld issue-to-PR skill contract", () => {
     expect(graph.steps.map((step) => step.id)).toEqual([
       "scafld-plan",
       "author-spec",
+      "normalize-spec",
       "write-spec",
       "read-draft-spec",
       "scafld-validate",
@@ -68,11 +69,18 @@ describe("scafld issue-to-PR skill contract", () => {
     });
     expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("scafld 2.0 markdown spec");
     expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("Files impacted");
+    expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("repo-change scope empty");
+    expect(graph.steps.find((step) => step.id === "normalize-spec")).toMatchObject({
+      tool: "spec.normalize_scafld_frontmatter",
+      context: {
+        spec_contents: "author-spec.spec_contents",
+      },
+    });
     expect(graph.steps.find((step) => step.id === "write-spec")).toMatchObject({
       tool: "fs.write",
       context: {
         path: "scafld-plan.result.path",
-        contents: "author-spec.spec_contents",
+        contents: "normalize-spec.normalized_spec.data.data.contents",
       },
     });
     expect(graph.steps.find((step) => step.id === "read-approved-spec")).toMatchObject({
@@ -92,6 +100,7 @@ describe("scafld issue-to-PR skill contract", () => {
       },
     });
     expect(graph.steps.find((step) => step.id === "author-fix")?.instructions).toContain("fix_bundle.status: blocked");
+    expect(graph.steps.find((step) => step.id === "author-fix")?.instructions).toContain("one scoped docs edit is possible");
     expect(graph.steps.find((step) => step.id === "read-current-branch")).toMatchObject({
       tool: "git.current_branch",
     });


### PR DESCRIPTION
## Summary
- tighten issue-to-pr spec/fix authoring guidance so approved docs/process lanes declare and write a concrete repo file
- reserve empty `fix_bundle.files` for true blockers and make the reason explicit
- refresh official skill lock and update stale issue-to-pr tests for normalize-spec and supported scafld command review providers

## Validation
- `pnpm exec runx harness skills/issue-to-pr --json`
- `pnpm test tests/scafld-issue-to-pr-parser.test.ts tests/agent-step-boundary.test.ts tests/issue-to-pr-graph.test.ts tests/recognizable-work-lanes.test.ts`
- `git diff --check`
- `pnpm verify:fast`