### PR TITLE
fix(thread): harden issue PR live retry

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,7 +41,7 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-95b39e8bbc82",
+    "version": "sha-80b66f9d966d",
     "digest": "316cb1dca2fd937b85d7835614a39e058d8af4e86d0ef52d79dc6e7cc8fd18da"
   },
   {

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -427,9 +427,14 @@ runners:
             approved spec, thread, repo_snapshot, repo_context, and current
             declared file contents are sufficient when they identify a narrow
             edit; do not return an empty bundle when one scoped docs edit is
-            possible. If a declared file has exists: false and the approved spec
-            intentionally creates it, write the new file when the desired
-            contents are inferable from the spec and thread. Do not widen scope.
+            possible. For any existing file, contents must be the complete
+            current file with the smallest necessary edit applied; preserve
+            unrelated sections, headings, prose, tables, links, setup
+            instructions, and ordering exactly. Never replace an existing file
+            with only the new section or a shortened summary. If a declared file
+            has exists: false and the approved spec intentionally creates it,
+            write the new file when the desired contents are inferable from the
+            spec and thread. Do not widen scope.
             Do not hand-edit scafld lifecycle files. Return
             fix_bundle.status: blocked with a reason and files: [] only when no
             concrete repo-relative target is declared, a required existing file

--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -623,6 +623,7 @@ describe("thread.push_outbox tool", () => {
           nextCommentId: 1000,
           failPrList: true,
           failPrCreateCount: 1,
+          failPrCreateMessage: "gh: Validation Failed (HTTP 422)\n{\"message\":\"Validation Failed\",\"errors\":[{\"resource\":\"PullRequest\",\"field\":\"head\",\"code\":\"invalid\"}],\"status\":\"422\"}\n",
         }, null, 2)}\n`,
       );
       await writeFakeGhScript(fakeGh);
@@ -1170,7 +1171,7 @@ if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/pulls$/.test(args[1] || "")) 
   if ((state.failPrCreateCount ?? 0) > 0) {
     state.failPrCreateCount -= 1;
     writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
-    process.stderr.write("GraphQL: Head sha can't be blank, Head repository can't be blank, No commits between example:main and example:issue-list-failure, not all refs are readable\\n");
+    process.stderr.write(state.failPrCreateMessage || "GraphQL: Head sha can't be blank, Head repository can't be blank, No commits between example:main and example:issue-list-failure, not all refs are readable\\n");
     process.exit(1);
   }
   const repo = (args[1] || "").replace(/^repos\\//, "").replace(/\\/pulls$/, "");

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -498,7 +498,7 @@ export function pushGitHubPullRequest({
       });
     } catch (error) {
       const fallback = findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env);
-      if (!fallback || !String(error?.message ?? error).match(/pull request.*(already exists|exists)|already.*pull request/i)) {
+      if (!fallback) {
         throw error;
       }
       pullRequestRef = firstNonEmptyString(fallback.url, fallback.number);
@@ -977,7 +977,7 @@ function buildGitHubPullRequestCreateArgs({ repoSlug, branch, base, title, body 
 }
 
 function isTransientGitHubPullRequestCreateError(message) {
-  return /Head sha can't be blank|Base sha can't be blank|Head repository can't be blank|No commits between|not all refs are readable/i
+  return /Head sha can't be blank|Base sha can't be blank|Head repository can't be blank|No commits between|not all refs are readable|Validation Failed/i
     .test(String(message));
 }
 


### PR DESCRIPTION
## Summary
- retry GitHub REST PR creation on validation/ref propagation failures
- reuse an open branch-matching PR after any create failure when it exists
- strengthen issue-to-pr builder instructions to preserve existing file content
- refresh the official skills lock

## Validation
- pnpm test tests/thread-push-outbox-tool.test.ts tests/scafld-issue-to-pr-parser.test.ts
- pnpm typecheck
- pnpm verify:fast
- pnpm build