### PR TITLE
fix(issue-to-pr): harden live retry path

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-136473071c35",
-    "digest": "928b281fe1d52f60ac81722ee249582bfff36d6165c6a6e7087aa35d6b3408b0"
+    "version": "sha-95b39e8bbc82",
+    "digest": "316cb1dca2fd937b85d7835614a39e058d8af4e86d0ef52d79dc6e7cc8fd18da"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -90,7 +90,10 @@ triage layer has approved a PR.
 
 Validation commands must run against the current workspace state after the fix
 bundle is written. Do not depend on git history ranges such as `HEAD~1` or
-merge-base comparisons.
+merge-base comparisons. Validation commands, when present, must be direct
+repo-local checks such as test, lint, build, or file-content commands. Never use
+runx skill runner internals or `skills/scafld/run.mjs` as a validation command;
+scafld is already the lifecycle runner around the task.
 
 ## Fix Authoring Contract
 

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -338,12 +338,16 @@ runners:
             under .scafld/specs, .scafld/reviews, .scafld/runs, or old .ai
             governance paths as repo-change scope. Validation commands must be
             executable in the current workspace after the fix bundle is written.
-            Do not depend on git history ranges such as HEAD~1. If a required
-            file path cannot be grounded from the thread or repository evidence,
-            keep the scope narrow and state the assumption instead of inventing
-            a file. When the approved lane is documentation or process work,
-            prefer existing documentation surfaces from repo_snapshot.existing_files
-            or repo_context, and declare at least one non-governance repo file;
+            Do not depend on git history ranges such as HEAD~1. When validation
+            commands are included, use direct repo-local checks such as tests,
+            lint, build, or file-content commands. Do not use runx skill runner
+            internals or skills/scafld/run.mjs as validation commands; scafld
+            is already the lifecycle runner around this graph. If a required file
+            path cannot be grounded from the thread or repository evidence, keep
+            the scope narrow and state the assumption instead of inventing a file.
+            When the approved lane is documentation or process work, prefer
+            existing documentation surfaces from repo_snapshot.existing_files or
+            repo_context, and declare at least one non-governance repo file;
             issue-to-pr is a PR lane, so an approved spec must not leave the
             repo-change scope empty.
           allowed_tools:

--- a/skills/scafld/run.mjs
+++ b/skills/scafld/run.mjs
@@ -1,8 +1,9 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-const inputs = JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+const inputs = loadInputs();
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const scafld = resolveBinary(String(inputs.scafld_bin || process.env.SCAFLD_BIN || "scafld"));
 const cwd = path.resolve(String(
@@ -32,7 +33,7 @@ const jsonCommands = new Set([
 const commandsWithoutTaskId = new Set(["init", "list", "report"]);
 
 if (!command) {
-  throw new Error("command is required.");
+  throw new Error("scafld command is required. Pass the `command` input through runx.");
 }
 if (!commandsWithoutTaskId.has(command) && !taskId) {
   throw new Error("task_id is required.");
@@ -174,6 +175,16 @@ function truthy(value) {
     return false;
   }
   return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function loadInputs() {
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  return {};
 }
 
 function resolveBinary(candidate) {

--- a/tests/scafld-issue-to-pr-parser.test.ts
+++ b/tests/scafld-issue-to-pr-parser.test.ts
@@ -68,6 +68,7 @@ describe("scafld issue-to-PR skill contract", () => {
       },
     });
     expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("scafld 2.0 markdown spec");
+    expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("Do not use runx skill runner");
     expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("Files impacted");
     expect(graph.steps.find((step) => step.id === "author-spec")?.instructions).toContain("repo-change scope empty");
     expect(graph.steps.find((step) => step.id === "normalize-spec")).toMatchObject({

--- a/tests/scafld-skill.test.ts
+++ b/tests/scafld-skill.test.ts
@@ -273,6 +273,60 @@ process.exit(1);
     }
   });
 
+  it("loads spilled runx inputs from RUNX_INPUTS_PATH", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-scafld-input-path-"));
+    const fakeScafld = path.join(tempDir, "fake-scafld.mjs");
+
+    try {
+      await writeFile(
+        fakeScafld,
+        `#!/usr/bin/env node
+const argv = process.argv.slice(2);
+if ((argv[0] || "") === "validate") {
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    command: "validate",
+    result: { task_id: "fixture-task", valid: true, errors: null },
+  }) + "\\n");
+  process.exit(0);
+}
+process.stderr.write(\`unsupported command: \${argv[0] || ""}\\n\`);
+process.exit(1);
+`,
+        { mode: 0o755 },
+      );
+
+      const result = await runLocalSkill({
+        skillPath: path.resolve("skills/scafld"),
+        runner: "scafld-cli",
+        inputs: {
+          command: "validate",
+          task_id: "fixture-task",
+          fixture: tempDir,
+          scafld_bin: fakeScafld,
+          large_context: "x".repeat(64 * 1024),
+        },
+        caller,
+        adapters: createDefaultSkillAdapters(),
+        receiptDir: path.join(tempDir, "receipts"),
+        runxHome: path.join(tempDir, "home"),
+        env: process.env,
+      });
+
+      expect(result.status).toBe("success");
+      if (result.status !== "success") {
+        return;
+      }
+      expect(JSON.parse(result.execution.stdout)).toMatchObject({
+        ok: true,
+        command: "validate",
+        result: { task_id: "fixture-task" },
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves native non-zero failures instead of normalizing them away", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-scafld-failure-"));
     const fakeScafld = path.join(tempDir, "fake-scafld.mjs");

--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -465,6 +465,132 @@ describe("thread.push_outbox tool", () => {
     }
   }, 15_000);
 
+  it("reuses an open GitHub pull request with the same head branch", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-reuse-tool-"));
+    const workspace = path.join(tempDir, "workspace");
+    const remote = path.join(tempDir, "remote.git");
+    const fakeGh = path.join(tempDir, "fake-gh.mjs");
+    const fakeState = path.join(tempDir, "fake-gh-state.json");
+
+    try {
+      await initGitHubWorkspace(workspace, remote, "issue-123");
+      await writeFile(
+        fakeState,
+        `${JSON.stringify({
+          issue: {
+            number: 123,
+            title: "Fix fixture behavior",
+            body: "The issue body for the fixture.",
+            url: "https://github.com/example/repo/issues/123",
+            state: "OPEN",
+            createdAt: "2026-04-22T00:00:00Z",
+            updatedAt: "2026-04-22T00:00:00Z",
+            author: {
+              login: "auscaster",
+            },
+            comments: [],
+            labels: [],
+            closedByPullRequestsReferences: [],
+          },
+          pulls: [
+            {
+              number: 77,
+              repo: "example/repo",
+              title: "Old title",
+              body: "Old body",
+              url: "https://github.com/example/repo/pull/77",
+              state: "OPEN",
+              isDraft: true,
+              headRefName: "issue-123",
+              baseRefName: "main",
+              updatedAt: "2026-04-22T00:30:00Z",
+            },
+          ],
+          nextPullNumber: 78,
+          nextCommentId: 1000,
+        }, null, 2)}\n`,
+      );
+      await writeFakeGhScript(fakeGh);
+
+      const result = runTool({
+        thread: {
+          kind: "runx.thread.v1",
+          adapter: {
+            type: "github",
+            adapter_ref: "example/repo#issue/123",
+          },
+          thread_kind: "work_item",
+          thread_locator: "github://example/repo/issues/123",
+          canonical_uri: "https://github.com/example/repo/issues/123",
+          entries: [],
+          decisions: [],
+          outbox: [],
+          source_refs: [],
+        },
+        outbox_entry: {
+          entry_id: "pull_request:issue-123",
+          kind: "pull_request",
+          title: "Fix fixture behavior",
+          status: "proposed",
+          thread_locator: "github://example/repo/issues/123",
+        },
+        draft_pull_request: {
+          schema_version: "runx.pull-request-draft.v1",
+          action: "create",
+          push_ready: true,
+          task_id: "issue-123",
+          thread: {
+            thread_locator: "github://example/repo/issues/123",
+            canonical_uri: "https://github.com/example/repo/issues/123",
+            title: "Fix fixture behavior",
+          },
+          target: {
+            repo: "example/repo",
+            branch: "issue-123",
+            base: "main",
+            remote: "origin",
+          },
+          pull_request: {
+            title: "Fix fixture behavior",
+            body_markdown: "# Fix fixture behavior\n\nUpdated body.\n",
+            is_draft: true,
+          },
+        },
+        workspace_path: workspace,
+        next_status: "draft",
+      }, {
+        RUNX_GH_BIN: fakeGh,
+        RUNX_FAKE_GH_STATE: fakeState,
+      });
+
+      expect(result).toMatchObject({
+        outbox_entry: {
+          entry_id: "pr-77",
+          locator: "https://github.com/example/repo/pull/77",
+          status: "draft",
+        },
+        push: {
+          pull_request: {
+            number: "77",
+            url: "https://github.com/example/repo/pull/77",
+          },
+        },
+      });
+      expect(JSON.parse(await readFile(fakeState, "utf8"))).toMatchObject({
+        nextPullNumber: 78,
+        pulls: [
+          {
+            number: 77,
+            title: "Fix fixture behavior",
+            body: expect.stringContaining("Updated body."),
+          },
+        ],
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("pushes a GitHub issue comment for a message outbox entry and returns the refreshed thread", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-message-tool-"));
     const fakeGh = path.join(tempDir, "fake-gh.mjs");

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -467,7 +467,13 @@ export function pushGitHubPullRequest({
 
   const existingNumber = parseGitHubPullRequestNumber(outbox.locator)
     ?? parseGitHubPullRequestNumber(optionalRecord(outbox.metadata)?.number);
+  const existingByBranch = existingNumber
+    ? undefined
+    : findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env);
   let pullRequestRef = existingNumber;
+  if (!pullRequestRef && existingByBranch) {
+    pullRequestRef = firstNonEmptyString(existingByBranch.url, existingByBranch.number);
+  }
 
   if (pullRequestRef) {
     const args = [
@@ -505,10 +511,18 @@ export function pushGitHubPullRequest({
     if (base) {
       args.push("--base", base);
     }
-    pullRequestRef = runCommand(resolveGhBinary(env), args, {
-      cwd: workspacePath,
-      env,
-    }).trim();
+    try {
+      pullRequestRef = runCommand(resolveGhBinary(env), args, {
+        cwd: workspacePath,
+        env,
+      }).trim();
+    } catch (error) {
+      const fallback = findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env);
+      if (!fallback || !String(error?.message ?? error).match(/pull request.*(already exists|exists)|already.*pull request/i)) {
+        throw error;
+      }
+      pullRequestRef = firstNonEmptyString(fallback.url, fallback.number);
+    }
   }
 
   const pullRequestView = runGhJson([
@@ -862,6 +876,29 @@ function buildGitHubCommitMessage(draftPullRequest, title, outboxEntry) {
     return existingTitle;
   }
   return `chore(issue-to-pr): apply ${firstNonEmptyString(draftPullRequest.task_id, existingTitle, "runx-change")}`;
+}
+
+function findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env) {
+  const pulls = runGhJson([
+    "pr",
+    "list",
+    "--repo",
+    repoSlug,
+    "--head",
+    branch,
+    "--state",
+    "open",
+    "--json",
+    "baseRefName,headRefName,isDraft,number,state,title,updatedAt,url",
+  ], {
+    cwd: workspacePath,
+    env,
+  });
+  const candidates = Array.isArray(pulls) ? pulls.filter(isRecord) : [];
+  return candidates.find((pull) =>
+    firstNonEmptyString(pull.headRefName) === branch
+    && String(pull.state ?? "").toUpperCase() === "OPEN"
+  );
 }
 
 function runGhJson(args, options) {


### PR DESCRIPTION
## Summary
- support spilled RUNX_INPUTS_PATH payloads in the scafld runner
- reuse an existing open GitHub PR by head branch before creating a new one
- tighten issue-to-pr validation guidance so generated specs do not call runx runner internals

## Validation
- pnpm test tests/scafld-skill.test.ts tests/thread-push-outbox-tool.test.ts tests/scafld-issue-to-pr-parser.test.ts --run
- pnpm build
- pnpm verify:fast