### PR TITLE
fix(thread): create PRs with direct REST call

### DIFF
--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -933,6 +933,17 @@ function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, works
   let lastError;
   for (let attempt = 0; attempt < 4; attempt += 1) {
     try {
+      const restCreated = runGitHubPullRequestCreateRest({
+        repoSlug,
+        branch,
+        base,
+        title,
+        body,
+        env,
+      });
+      if (restCreated) {
+        return restCreated;
+      }
       return runCommand(resolveGhBinary(env), buildGitHubPullRequestCreateArgs({
         repoSlug,
         branch,
@@ -952,6 +963,53 @@ function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, works
     }
   }
   throw lastError;
+}
+
+function runGitHubPullRequestCreateRest({ repoSlug, branch, base, title, body, env }) {
+  if (firstNonEmptyString(env?.RUNX_GH_BIN)) {
+    return undefined;
+  }
+  const token = firstNonEmptyString(env?.GH_TOKEN, env?.GITHUB_TOKEN);
+  if (!token) {
+    return undefined;
+  }
+  const payload = JSON.stringify(prune({
+    title,
+    head: branch,
+    base,
+    body,
+    draft: true,
+  }));
+  const result = spawnSync("curl", [
+    "--fail-with-body",
+    "--silent",
+    "--show-error",
+    "--request",
+    "POST",
+    "--url",
+    `https://api.github.com/repos/${repoSlug}/pulls`,
+    "--header",
+    "Accept: application/vnd.github+json",
+    "--header",
+    "X-GitHub-Api-Version: 2022-11-28",
+    "--header",
+    `Authorization: Bearer ${token}`,
+    "--data-binary",
+    "@-",
+  ], {
+    input: payload,
+    env: env ?? process.env,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`command failed: curl GitHub pull request create\n${result.stderr || result.stdout || "unknown failure"}`);
+  }
+  const parsed = JSON.parse(result.stdout);
+  const url = firstNonEmptyString(parsed.html_url, parsed.url);
+  if (!url) {
+    throw new Error("GitHub pull request create response did not include html_url.");
+  }
+  return url;
 }
 
 function buildGitHubPullRequestCreateArgs({ repoSlug, branch, base, title, body }) {


### PR DESCRIPTION
## Summary
- create GitHub PRs directly through REST using curl when a token is available
- keep gh-based creation as fallback for custom gh adapters/tests
- avoid leaking the token in create failure messages

## Validation
- pnpm test tests/thread-push-outbox-tool.test.ts
- pnpm typecheck
- pnpm verify:fast