### PR TITLE
fix(thread): fall back across github pr tokens

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -359,6 +359,111 @@ describe("thread.push_outbox tool", () => {
     }
   }, 15_000);
 
+  it("falls back from GH_TOKEN to GITHUB_TOKEN for direct REST pull request creation", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-rest-token-tool-"));
+    const workspace = path.join(tempDir, "workspace");
+    const remote = path.join(tempDir, "remote.git");
+    const fakeBin = path.join(tempDir, "bin");
+    const fakeGh = path.join(fakeBin, "gh");
+    const fakeCurl = path.join(fakeBin, "curl");
+    const fakeState = path.join(tempDir, "fake-gh-state.json");
+
+    try {
+      await mkdir(fakeBin, { recursive: true });
+      await initGitHubWorkspace(workspace, remote, "issue-rest-token");
+      await writeFile(
+        fakeState,
+        `${JSON.stringify({
+          issue: {
+            number: 123,
+            title: "Fix fixture behavior",
+            body: "The issue body for the fixture.",
+            url: "https://github.com/example/repo/issues/123",
+            state: "OPEN",
+            createdAt: "2026-04-22T00:00:00Z",
+            updatedAt: "2026-04-22T00:00:00Z",
+            author: {
+              login: "auscaster",
+            },
+            comments: [],
+            labels: [],
+            closedByPullRequestsReferences: [],
+          },
+          pulls: [],
+          nextPullNumber: 77,
+          nextCommentId: 1000,
+          curlTokens: [],
+        }, null, 2)}\n`,
+      );
+      await writeFakeGhScript(fakeGh);
+      await writeFakeCurlScript(fakeCurl);
+
+      const result = runTool({
+        thread: {
+          kind: "runx.thread.v1",
+          adapter: {
+            type: "github",
+            adapter_ref: "example/repo#issue/123",
+          },
+          thread_kind: "work_item",
+          thread_locator: "github://example/repo/issues/123",
+          canonical_uri: "https://github.com/example/repo/issues/123",
+          entries: [],
+          decisions: [],
+          outbox: [],
+          source_refs: [],
+        },
+        outbox_entry: {
+          entry_id: "pull_request:issue-rest-token",
+          kind: "pull_request",
+          title: "Fix fixture behavior",
+          status: "proposed",
+          thread_locator: "github://example/repo/issues/123",
+        },
+        draft_pull_request: {
+          schema_version: "runx.pull-request-draft.v1",
+          action: "create",
+          push_ready: true,
+          task_id: "issue-rest-token",
+          target: {
+            repo: "example/repo",
+            branch: "issue-rest-token",
+            base: "main",
+            remote: "origin",
+          },
+          pull_request: {
+            title: "Fix fixture behavior",
+            body_markdown: "# Fix fixture behavior\n\nBody.\n",
+            is_draft: true,
+          },
+        },
+        workspace_path: workspace,
+        next_status: "draft",
+      }, {
+        GH_TOKEN: "bad-token",
+        GITHUB_TOKEN: "good-token",
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        RUNX_FAKE_GH_STATE: fakeState,
+        RUNX_GH_BIN: undefined,
+      });
+
+      expect(result.push.status).toBe("pushed");
+      expect(result.push.pull_request.url).toBe("https://github.com/example/repo/pull/77");
+      expect(JSON.parse(await readFile(fakeState, "utf8"))).toMatchObject({
+        curlTokens: ["bad-token", "good-token"],
+        pulls: [
+          {
+            number: 77,
+            headRefName: "issue-rest-token",
+            baseRefName: "main",
+          },
+        ],
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("sets a default Git commit identity before committing uncommitted GitHub pull request changes", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-identity-tool-"));
     const workspace = path.join(tempDir, "workspace");
@@ -1284,6 +1389,72 @@ function readField(argv, key) {
     const value = argv[index + 1] || "";
     if (value.startsWith(\`\${key}=\`)) {
       return value.slice(key.length + 1);
+    }
+  }
+  return "";
+}
+`,
+    { mode: 0o755 },
+  );
+}
+
+async function writeFakeCurlScript(scriptPath: string): Promise<void> {
+  await writeFile(
+    scriptPath,
+    `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const statePath = process.env.RUNX_FAKE_GH_STATE;
+if (!statePath) {
+  throw new Error("RUNX_FAKE_GH_STATE is required.");
+}
+
+const state = JSON.parse(readFileSync(statePath, "utf8"));
+const authHeader = readHeader(args, "Authorization");
+const token = authHeader.replace(/^Bearer\\s+/, "");
+state.curlTokens = [...(state.curlTokens || []), token];
+
+if (token === "bad-token") {
+  writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+  process.stderr.write("bad token cannot create pull requests\\n");
+  process.exit(22);
+}
+
+const repo = (readFlag(args, "--url").match(/\\/repos\\/([^/]+\\/[^/]+)\\/pulls$/) || [])[1];
+const payload = JSON.parse(readFileSync(0, "utf8"));
+const number = state.nextPullNumber++;
+const pull = {
+  number,
+  repo,
+  title: payload.title,
+  body: payload.body,
+  url: \`https://github.com/\${repo}/pull/\${number}\`,
+  html_url: \`https://github.com/\${repo}/pull/\${number}\`,
+  state: "OPEN",
+  isDraft: payload.draft === true,
+  headRefName: payload.head,
+  baseRefName: payload.base,
+  updatedAt: "2026-04-22T01:00:00Z",
+};
+state.pulls.push(pull);
+writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+process.stdout.write(JSON.stringify(pull));
+
+function readFlag(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? argv[index + 1] : "";
+}
+
+function readHeader(argv, headerName) {
+  for (let index = 0; index < argv.length - 1; index += 1) {
+    if (argv[index] !== "--header") {
+      continue;
+    }
+    const value = argv[index + 1] || "";
+    const prefix = \`\${headerName}:\`;
+    if (value.startsWith(prefix)) {
+      return value.slice(prefix.length).trim();
     }
   }
   return "";

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -933,27 +933,40 @@ function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, works
   let lastError;
   for (let attempt = 0; attempt < 4; attempt += 1) {
     try {
-      const restCreated = runGitHubPullRequestCreateRest({
-        repoSlug,
-        branch,
-        base,
-        title,
-        body,
-        env,
-      });
+      let restError;
+      let restCreated;
+      try {
+        restCreated = runGitHubPullRequestCreateRest({
+          repoSlug,
+          branch,
+          base,
+          title,
+          body,
+          env,
+        });
+      } catch (error) {
+        restError = error;
+      }
       if (restCreated) {
         return restCreated;
       }
-      return runCommand(resolveGhBinary(env), buildGitHubPullRequestCreateArgs({
-        repoSlug,
-        branch,
-        base,
-        title,
-        body,
-      }), {
-        cwd: workspacePath,
-        env,
-      }).trim();
+      try {
+        return runCommand(resolveGhBinary(env), buildGitHubPullRequestCreateArgs({
+          repoSlug,
+          branch,
+          base,
+          title,
+          body,
+        }), {
+          cwd: workspacePath,
+          env,
+        }).trim();
+      } catch (error) {
+        if (restError) {
+          throw new Error(`${error.message}\nREST create failed first:\n${restError.message}`);
+        }
+        throw error;
+      }
     } catch (error) {
       lastError = error;
       if (attempt === 3) {
@@ -969,8 +982,8 @@ function runGitHubPullRequestCreateRest({ repoSlug, branch, base, title, body, e
   if (firstNonEmptyString(env?.RUNX_GH_BIN)) {
     return undefined;
   }
-  const token = firstNonEmptyString(env?.GH_TOKEN, env?.GITHUB_TOKEN);
-  if (!token) {
+  const tokens = githubTokenCandidates(env);
+  if (tokens.length === 0) {
     return undefined;
   }
   const payload = JSON.stringify(prune({
@@ -980,36 +993,60 @@ function runGitHubPullRequestCreateRest({ repoSlug, branch, base, title, body, e
     body,
     draft: true,
   }));
-  const result = spawnSync("curl", [
-    "--fail-with-body",
-    "--silent",
-    "--show-error",
-    "--request",
-    "POST",
-    "--url",
-    `https://api.github.com/repos/${repoSlug}/pulls`,
-    "--header",
-    "Accept: application/vnd.github+json",
-    "--header",
-    "X-GitHub-Api-Version: 2022-11-28",
-    "--header",
-    `Authorization: Bearer ${token}`,
-    "--data-binary",
-    "@-",
-  ], {
-    input: payload,
-    env: env ?? process.env,
-    encoding: "utf8",
-  });
-  if (result.status !== 0) {
-    throw new Error(`command failed: curl GitHub pull request create\n${result.stderr || result.stdout || "unknown failure"}`);
+  const failures = [];
+  for (const token of tokens) {
+    const result = spawnSync("curl", [
+      "--fail-with-body",
+      "--silent",
+      "--show-error",
+      "--request",
+      "POST",
+      "--url",
+      `https://api.github.com/repos/${repoSlug}/pulls`,
+      "--header",
+      "Accept: application/vnd.github+json",
+      "--header",
+      "X-GitHub-Api-Version: 2022-11-28",
+      "--header",
+      `Authorization: Bearer ${token.value}`,
+      "--data-binary",
+      "@-",
+    ], {
+      input: payload,
+      env: env ?? process.env,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      failures.push(`${token.name}: ${result.stderr || result.stdout || "unknown failure"}`);
+      continue;
+    }
+    const parsed = JSON.parse(result.stdout);
+    const url = firstNonEmptyString(parsed.html_url, parsed.url);
+    if (!url) {
+      throw new Error("GitHub pull request create response did not include html_url.");
+    }
+    return url;
   }
-  const parsed = JSON.parse(result.stdout);
-  const url = firstNonEmptyString(parsed.html_url, parsed.url);
-  if (!url) {
-    throw new Error("GitHub pull request create response did not include html_url.");
+  throw new Error(`command failed: curl GitHub pull request create\n${failures.join("\n")}`);
+}
+
+function githubTokenCandidates(env) {
+  const candidates = [
+    ["GH_TOKEN", env?.GH_TOKEN],
+    ["GITHUB_TOKEN", env?.GITHUB_TOKEN],
+    ["RUNX_GITHUB_TOKEN", env?.RUNX_GITHUB_TOKEN],
+  ];
+  const seen = new Set();
+  const tokens = [];
+  for (const [name, value] of candidates) {
+    const token = firstNonEmptyString(value);
+    if (!token || seen.has(token)) {
+      continue;
+    }
+    seen.add(token);
+    tokens.push({ name, value: token });
   }
-  return url;
+  return tokens;
 }
 
 function buildGitHubPullRequestCreateArgs({ repoSlug, branch, base, title, body }) {


### PR DESCRIPTION
## Summary

Teach the GitHub thread adapter's direct REST PR create path to try distinct token candidates (`GH_TOKEN`, `GITHUB_TOKEN`, `RUNX_GITHUB_TOKEN`) before falling back to `gh api`.

## Why

Live issue-to-pr runs can have a custom `GH_TOKEN` for git operations plus the Actions runtime token available separately. If the custom token cannot create PRs, the adapter should use the next available token instead of failing after the branch has already been pushed.

## Validation

- `pnpm test tests/thread-push-outbox-tool.test.ts`
- `pnpm typecheck`
- `pnpm verify:fast`
- `pnpm build`
