### PR TITLE
fix(spec): collapse duplicate scafld titles

### DIFF
--- a/tests/normalize-scafld-frontmatter.test.ts
+++ b/tests/normalize-scafld-frontmatter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import normalizeScafldFrontmatter from "../tools/spec/normalize_scafld_frontmatter/src/index.js";
+
+describe("spec.normalize_scafld_frontmatter", () => {
+  it("collapses agent-authored top-level titles to one canonical scafld title", async () => {
+    const result = await normalizeScafldFrontmatter.runWith({
+      task_id: "issue-91-docs",
+      thread_title: "Dogfood checklist docs",
+      size: "small",
+      risk: "low",
+      spec_contents: `---
+spec_version: '2.0'
+task_id: issue-91-docs
+created: 2026-05-12T00:00:00Z
+updated: 2026-05-12T00:00:00Z
+status: draft
+harden_status: not_run
+size: small
+risk_level: low
+---
+
+# Draft title from the agent
+
+## Current State
+
+Still relevant.
+
+# Duplicate title from the issue body
+
+## Summary
+
+Keep this section.
+
+\`\`\`
+# This is fenced text, not a Markdown title.
+\`\`\`
+`,
+    });
+
+    if (!("data" in result)) {
+      throw new Error("expected packet output");
+    }
+
+    const packet = result as { readonly data: { readonly contents: string; readonly repairs: readonly string[] } };
+    const contents = packet.data.contents;
+    const headings = contents.match(/^# .+$/gmu) ?? [];
+
+    expect(headings).toEqual([
+      "# Dogfood checklist docs",
+      "# This is fenced text, not a Markdown title.",
+    ]);
+    expect(contents).not.toContain("Draft title from the agent");
+    expect(contents).not.toContain("Duplicate title from the issue body");
+    expect(contents).toContain("## Current State\n\nStill relevant.");
+    expect(contents).toContain("## Summary\n\nKeep this section.");
+    expect(packet.data.repairs).toContain("title_heading");
+  });
+});

--- a/tools/spec/normalize_scafld_frontmatter/manifest.json
+++ b/tools/spec/normalize_scafld_frontmatter/manifest.json
@@ -54,7 +54,7 @@
       "./run.mjs"
     ]
   },
-  "source_hash": "sha256:6de6e0976cddb0c021beeb9518025125b3699d2a90aa030927a3c4e63517b643",
+  "source_hash": "sha256:b700fb44fb9aa361aa92bda367f1b1fe43e3a064d4677a1f09e0730e79334f90",
   "schema_hash": "sha256:5572fff6a0dfb3f3965e2f6f91b62b5957cd1df6f5d4c568102b8f3a74dab389",
   "toolkit_version": "0.1.3"
 }

--- a/tools/spec/normalize_scafld_frontmatter/src/index.ts
+++ b/tools/spec/normalize_scafld_frontmatter/src/index.ts
@@ -6,6 +6,14 @@ import {
 const validSizes = new Set(["small", "medium", "large"]);
 const validRisks = new Set(["low", "medium", "high"]);
 
+interface NormalizeScafldInputs {
+  readonly spec_contents?: string;
+  readonly task_id?: string;
+  readonly thread_title?: string;
+  readonly size?: string;
+  readonly risk?: string;
+}
+
 export default defineTool({
   name: "spec.normalize_scafld_frontmatter",
   description: "Normalize scafld 2 markdown frontmatter before writing an agent-authored spec.",
@@ -24,7 +32,7 @@ export default defineTool({
   run: runNormalizeScafldFrontmatter,
 });
 
-function runNormalizeScafldFrontmatter({ inputs }) {
+function runNormalizeScafldFrontmatter({ inputs }: { readonly inputs: NormalizeScafldInputs }) {
   const original = String(inputs.spec_contents ?? "");
   const parsed = parseFrontmatter(original);
   const existing = parsed.frontmatter;
@@ -55,7 +63,7 @@ function runNormalizeScafldFrontmatter({ inputs }) {
     }
   }
 
-  const body = ensureTitleHeading(parsed.body, title);
+  const body = ensureSingleTitleHeading(parsed.body, title);
   if (body !== parsed.body.replace(/^\s+/, "")) {
     repairs.push("title_heading");
   }
@@ -127,25 +135,24 @@ function firstNonEmpty(...values: unknown[]): string | undefined {
   return undefined;
 }
 
-function ensureTitleHeading(body: string, title: string): string {
+function ensureSingleTitleHeading(body: string, title: string): string {
   const trimmed = body.replace(/^\s+/, "");
   const lines = trimmed.split("\n");
   let inFence = false;
+  const bodyWithoutTitles: string[] = [];
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     if (line.startsWith("```")) {
       inFence = !inFence;
+      bodyWithoutTitles.push(line);
       continue;
     }
-    if (inFence) {
+    if (!inFence && line.startsWith("# ")) {
       continue;
     }
-    if (line.startsWith("# ")) {
-      lines[index] = `# ${title}`;
-      return lines.join("\n").replace(/^\n+/, "");
-    }
+    bodyWithoutTitles.push(line);
   }
-  return [`# ${title}`, "", trimmed].join("\n").replace(/\n*$/u, "\n");
+  return [`# ${title}`, "", bodyWithoutTitles.join("\n").replace(/^\n+/, "")].join("\n").replace(/\n*$/u, "\n");
 }
 
 function stripYamlQuotes(value: string): string {


### PR DESCRIPTION
## Summary
- canonicalize generated scafld specs to one top-level title heading
- preserve fenced markdown that starts with #
- add a regression test for duplicate agent-authored titles

## Validation
- pnpm test tests/normalize-scafld-frontmatter.test.ts tests/scafld-issue-to-pr-parser.test.ts
- pnpm typecheck
- pnpm build