### PR TITLE
Build scafld lanes until review

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-80b66f9d966d",
-    "digest": "316cb1dca2fd937b85d7835614a39e058d8af4e86d0ef52d79dc6e7cc8fd18da"
+    "version": "sha-794e28b7e05f",
+    "digest": "9a8ffe8acd19c3c5270539fc50d5358c498130a45ca102cb5b4ae9c43c18f295"
   },
   {
     "skill_id": "runx/issue-triage",
@@ -91,8 +91,8 @@
   },
   {
     "skill_id": "runx/scafld",
-    "version": "sha-19f8fb31f4d0",
-    "digest": "1f72a893584cf674fb060c2190e96c339f4704bfa4c85c929a83990e1a0076b3"
+    "version": "sha-c05d20e151b5",
+    "digest": "148db9da65d217e8cbb4bbad8d663e087d74e1fc35c8e110cf843add461044c0"
   },
   {
     "skill_id": "runx/skill-lab",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -26,8 +26,9 @@ The graph runs:
 
 `scafld plan` -> author markdown spec -> write spec -> read spec -> validate ->
 approve -> read approved spec -> read declared files -> author fix bundle ->
-write fix bundle -> build -> status -> read current branch -> review ->
-complete -> final status -> handoff -> package draft PR outbox -> adapter push.
+write fix bundle -> build to review -> status -> read current branch -> review
+-> complete -> final status -> handoff -> package draft PR outbox -> adapter
+push.
 
 There are no translation projection steps. `scafld handoff` is the human handoff
 surface, `scafld build` is the validation/check surface, and `scafld review` is
@@ -40,8 +41,8 @@ the native review boundary.
 - Audience: maintainers reviewing the issue, spec, code change, native review,
   handoff, and draft PR.
 - Artifact contract: markdown scafld spec, authored change bundle, build
-  result, review result, completed status, handoff markdown, draft PR packet,
-  outbox entry, and receipt trail.
+  build-to-review result, review result, completed status, handoff markdown,
+  draft PR packet, outbox entry, and receipt trail.
 - Evidence bar: every spec objective, file impact, validation command, and PR
   claim must trace to the thread, repo snapshot, scafld state, or actual
   working-tree change.

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -463,13 +463,13 @@ runners:
           context:
             files: author-fix.fix_bundle.data.files
         - id: scafld-build
-          label: build task
+          label: build to review
           skill: ../scafld
           scopes:
             - scafld:build
           mutation: true
           inputs:
-            command: build
+            command: build_to_review
         - id: scafld-status
           label: inspect review state
           skill: ../scafld

--- a/skills/scafld/SKILL.md
+++ b/skills/scafld/SKILL.md
@@ -45,7 +45,7 @@ Specs are Markdown files under `.scafld/specs/`:
 - `active/` - active or review-stage specs
 - `archive/YYYY-MM/` - completed, failed, or cancelled specs
 
-The supported native commands are:
+The supported commands are:
 
 1. `init` - bootstrap a scafld workspace.
 2. `plan <task-id>` - create `.scafld/specs/drafts/<task-id>.md`.
@@ -54,14 +54,17 @@ The supported native commands are:
 5. `validate <task-id>` - validate the Markdown spec shape.
 6. `approve <task-id>` - move a draft into the approved lane.
 7. `build <task-id>` - activate approved work, run acceptance, and write evidence.
-8. `exec <task-id>` - run the execution path for the current task.
-9. `review <task-id>` - run scafld's native adversarial review gate.
-10. `complete <task-id>` - archive reviewed work after the native gate passes.
-11. `status <task-id>` - inspect native task state.
-12. `list` - list native task specs.
-13. `report` - aggregate native run/spec metrics.
-14. `handoff <task-id>` - render model-facing Markdown transport.
-15. `fail <task-id>` and `cancel <task-id>` - archive incomplete work.
+8. `build_to_review <task-id>` - repeatedly run native `scafld build
+   <task-id> --json` until scafld reports status `review`, stopping on the
+   first native build failure or blocker.
+9. `exec <task-id>` - run the execution path for the current task.
+10. `review <task-id>` - run scafld's native adversarial review gate.
+11. `complete <task-id>` - archive reviewed work after the native gate passes.
+12. `status <task-id>` - inspect native task state.
+13. `list` - list native task specs.
+14. `report` - aggregate native run/spec metrics.
+15. `handoff <task-id>` - render model-facing Markdown transport.
+16. `fail <task-id>` and `cancel <task-id>` - archive incomplete work.
 
 Branch creation, issue updates, PR creation, and CI publication are wrapper
 responsibilities. scafld owns the local lifecycle, spec projection, session
@@ -83,7 +86,7 @@ matter:
 ## Inputs
 
 - `command` (required): one of `init`, `plan`, `harden`, `validate`,
-  `approve`, `build`, `exec`, `review`, `complete`, `fail`, `cancel`,
+  `approve`, `build`, `build_to_review`, `exec`, `review`, `complete`, `fail`, `cancel`,
   `status`, `list`, `report`, or `handoff`.
 - `task_id`: scafld task id. Required for all commands except `init`, `list`,
   and `report`.
@@ -94,6 +97,8 @@ matter:
 - `mark_passed`: forwarded to `harden --mark-passed`.
 - `provider`, `provider_command`, `provider_binary`, `model`: forwarded to
   `review`.
+- `max_builds`: optional cap for `build_to_review`; defaults to 12 native
+  build advances.
 - `scafld_bin`: explicit scafld executable path. Defaults to `SCAFLD_BIN` or
   `scafld` on PATH.
 
@@ -101,5 +106,7 @@ matter:
 
 runx does not rebuild scafld state locally. For commands with native JSON
 contracts, the wrapper forwards the scafld payload directly after argv/env
-sanitization. `handoff` is the exception: it forwards native Markdown because
-handoff is model transport, not lifecycle state.
+sanitization. `build_to_review` is a bounded lifecycle driver over native
+`scafld build` outputs, not a local state reconstruction. `handoff` is the
+exception: it forwards native Markdown because handoff is model transport, not
+lifecycle state.

--- a/skills/scafld/X.yaml
+++ b/skills/scafld/X.yaml
@@ -32,7 +32,7 @@ runners:
       command:
         type: string
         required: true
-        description: "Native scafld command to run: init, plan, harden, validate, approve, build, exec, review, complete, fail, cancel, status, list, report, or handoff."
+        description: "scafld command to run: init, plan, harden, validate, approve, build, build_to_review, exec, review, complete, fail, cancel, status, list, report, or handoff."
       task_id:
         type: string
         required: false
@@ -69,6 +69,10 @@ runners:
         type: boolean
         required: false
         description: "When true, pass `--mark-passed` to `scafld harden`."
+      max_builds:
+        type: string
+        required: false
+        description: "Maximum native `scafld build` advances for `build_to_review`; defaults to 12."
       provider:
         type: string
         required: false

--- a/skills/scafld/run.mjs
+++ b/skills/scafld/run.mjs
@@ -29,6 +29,7 @@ const jsonCommands = new Set([
   "list",
   "report",
   "build",
+  "build_to_review",
 ]);
 const commandsWithoutTaskId = new Set(["init", "list", "report"]);
 
@@ -83,6 +84,8 @@ switch (command) {
   case "build":
     args.push(command, taskId);
     break;
+  case "build_to_review":
+    break;
   case "review":
     args.push("review", taskId);
     if (inputs.provider) {
@@ -124,6 +127,23 @@ for (const key of Object.keys(env)) {
 }
 if (path.isAbsolute(scafld) || scafld.includes(path.sep)) {
   env.PATH = `${path.dirname(scafld)}${path.delimiter}${env.PATH || "/usr/local/bin:/usr/bin:/bin"}`;
+}
+
+if (command === "build_to_review") {
+  const advanced = buildToReview({
+    scafld,
+    taskId,
+    cwd,
+    env,
+    maxBuilds: positiveInteger(inputs.max_builds, 12),
+  });
+  if (advanced.stdout) {
+    process.stdout.write(advanced.stdout);
+  }
+  if (advanced.stderr) {
+    process.stderr.write(advanced.stderr);
+  }
+  process.exit(advanced.exitCode);
 }
 
 const result = spawnSync(scafld, args, {
@@ -195,6 +215,112 @@ function resolveBinary(candidate) {
     return candidate;
   }
   return path.isAbsolute(candidate) ? candidate : path.resolve(scriptDirectory, candidate);
+}
+
+function buildToReview({ scafld, taskId, cwd, env, maxBuilds }) {
+  const builds = [];
+  let passed = 0;
+  let failed = 0;
+
+  for (let attempt = 1; attempt <= maxBuilds; attempt += 1) {
+    const result = spawnSync(scafld, ["build", taskId, "--json"], {
+      cwd,
+      env,
+      encoding: "utf8",
+      shell: false,
+    });
+    if (result.error) {
+      return {
+        exitCode: 1,
+        stderr: `${result.error.message}\n`,
+      };
+    }
+
+    const stdout = result.stdout ?? "";
+    const stderr = result.stderr ?? "";
+    let structured = null;
+    try {
+      structured = parseJsonPayload("build", stdout);
+    } catch (error) {
+      return {
+        exitCode: result.status === 0 ? 1 : result.status ?? 1,
+        stderr: `${stderr}${error.message}\n`,
+      };
+    }
+
+    const payload = unwrapScafldResult(structured);
+    builds.push(payload);
+    passed += Number.isFinite(payload.passed) ? payload.passed : 0;
+    failed += Number.isFinite(payload.failed) ? payload.failed : 0;
+
+    const exitCode = result.status ?? 1;
+    if (exitCode !== 0) {
+      return {
+        exitCode,
+        stdout: `${JSON.stringify(structured)}\n`,
+        stderr,
+      };
+    }
+
+    if (payload.status === "review") {
+      return {
+        exitCode: 0,
+        stdout: `${JSON.stringify({
+          ok: true,
+          command: "build_to_review",
+          result: {
+            task_id: payload.task_id || taskId,
+            status: payload.status,
+            phase: payload.phase,
+            passed,
+            failed,
+            next: payload.next,
+            iterations: builds.length,
+            builds,
+            last: payload,
+          },
+        })}\n`,
+        stderr,
+      };
+    }
+  }
+
+  return {
+    exitCode: 1,
+    stdout: `${JSON.stringify({
+      ok: false,
+      command: "build_to_review",
+      error: {
+        code: "runtime_error",
+        message: `scafld build_to_review exceeded ${maxBuilds} build attempts before status review`,
+        exit_code: 1,
+      },
+      result: {
+        task_id: taskId,
+        status: builds.at(-1)?.status || "unknown",
+        passed,
+        failed,
+        iterations: builds.length,
+        builds,
+        last: builds.at(-1),
+      },
+    })}\n`,
+  };
+}
+
+function unwrapScafldResult(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    if (value.result && typeof value.result === "object" && !Array.isArray(value.result)) {
+      return value.result;
+    }
+    return value;
+  }
+  return {};
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function parseJsonPayload(commandName, rawStdout) {

--- a/tests/issue-to-pr-graph.test.ts
+++ b/tests/issue-to-pr-graph.test.ts
@@ -55,7 +55,7 @@ describe("issue-to-PR composite skill", () => {
       "plan",
       "validate",
       "approve",
-      "build",
+      "build_to_review",
       "status",
       "review",
       "complete",

--- a/tests/scafld-issue-to-pr-parser.test.ts
+++ b/tests/scafld-issue-to-pr-parser.test.ts
@@ -47,7 +47,7 @@ describe("scafld issue-to-PR skill contract", () => {
       "scafld-plan": "plan",
       "scafld-validate": "validate",
       "scafld-approve": "approve",
-      "scafld-build": "build",
+      "scafld-build": "build_to_review",
       "scafld-status": "status",
       "scafld-review": "review",
       "scafld-complete": "complete",

--- a/tests/scafld-skill-parser.test.ts
+++ b/tests/scafld-skill-parser.test.ts
@@ -28,6 +28,7 @@ describe("scafld skill contract", () => {
     expect(wrapper).toContain('"plan"');
     expect(wrapper).toContain('"harden"');
     expect(wrapper).toContain('"build"');
+    expect(wrapper).toContain('"build_to_review"');
     expect(wrapper).toContain('"handoff"');
     expect(wrapper).not.toContain('"new"');
     expect(wrapper).not.toContain('"branch"');
@@ -45,6 +46,7 @@ describe("scafld skill contract", () => {
     expect(runner?.inputs.acceptance_command.required).toBe(false);
     expect(runner?.inputs.provider.required).toBe(false);
     expect(runner?.inputs.mark_passed.required).toBe(false);
+    expect(runner?.inputs.max_builds.required).toBe(false);
     expect(runner?.runtime).toEqual({
       requirements: [
         "scafld CLI with native JSON contracts available on PATH, via SCAFLD_BIN, or through explicit scafld_bin input",

--- a/tests/scafld-skill.test.ts
+++ b/tests/scafld-skill.test.ts
@@ -327,6 +327,108 @@ process.exit(1);
     }
   });
 
+  it("build_to_review advances native build until scafld reports review", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-scafld-build-to-review-"));
+    const fakeScafld = path.join(tempDir, "fake-scafld.mjs");
+
+    try {
+      await writeFile(
+        fakeScafld,
+        `#!/usr/bin/env node
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const countPath = join(__dirname, "build-count.txt");
+const argv = process.argv.slice(2);
+if ((argv[0] || "") === "build") {
+  const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) + 1 : 1;
+  writeFileSync(countPath, String(count));
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    command: "build",
+    result: {
+      task_id: argv[1],
+      status: count === 1 ? "active" : "review",
+      phase: count === 1 ? "phase1" : "final",
+      passed: count === 1 ? 0 : 2,
+      failed: 0,
+      next: count === 1 ? "scafld build fixture-task" : "scafld review fixture-task",
+    },
+  }) + "\\n");
+  process.exit(0);
+}
+process.stderr.write(\`unsupported command: \${argv[0] || ""}\\n\`);
+process.exit(1);
+`,
+        { mode: 0o755 },
+      );
+
+      const result = await runLocalSkill({
+        skillPath: path.resolve("skills/scafld"),
+        runner: "scafld-cli",
+        inputs: {
+          command: "build_to_review",
+          task_id: "fixture-task",
+          fixture: tempDir,
+          scafld_bin: fakeScafld,
+        },
+        caller,
+        adapters: createDefaultSkillAdapters(),
+        receiptDir: path.join(tempDir, "receipts"),
+        runxHome: path.join(tempDir, "home"),
+        env: process.env,
+      });
+
+      expect(result.status).toBe("success");
+      if (result.status !== "success") {
+        return;
+      }
+      expect(JSON.parse(result.execution.stdout)).toEqual({
+        ok: true,
+        command: "build_to_review",
+        result: {
+          task_id: "fixture-task",
+          status: "review",
+          phase: "final",
+          passed: 2,
+          failed: 0,
+          next: "scafld review fixture-task",
+          iterations: 2,
+          builds: [
+            {
+              task_id: "fixture-task",
+              status: "active",
+              phase: "phase1",
+              passed: 0,
+              failed: 0,
+              next: "scafld build fixture-task",
+            },
+            {
+              task_id: "fixture-task",
+              status: "review",
+              phase: "final",
+              passed: 2,
+              failed: 0,
+              next: "scafld review fixture-task",
+            },
+          ],
+          last: {
+            task_id: "fixture-task",
+            status: "review",
+            phase: "final",
+            passed: 2,
+            failed: 0,
+            next: "scafld review fixture-task",
+          },
+        },
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves native non-zero failures instead of normalizing them away", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-scafld-failure-"));
     const fakeScafld = path.join(tempDir, "fake-scafld.mjs");


### PR DESCRIPTION
## Summary
- add a reusable scafld `build_to_review` boundary that advances native `scafld build` until status `review`
- switch `issue-to-pr` to use that reusable lifecycle boundary instead of assuming one build call reaches review
- update the official skills lock and tests for the current scafld build lifecycle

## Validation
- pnpm build
- pnpm test tests/scafld-skill.test.ts tests/scafld-skill-parser.test.ts tests/issue-to-pr-graph.test.ts tests/scafld-issue-to-pr-parser.test.ts
- pnpm typecheck
- pnpm verify:fast
- git diff --check