### PR TITLE
fix(thread): fall back to gh pr create

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -565,6 +565,104 @@ describe("thread.push_outbox tool", () => {
     }
   }, 15_000);
 
+  it("falls back from gh api to gh pr create for pull request creation", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-pr-create-tool-"));
+    const workspace = path.join(tempDir, "workspace");
+    const remote = path.join(tempDir, "remote.git");
+    const fakeGh = path.join(tempDir, "fake-gh.mjs");
+    const fakeState = path.join(tempDir, "fake-gh-state.json");
+
+    try {
+      await initGitHubWorkspace(workspace, remote, "issue-pr-create");
+      await writeFile(
+        fakeState,
+        `${JSON.stringify({
+          issue: {
+            number: 123,
+            title: "Fix fixture behavior",
+            body: "The issue body for the fixture.",
+            url: "https://github.com/example/repo/issues/123",
+            state: "OPEN",
+            createdAt: "2026-04-22T00:00:00Z",
+            updatedAt: "2026-04-22T00:00:00Z",
+            author: {
+              login: "auscaster",
+            },
+            comments: [],
+            labels: [],
+            closedByPullRequestsReferences: [],
+          },
+          pulls: [],
+          nextPullNumber: 77,
+          nextCommentId: 1000,
+          failPrCreateCount: 1,
+        }, null, 2)}\n`,
+      );
+      await writeFakeGhScript(fakeGh);
+
+      const result = runTool({
+        thread: {
+          kind: "runx.thread.v1",
+          adapter: {
+            type: "github",
+            adapter_ref: "example/repo#issue/123",
+          },
+          thread_kind: "work_item",
+          thread_locator: "github://example/repo/issues/123",
+          canonical_uri: "https://github.com/example/repo/issues/123",
+          entries: [],
+          decisions: [],
+          outbox: [],
+          source_refs: [],
+        },
+        outbox_entry: {
+          entry_id: "pull_request:issue-pr-create",
+          kind: "pull_request",
+          title: "Fix fixture behavior",
+          status: "proposed",
+          thread_locator: "github://example/repo/issues/123",
+        },
+        draft_pull_request: {
+          schema_version: "runx.pull-request-draft.v1",
+          action: "create",
+          push_ready: true,
+          task_id: "issue-pr-create",
+          target: {
+            repo: "example/repo",
+            branch: "issue-pr-create",
+            base: "main",
+            remote: "origin",
+          },
+          pull_request: {
+            title: "Fix fixture behavior",
+            body_markdown: "# Fix fixture behavior\n\nBody.\n",
+            is_draft: true,
+          },
+        },
+        workspace_path: workspace,
+        next_status: "draft",
+      }, {
+        GH_TOKEN: "token",
+        RUNX_GH_BIN: fakeGh,
+        RUNX_FAKE_GH_STATE: fakeState,
+      });
+
+      expect(result.push.status).toBe("pushed");
+      expect(result.push.pull_request.url).toBe("https://github.com/example/repo/pull/77");
+      expect(JSON.parse(await readFile(fakeState, "utf8"))).toMatchObject({
+        pulls: [
+          {
+            number: 77,
+            headRefName: "issue-pr-create",
+            baseRefName: "main",
+          },
+        ],
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("sets a default Git commit identity before committing uncommitted GitHub pull request changes", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-identity-tool-"));
     const workspace = path.join(tempDir, "workspace");

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -1003,6 +1003,7 @@ function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, works
       if (restCreated) {
         return restCreated;
       }
+      let apiError;
       try {
         return runGitHubPullRequestCreateGh({
           repoSlug,
@@ -1014,10 +1015,25 @@ function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, works
           env,
         });
       } catch (error) {
-        if (restError) {
-          throw new Error(`${error.message}\nREST create failed first:\n${restError.message}`);
-        }
-        throw error;
+        apiError = error;
+      }
+      try {
+        return runGitHubPullRequestCreateCli({
+          repoSlug,
+          branch,
+          base,
+          title,
+          body,
+          workspacePath,
+          env,
+        });
+      } catch (error) {
+        throw new Error([
+          error.message,
+          "gh api create failed first:",
+          apiError.message,
+          restError ? `REST create failed first:\n${restError.message}` : undefined,
+        ].filter(Boolean).join("\n"));
       }
     } catch (error) {
       lastError = error;
@@ -1114,6 +1130,49 @@ function runGitHubPullRequestCreateGh({ repoSlug, branch, base, title, body, wor
     }
   }
   throw new Error(`command failed: gh GitHub pull request create\n${failures.join("\n")}`);
+}
+
+function runGitHubPullRequestCreateCli({ repoSlug, branch, base, title, body, workspacePath, env }) {
+  const args = [
+    "pr",
+    "create",
+    "--repo",
+    repoSlug,
+    "--head",
+    branch,
+    "--title",
+    title,
+    "--body",
+    body,
+    "--draft",
+  ];
+  if (base) {
+    args.push("--base", base);
+  }
+  const tokens = githubTokenCandidates(env);
+  if (tokens.length === 0) {
+    return runCommand(resolveGhBinary(env), args, {
+      cwd: workspacePath,
+      env,
+    }).trim();
+  }
+  const failures = [];
+  for (const token of tokens) {
+    const candidateEnv = {
+      ...(env ?? process.env),
+      GH_TOKEN: token.value,
+      GITHUB_TOKEN: token.value,
+    };
+    try {
+      return runCommand(resolveGhBinary(candidateEnv), args, {
+        cwd: workspacePath,
+        env: candidateEnv,
+      }).trim();
+    } catch (error) {
+      failures.push(`${token.name}: ${error.message}`);
+    }
+  }
+  throw new Error(`command failed: gh pr create\n${failures.join("\n")}`);
 }
 
 function githubTokenCandidates(env) {


### PR DESCRIPTION
## Summary
- add a final `gh pr create` fallback after direct REST and `gh api` PR create attempts fail
- retry this fallback across the same GitHub token candidates
- add regression coverage for REST-disabled environments where `gh api` fails but `gh pr create` succeeds

## Validation
- pnpm test tests/thread-push-outbox-tool.test.ts
- pnpm typecheck
- pnpm verify:fast
- pnpm build
