### PR TITLE
Lease-update stale generated branches

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -1028,6 +1028,143 @@ describe("thread.push_outbox tool", () => {
     }
   }, 15_000);
 
+  it("lease-updates a stale generated branch before reopening an existing pull request", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-stale-branch-tool-"));
+    const workspace = path.join(tempDir, "workspace");
+    const remote = path.join(tempDir, "remote.git");
+    const remoteClone = path.join(tempDir, "remote-clone");
+    const fakeGh = path.join(tempDir, "fake-gh.mjs");
+    const fakeState = path.join(tempDir, "fake-gh-state.json");
+    const branch = "runx/stale-issue";
+
+    try {
+      await initGitHubWorkspace(workspace, remote, branch);
+      runChecked("git", ["-C", workspace, "push", "--set-upstream", "origin", branch], tempDir);
+      runChecked("git", ["clone", remote, remoteClone], tempDir);
+      runChecked("git", ["-C", remoteClone, "checkout", branch], tempDir);
+      runChecked("git", ["-C", remoteClone, "config", "user.email", "remote@example.com"], tempDir);
+      runChecked("git", ["-C", remoteClone, "config", "user.name", "Remote Update"], tempDir);
+      await writeFile(path.join(remoteClone, "README.md"), "stale remote update\n");
+      runChecked("git", ["-C", remoteClone, "commit", "-am", "stale remote update"], tempDir);
+      runChecked("git", ["-C", remoteClone, "push", "origin", branch], tempDir);
+      await writeFile(path.join(workspace, "README.md"), "fresh generated update\n");
+      runChecked("git", ["-C", workspace, "commit", "-am", "fresh generated update"], tempDir);
+      await writeFile(
+        fakeState,
+        `${JSON.stringify({
+          issue: {
+            number: 123,
+            title: "Fix fixture behavior",
+            body: "The issue body for the fixture.",
+            url: "https://github.com/example/repo/issues/123",
+            state: "OPEN",
+            createdAt: "2026-04-22T00:00:00Z",
+            updatedAt: "2026-04-22T00:00:00Z",
+            author: { login: "auscaster" },
+            comments: [],
+            labels: [],
+            closedByPullRequestsReferences: [],
+          },
+          pulls: [
+            {
+              number: 112,
+              repo: "example/repo",
+              title: "Old fixture behavior",
+              body: "Old body.",
+              url: "https://github.com/example/repo/pull/112",
+              state: "CLOSED",
+              isDraft: true,
+              headRefName: branch,
+              baseRefName: "main",
+              mergedAt: null,
+              updatedAt: "2026-04-22T00:30:00Z",
+            },
+          ],
+          nextPullNumber: 113,
+          nextCommentId: 1000,
+        }, null, 2)}\n`,
+      );
+      await writeFakeGhScript(fakeGh);
+
+      const result = runTool({
+        thread: {
+          kind: "runx.thread.v1",
+          adapter: {
+            type: "github",
+            adapter_ref: "example/repo#issue/123",
+          },
+          thread_kind: "work_item",
+          thread_locator: "github://example/repo/issues/123",
+          canonical_uri: "https://github.com/example/repo/issues/123",
+          entries: [],
+          decisions: [],
+          outbox: [],
+          source_refs: [],
+        },
+        outbox_entry: {
+          entry_id: "pull_request:stale-issue",
+          kind: "pull_request",
+          title: "Fix fixture behavior",
+          status: "proposed",
+          thread_locator: "github://example/repo/issues/123",
+        },
+        draft_pull_request: {
+          schema_version: "runx.pull-request-draft.v1",
+          action: "create",
+          push_ready: true,
+          task_id: "stale-issue",
+          target: {
+            repo: "example/repo",
+            branch,
+            base: "main",
+            remote: "origin",
+          },
+          pull_request: {
+            title: "Fix fixture behavior",
+            body_markdown: "# Fix fixture behavior\n\nUpdated body.\n",
+            is_draft: true,
+          },
+        },
+        workspace_path: workspace,
+        next_status: "draft",
+      }, {
+        RUNX_GH_BIN: fakeGh,
+        RUNX_FAKE_GH_STATE: fakeState,
+      });
+
+      const localHead = runChecked("git", ["-C", workspace, "rev-parse", branch], tempDir);
+      const remoteHead = runChecked("git", ["ls-remote", remote, `refs/heads/${branch}`], tempDir).split(/\s+/)[0];
+      expect(remoteHead).toBe(localHead);
+      expect(result).toMatchObject({
+        outbox_entry: {
+          entry_id: "pr-112",
+          locator: "https://github.com/example/repo/pull/112",
+          status: "draft",
+        },
+        push: {
+          status: "pushed",
+          pull_request: {
+            number: "112",
+            url: "https://github.com/example/repo/pull/112",
+          },
+        },
+      });
+      expect(JSON.parse(await readFile(fakeState, "utf8"))).toMatchObject({
+        pulls: [
+          {
+            number: 112,
+            state: "OPEN",
+            title: "Fix fixture behavior",
+            body: expect.stringContaining("Updated body."),
+            headRefName: branch,
+          },
+        ],
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("creates a GitHub pull request when optional GitHub PR setup calls need retry", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-thread-gh-list-failure-tool-"));
     const workspace = path.join(tempDir, "workspace");

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -460,8 +460,10 @@ export function pushGitHubPullRequest({
     });
   }
 
-  runCommand("git", ["push", "--set-upstream", remote, branch], {
-    cwd: workspacePath,
+  pushGitHubBranch({
+    workspacePath,
+    remote,
+    branch,
     env,
   });
 
@@ -1302,6 +1304,48 @@ function defaultGitUserEmail(env) {
     env?.GITHUB_ACTIONS === "true" ? "41898282+github-actions[bot]@users.noreply.github.com" : undefined,
     "runx@example.invalid",
   );
+}
+
+function pushGitHubBranch({ workspacePath, remote, branch, env }) {
+  try {
+    runCommand("git", ["push", "--set-upstream", remote, branch], {
+      cwd: workspacePath,
+      env,
+    });
+    return;
+  } catch (error) {
+    if (!isRunxGeneratedBranch(branch)) {
+      throw error;
+    }
+    const remoteSha = readRemoteBranchSha({ workspacePath, remote, branch, env });
+    if (!remoteSha) {
+      throw error;
+    }
+    runCommand("git", [
+      "push",
+      "--set-upstream",
+      `--force-with-lease=refs/heads/${branch}:${remoteSha}`,
+      remote,
+      branch,
+    ], {
+      cwd: workspacePath,
+      env,
+    });
+  }
+}
+
+function readRemoteBranchSha({ workspacePath, remote, branch, env }) {
+  const stdout = runCommand("git", ["ls-remote", "--heads", remote, `refs/heads/${branch}`], {
+    cwd: workspacePath,
+    env,
+  });
+  const line = stdout.split(/\r?\n/).find((entry) => entry.trim().length > 0);
+  const sha = line?.split(/\s+/)[0];
+  return /^[0-9a-f]{40}$/i.test(sha ?? "") ? sha : undefined;
+}
+
+function isRunxGeneratedBranch(branch) {
+  return typeof branch === "string" && branch.startsWith("runx/");
 }
 
 function runCommand(command, args, options) {


### PR DESCRIPTION
## Summary
- retry generated runx branch publication with an explicit force-with-lease against the observed remote branch SHA
- keep non-runx branch push failures unchanged
- cover the stale branch + closed PR reopen path in thread.push_outbox

## Validation
- pnpm build
- pnpm test tests/thread-push-outbox-tool.test.ts
- pnpm typecheck
- pnpm verify:fast