### PR TITLE
fix(thread): create pull requests through REST

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -1152,7 +1152,7 @@ if (args[0] === "issue" && args[1] === "comment") {
 }
 
 if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/issues\\/comments\\/\\d+$/.test(args[1] || "")) {
-  const body = readFlag(args, "-f")?.replace(/^body=/, "");
+  const body = readField(args, "body");
   const commentId = (args[1] || "").split("/").pop();
   const comment = state.issue.comments.find((candidate) => String(candidate.id) === String(commentId));
   if (!comment) {
@@ -1166,6 +1166,48 @@ if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/issues\\/comments\\/\\d+$/.te
   process.exit(0);
 }
 
+if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/pulls$/.test(args[1] || "")) {
+  if ((state.failPrCreateCount ?? 0) > 0) {
+    state.failPrCreateCount -= 1;
+    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+    process.stderr.write("GraphQL: Head sha can't be blank, Head repository can't be blank, No commits between example:main and example:issue-list-failure, not all refs are readable\\n");
+    process.exit(1);
+  }
+  const repo = (args[1] || "").replace(/^repos\\//, "").replace(/\\/pulls$/, "");
+  const head = readField(args, "head");
+  const base = readField(args, "base");
+  const title = readField(args, "title");
+  const body = readField(args, "body");
+  const number = state.nextPullNumber++;
+  const pull = {
+    number,
+    repo,
+    title,
+    body,
+    url: \`https://github.com/\${repo}/pull/\${number}\`,
+    state: "OPEN",
+    isDraft: readField(args, "draft") === "true",
+    headRefName: head,
+    baseRefName: base,
+    updatedAt: "2026-04-22T01:00:00Z",
+  };
+  state.pulls.push(pull);
+  writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+  process.stdout.write(args.includes("--jq") ? \`\${pull.url}\\n\` : JSON.stringify(pull));
+  process.exit(0);
+}
+
+if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/pulls\\/\\d+$/.test(args[1] || "")) {
+  const pull = findPull(state.pulls, (args[1] || "").split("/").pop());
+  pull.title = readField(args, "title") || pull.title;
+  pull.body = readField(args, "body") || pull.body;
+  pull.baseRefName = readField(args, "base") || pull.baseRefName;
+  pull.updatedAt = "2026-04-22T01:00:00Z";
+  writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+  process.stdout.write(JSON.stringify(pull));
+  process.exit(0);
+}
+
 if (args[0] === "pr" && args[1] === "list") {
   if (state.failPrList && args.includes("--head")) {
     process.stderr.write("preflight lookup failed\\n");
@@ -1176,12 +1218,6 @@ if (args[0] === "pr" && args[1] === "list") {
 }
 
 if (args[0] === "pr" && args[1] === "create") {
-  if ((state.failPrCreateCount ?? 0) > 0) {
-    state.failPrCreateCount -= 1;
-    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
-    process.stderr.write("GraphQL: Head sha can't be blank, Head repository can't be blank, No commits between example:main and example:issue-list-failure, not all refs are readable\\n");
-    process.exit(1);
-  }
   const repo = readFlag(args, "--repo");
   const head = readFlag(args, "--head");
   const base = readFlag(args, "--base");
@@ -1237,6 +1273,19 @@ function findPull(pulls, ref) {
 function readFlag(argv, flag) {
   const index = argv.indexOf(flag);
   return index >= 0 ? argv[index + 1] : "";
+}
+
+function readField(argv, key) {
+  for (let index = 0; index < argv.length - 1; index += 1) {
+    if (argv[index] !== "-f" && argv[index] !== "-F") {
+      continue;
+    }
+    const value = argv[index + 1] || "";
+    if (value.startsWith(\`\${key}=\`)) {
+      return value.slice(key.length + 1);
+    }
+  }
+  return "";
 }
 `,
     { mode: 0o755 },

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -476,43 +476,23 @@ export function pushGitHubPullRequest({
   }
 
   if (pullRequestRef) {
-    const args = [
-      "pr",
-      "edit",
-      pullRequestRef,
-      "--repo",
+    editGitHubPullRequest({
       repoSlug,
-      "--title",
+      pullRequestRef,
       title,
-      "--body",
       body,
-    ];
-    if (base) {
-      args.push("--base", base);
-    }
-    runCommand(resolveGhBinary(env), args, {
-      cwd: workspacePath,
+      base,
+      workspacePath,
       env,
     });
   } else {
-    const args = [
-      "pr",
-      "create",
-      "--repo",
-      repoSlug,
-      "--head",
-      branch,
-      "--title",
-      title,
-      "--body",
-      body,
-      "--draft",
-    ];
-    if (base) {
-      args.push("--base", base);
-    }
     try {
-      pullRequestRef = runGitHubPullRequestCreate(args, {
+      pullRequestRef = runGitHubPullRequestCreate({
+        repoSlug,
+        branch,
+        base,
+        title,
+        body,
         workspacePath,
         env,
       });
@@ -906,11 +886,60 @@ function findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env) {
   );
 }
 
-function runGitHubPullRequestCreate(args, { workspacePath, env }) {
+function editGitHubPullRequest({ repoSlug, pullRequestRef, title, body, base, workspacePath, env }) {
+  const number = parseGitHubPullRequestNumber(pullRequestRef);
+  if (!number) {
+    const args = [
+      "pr",
+      "edit",
+      pullRequestRef,
+      "--repo",
+      repoSlug,
+      "--title",
+      title,
+      "--body",
+      body,
+    ];
+    if (base) {
+      args.push("--base", base);
+    }
+    runCommand(resolveGhBinary(env), args, {
+      cwd: workspacePath,
+      env,
+    });
+    return;
+  }
+
+  const args = [
+    "api",
+    `repos/${repoSlug}/pulls/${number}`,
+    "--method",
+    "PATCH",
+    "-f",
+    `title=${title}`,
+    "-f",
+    `body=${body}`,
+  ];
+  if (base) {
+    args.push("-f", `base=${base}`);
+  }
+  runCommand(resolveGhBinary(env), args, {
+    cwd: workspacePath,
+    env,
+  });
+}
+
+function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, workspacePath, env }) {
   let lastError;
   for (let attempt = 0; attempt < 4; attempt += 1) {
     try {
-      return runCommand(resolveGhBinary(env), args, {
+      return runCommand(resolveGhBinary(env), buildGitHubPullRequestCreateArgs({
+        repoSlug,
+        branch,
+        base,
+        title,
+        body,
+      }), {
         cwd: workspacePath,
         env,
       }).trim();
@@ -924,6 +953,27 @@ function runGitHubPullRequestCreate(args, { workspacePath, env }) {
     }
   }
   throw lastError;
+}
+
+function buildGitHubPullRequestCreateArgs({ repoSlug, branch, base, title, body }) {
+  const args = [
+    "api",
+    `repos/${repoSlug}/pulls`,
+    "-f",
+    `title=${title}`,
+    "-f",
+    `head=${branch}`,
+    "-f",
+    `body=${body}`,
+    "-F",
+    "draft=true",
+    "--jq",
+    ".html_url",
+  ];
+  if (base) {
+    args.push("-f", `base=${base}`);
+  }
+  return args;
 }
 
 function isTransientGitHubPullRequestCreateError(message) {


### PR DESCRIPTION
## Summary
- Create and update GitHub pull requests through the REST API via gh api
- Keep retry handling for transient branch propagation after push
- Extend the push_outbox fake GitHub test adapter for REST PR create/update

## Validation
- pnpm test tests/thread-push-outbox-tool.test.ts --run
- pnpm build
- pnpm verify:fast