### PR TITLE
fix(thread): retry pr lifecycle across tokens

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -939,6 +939,9 @@ describe("thread.push_outbox tool", () => {
           ],
           nextPullNumber: 113,
           nextCommentId: 1000,
+          failPrListTokens: ["bad-token"],
+          failPrMutationTokens: ["bad-token"],
+          failPrViewTokens: ["bad-token"],
         }, null, 2)}\n`,
       );
       await writeFakeGhScript(fakeGh);
@@ -985,6 +988,8 @@ describe("thread.push_outbox tool", () => {
         workspace_path: workspace,
         next_status: "draft",
       }, {
+        GH_TOKEN: "bad-token",
+        GITHUB_TOKEN: "good-token",
         RUNX_GH_BIN: fakeGh,
         RUNX_FAKE_GH_STATE: fakeState,
       });
@@ -1004,6 +1009,9 @@ describe("thread.push_outbox tool", () => {
         },
       });
       expect(JSON.parse(await readFile(fakeState, "utf8"))).toMatchObject({
+        ghListTokens: ["bad-token", "good-token", "bad-token", "good-token"],
+        ghMutationTokens: ["bad-token", "good-token", "bad-token", "good-token"],
+        ghViewTokens: ["bad-token", "good-token"],
         nextPullNumber: 113,
         pulls: [
           {
@@ -1635,6 +1643,13 @@ if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/pulls$/.test(args[1] || "")) 
 }
 
 if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/pulls\\/\\d+$/.test(args[1] || "")) {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  state.ghMutationTokens = [...(state.ghMutationTokens || []), token];
+  if ((state.failPrMutationTokens || []).includes(token)) {
+    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+    process.stderr.write(\`token \${token} cannot update pull requests\\n\`);
+    process.exit(1);
+  }
   const pull = findPull(state.pulls, (args[1] || "").split("/").pop());
   pull.title = readField(args, "title") || pull.title;
   pull.body = readField(args, "body") || pull.body;
@@ -1646,10 +1661,18 @@ if (args[0] === "api" && /^repos\\/[^/]+\\/[^/]+\\/pulls\\/\\d+$/.test(args[1] |
 }
 
 if (args[0] === "pr" && args[1] === "list") {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  state.ghListTokens = [...(state.ghListTokens || []), token];
+  if ((state.failPrListTokens || []).includes(token)) {
+    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+    process.stderr.write(\`token \${token} cannot list pull requests\\n\`);
+    process.exit(1);
+  }
   if (state.failPrList && args.includes("--head")) {
     process.stderr.write("preflight lookup failed\\n");
     process.exit(1);
   }
+  writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
   process.stdout.write(JSON.stringify(state.pulls));
   process.exit(0);
 }
@@ -1680,6 +1703,13 @@ if (args[0] === "pr" && args[1] === "create") {
 }
 
 if (args[0] === "pr" && args[1] === "edit") {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  state.ghMutationTokens = [...(state.ghMutationTokens || []), token];
+  if ((state.failPrMutationTokens || []).includes(token)) {
+    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+    process.stderr.write(\`token \${token} cannot edit pull requests\\n\`);
+    process.exit(1);
+  }
   const ref = args[2];
   const pull = findPull(state.pulls, ref);
   pull.title = readFlag(args, "--title");
@@ -1691,6 +1721,13 @@ if (args[0] === "pr" && args[1] === "edit") {
 }
 
 if (args[0] === "pr" && args[1] === "reopen") {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  state.ghMutationTokens = [...(state.ghMutationTokens || []), token];
+  if ((state.failPrMutationTokens || []).includes(token)) {
+    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+    process.stderr.write(\`token \${token} cannot reopen pull requests\\n\`);
+    process.exit(1);
+  }
   const pull = findPull(state.pulls, args[2]);
   pull.state = "OPEN";
   pull.updatedAt = "2026-04-22T01:00:00Z";
@@ -1699,7 +1736,15 @@ if (args[0] === "pr" && args[1] === "reopen") {
 }
 
 if (args[0] === "pr" && args[1] === "view") {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  state.ghViewTokens = [...(state.ghViewTokens || []), token];
+  if ((state.failPrViewTokens || []).includes(token)) {
+    writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
+    process.stderr.write(\`token \${token} cannot view pull requests\\n\`);
+    process.exit(1);
+  }
   const pull = findPull(state.pulls, args[2]);
+  writeFileSync(statePath, \`\${JSON.stringify(state, null, 2)}\\n\`);
   process.stdout.write(JSON.stringify(pull));
   process.exit(0);
 }

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -382,7 +382,7 @@ export function fetchGitHubIssueThread({ adapterRef, env, cwd }) {
     "--comments",
     "--json",
     "author,body,closedByPullRequestsReferences,comments,createdAt,labels,number,state,title,updatedAt,url",
-  ], { env, cwd });
+  ], { env, cwd }, { tokenFallback: true });
   const pullRequests = dedupeGitHubPullRequests([
     ...normalizeGitHubPullRequestArray(issue.closedByPullRequestsReferences),
     ...normalizeGitHubPullRequestArray(runGhJson([
@@ -396,7 +396,7 @@ export function fetchGitHubIssueThread({ adapterRef, env, cwd }) {
       gitHubIssueSearchQuery(issueRef),
       "--json",
       "baseRefName,headRefName,isDraft,number,state,title,updatedAt,url",
-    ], { env, cwd })),
+    ], { env, cwd }, { tokenFallback: true })),
   ]);
   return hydrateGitHubIssueThread({
     adapterRef: issueRef.adapter_ref,
@@ -528,7 +528,7 @@ export function pushGitHubPullRequest({
   ], {
     cwd: workspacePath,
     env,
-  });
+  }, { tokenFallback: true });
   const refreshedEntry = mapGitHubPullRequestToOutboxEntry(
     {
       ...pullRequestView,
@@ -607,7 +607,7 @@ export function pushGitHubMessage({
     ], {
       cwd: workspacePath ?? process.cwd(),
       env,
-    });
+    }, { tokenFallback: true });
   } else {
     runCommand(resolveGhBinary(env), [
       "api",
@@ -888,7 +888,7 @@ function findGitHubPullRequestByHead(repoSlug, branch, workspacePath, env, optio
     ], {
       cwd: workspacePath,
       env,
-    });
+    }, { tokenFallback: true });
   } catch {
     return undefined;
   }
@@ -923,7 +923,7 @@ function reopenGitHubPullRequestIfClosed({ repoSlug, pullRequest, workspacePath,
   if (!pullRequestRef) {
     throw new Error("GitHub pull request reference is required to reopen a closed branch match.");
   }
-  runCommand(resolveGhBinary(env), [
+  runGhCommand([
     "pr",
     "reopen",
     pullRequestRef,
@@ -932,7 +932,7 @@ function reopenGitHubPullRequestIfClosed({ repoSlug, pullRequest, workspacePath,
   ], {
     cwd: workspacePath,
     env,
-  });
+  }, { tokenFallback: true });
 }
 
 function gitHubPullRequestOpenScore(pullRequest) {
@@ -956,10 +956,10 @@ function editGitHubPullRequest({ repoSlug, pullRequestRef, title, body, base, wo
     if (base) {
       args.push("--base", base);
     }
-    runCommand(resolveGhBinary(env), args, {
+    runGhCommand(args, {
       cwd: workspacePath,
       env,
-    });
+    }, { tokenFallback: true });
     return;
   }
 
@@ -976,10 +976,10 @@ function editGitHubPullRequest({ repoSlug, pullRequestRef, title, body, base, wo
   if (base) {
     args.push("-f", `base=${base}`);
   }
-  runCommand(resolveGhBinary(env), args, {
+  runGhCommand(args, {
     cwd: workspacePath,
     env,
-  });
+  }, { tokenFallback: true });
 }
 
 function runGitHubPullRequestCreate({ repoSlug, branch, base, title, body, workspacePath, env }) {
@@ -1115,11 +1115,7 @@ function runGitHubPullRequestCreateGh({ repoSlug, branch, base, title, body, wor
   }
   const failures = [];
   for (const token of tokens) {
-    const candidateEnv = {
-      ...(env ?? process.env),
-      GH_TOKEN: token.value,
-      GITHUB_TOKEN: token.value,
-    };
+    const candidateEnv = githubTokenCandidateEnv(env, token.value);
     try {
       return runCommand(resolveGhBinary(candidateEnv), args, {
         cwd: workspacePath,
@@ -1158,11 +1154,7 @@ function runGitHubPullRequestCreateCli({ repoSlug, branch, base, title, body, wo
   }
   const failures = [];
   for (const token of tokens) {
-    const candidateEnv = {
-      ...(env ?? process.env),
-      GH_TOKEN: token.value,
-      GITHUB_TOKEN: token.value,
-    };
+    const candidateEnv = githubTokenCandidateEnv(env, token.value);
     try {
       return runCommand(resolveGhBinary(candidateEnv), args, {
         cwd: workspacePath,
@@ -1221,8 +1213,39 @@ function sleepSync(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
-function runGhJson(args, options) {
-  return JSON.parse(runCommand(resolveGhBinary(options?.env), args, options));
+function runGhJson(args, options, runOptions = {}) {
+  return JSON.parse(runGhCommand(args, options, runOptions));
+}
+
+function runGhCommand(args, options, runOptions = {}) {
+  if (runOptions.tokenFallback !== true) {
+    return runCommand(resolveGhBinary(options?.env), args, options);
+  }
+  const tokens = githubTokenCandidates(options?.env);
+  if (tokens.length === 0) {
+    return runCommand(resolveGhBinary(options?.env), args, options);
+  }
+  const failures = [];
+  for (const token of tokens) {
+    const candidateEnv = githubTokenCandidateEnv(options?.env, token.value);
+    try {
+      return runCommand(resolveGhBinary(candidateEnv), args, {
+        ...options,
+        env: candidateEnv,
+      });
+    } catch (error) {
+      failures.push(`${token.name}: ${error.message}`);
+    }
+  }
+  throw new Error(`command failed: gh ${args.join(" ")}\n${failures.join("\n")}`);
+}
+
+function githubTokenCandidateEnv(env, token) {
+  return {
+    ...(env ?? process.env),
+    GH_TOKEN: token,
+    GITHUB_TOKEN: token,
+  };
 }
 
 function repoHasUncommittedChanges(workspacePath, env) {


### PR DESCRIPTION
## Summary
- apply GitHub token fallback to PR lookup, reopen, edit, final view, and thread rehydration
- keep create fallbacks from prior fixes, but make stale closed-PR recovery work when the primary token can push but cannot call PR APIs
- strengthen regression coverage so a bad primary token fails list/reopen/edit/view and the secondary token must complete the closed-PR refresh path

## Validation
- pnpm test tests/thread-push-outbox-tool.test.ts
- pnpm typecheck
- pnpm verify:fast
- pnpm build
