### PR TITLE
Fix PR create body handling

### DIFF
--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -649,15 +649,19 @@ describe("thread.push_outbox tool", () => {
 
       expect(result.push.status).toBe("pushed");
       expect(result.push.pull_request.url).toBe("https://github.com/example/repo/pull/77");
-      expect(JSON.parse(await readFile(fakeState, "utf8"))).toMatchObject({
+      const state = JSON.parse(await readFile(fakeState, "utf8"));
+      expect(state).toMatchObject({
         pulls: [
           {
             number: 77,
             headRefName: "issue-pr-create",
             baseRefName: "main",
+            body: expect.stringContaining("Body."),
           },
         ],
       });
+      expect(state.lastPrCreateArgs).toContain("--body-file");
+      expect(state.lastPrCreateArgs).not.toContain("--body");
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
@@ -1819,8 +1823,9 @@ if (args[0] === "pr" && args[1] === "create") {
   const head = readFlag(args, "--head");
   const base = readFlag(args, "--base");
   const title = readFlag(args, "--title");
-  const body = readFlag(args, "--body");
+  const body = readFlag(args, "--body") || readBodyFile(args, "--body-file");
   const number = state.nextPullNumber++;
+  state.lastPrCreateArgs = args;
   const pull = {
     number,
     repo,
@@ -1913,6 +1918,17 @@ function readField(argv, key) {
     }
   }
   return "";
+}
+
+function readBodyFile(argv, flag) {
+  const value = readFlag(argv, flag);
+  if (!value) {
+    return "";
+  }
+  if (value === "-") {
+    return readFileSync(0, "utf8");
+  }
+  return readFileSync(value, "utf8");
 }
 `,
     { mode: 0o755 },

--- a/tools/thread/github_adapter.mjs
+++ b/tools/thread/github_adapter.mjs
@@ -1140,8 +1140,8 @@ function runGitHubPullRequestCreateCli({ repoSlug, branch, base, title, body, wo
     branch,
     "--title",
     title,
-    "--body",
-    body,
+    "--body-file",
+    "-",
     "--draft",
   ];
   if (base) {
@@ -1152,6 +1152,7 @@ function runGitHubPullRequestCreateCli({ repoSlug, branch, base, title, body, wo
     return runCommand(resolveGhBinary(env), args, {
       cwd: workspacePath,
       env,
+      input: body,
     }).trim();
   }
   const failures = [];
@@ -1161,6 +1162,7 @@ function runGitHubPullRequestCreateCli({ repoSlug, branch, base, title, body, wo
       return runCommand(resolveGhBinary(candidateEnv), args, {
         cwd: workspacePath,
         env: candidateEnv,
+        input: body,
       }).trim();
     } catch (error) {
       failures.push(`${token.name}: ${error.message}`);
@@ -1352,6 +1354,7 @@ function runCommand(command, args, options) {
   const result = spawnSync(command, args, {
     cwd: options?.cwd,
     env: options?.env ?? process.env,
+    input: options?.input,
     encoding: "utf8",
   });
   if (result.status !== 0) {


### PR DESCRIPTION
## Summary
- pass `gh pr create` bodies through stdin via `--body-file -`
- keep markdown PR bodies out of command-line error summaries
- assert the fallback path preserves body content without using `--body`

## Validation
- `pnpm test tests/thread-push-outbox-tool.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm verify:fast`
- `git diff --check`
