### PR TITLE
fix(thread): tolerate PR head lookup failures

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -591,6 +591,106 @@ describe("thread.push_outbox tool", () => {
     }
   }, 15_000);
 
+  it("creates a GitHub pull request when the optional head lookup fails", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-list-failure-tool-"));
+    const workspace = path.join(tempDir, "workspace");
+    const remote = path.join(tempDir, "remote.git");
+    const fakeGh = path.join(tempDir, "fake-gh.mjs");
+    const fakeState = path.join(tempDir, "fake-gh-state.json");
+
+    try {
+      await initGitHubWorkspace(workspace, remote, "issue-list-failure");
+      await writeFile(
+        fakeState,
+        `${JSON.stringify({
+          issue: {
+            number: 123,
+            title: "Fix fixture behavior",
+            body: "The issue body for the fixture.",
+            url: "https://github.com/example/repo/issues/123",
+            state: "OPEN",
+            createdAt: "2026-04-22T00:00:00Z",
+            updatedAt: "2026-04-22T00:00:00Z",
+            author: {
+              login: "auscaster",
+            },
+            comments: [],
+            labels: [],
+            closedByPullRequestsReferences: [],
+          },
+          pulls: [],
+          nextPullNumber: 77,
+          nextCommentId: 1000,
+          failPrList: true,
+        }, null, 2)}\n`,
+      );
+      await writeFakeGhScript(fakeGh);
+
+      const result = runTool({
+        thread: {
+          kind: "runx.thread.v1",
+          adapter: {
+            type: "github",
+            adapter_ref: "example/repo#issue/123",
+          },
+          thread_kind: "work_item",
+          thread_locator: "github://example/repo/issues/123",
+          canonical_uri: "https://github.com/example/repo/issues/123",
+          entries: [],
+          decisions: [],
+          outbox: [],
+          source_refs: [],
+        },
+        outbox_entry: {
+          entry_id: "pull_request:issue-list-failure",
+          kind: "pull_request",
+          title: "Fix fixture behavior",
+          status: "proposed",
+          thread_locator: "github://example/repo/issues/123",
+        },
+        draft_pull_request: {
+          schema_version: "runx.pull-request-draft.v1",
+          action: "create",
+          push_ready: true,
+          task_id: "issue-list-failure",
+          target: {
+            repo: "example/repo",
+            branch: "issue-list-failure",
+            base: "main",
+            remote: "origin",
+          },
+          pull_request: {
+            title: "Fix fixture behavior",
+            body_markdown: "# Fix fixture behavior\n\nBody.\n",
+            is_draft: true,
+          },
+        },
+        workspace_path: workspace,
+        next_status: "draft",
+      }, {
+        RUNX_GH_BIN: fakeGh,
+        RUNX_FAKE_GH_STATE: fakeState,
+      });
+
+      expect(result).toMatchObject({
+        outbox_entry: {
+          entry_id: "pr-77",
+          locator: "https://github.com/example/repo/pull/77",
+          status: "draft",
+        },
+        push: {
+          status: "pushed",
+          pull_request: {
+            number: "77",
+            url: "https://github.com/example/repo/pull/77",
+          },
+        },
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("pushes a GitHub issue comment for a message outbox entry and returns the refreshed thread", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-message-tool-"));
     const fakeGh = path.join(tempDir, "fake-gh.mjs");
@@ -1066,6 +1166,10 @@ if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/issues\\/comments\\/\\d+$/.te
 }
 
 if (args[0] === "pr" && args[1] === "list") {
+  if (state.failPrList && args.includes("--head")) {
+    process.stderr.write("preflight lookup failed\\n");
+    process.exit(1);
+  }
   process.stdout.write(JSON.stringify(state.pulls));
   process.exit(0);
 }

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -879,21 +879,26 @@ function buildGitHubCommitMessage(draftPullRequest, title, outboxEntry) {
 }
 
 function findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env) {
-  const pulls = runGhJson([
-    "pr",
-    "list",
-    "--repo",
-    repoSlug,
-    "--head",
-    branch,
-    "--state",
-    "open",
-    "--json",
-    "baseRefName,headRefName,isDraft,number,state,title,updatedAt,url",
-  ], {
-    cwd: workspacePath,
-    env,
-  });
+  let pulls;
+  try {
+    pulls = runGhJson([
+      "pr",
+      "list",
+      "--repo",
+      repoSlug,
+      "--head",
+      branch,
+      "--state",
+      "open",
+      "--json",
+      "baseRefName,headRefName,isDraft,number,state,title,updatedAt,url",
+    ], {
+      cwd: workspacePath,
+      env,
+    });
+  } catch {
+    return undefined;
+  }
   const candidates = Array.isArray(pulls) ? pulls.filter(isRecord) : [];
   return candidates.find((pull) =>
     firstNonEmptyString(pull.headRefName) === branch


### PR DESCRIPTION
## Summary
- Treat GitHub PR head lookup as best-effort before creating a draft PR
- Add a regression covering a failed optional preflight lookup

## Validation
- pnpm test tests/thread-push-outbox-tool.test.ts --run
- pnpm build
- pnpm verify:fast