### PR TITLE
Scope GitHub publish env for thread pushes

### DIFF
--- a/packages/adapters/src/cli-tool/index.ts
+++ b/packages/adapters/src/cli-tool/index.ts
@@ -82,7 +82,8 @@ export async function invokeCliTool(request: CliToolInvokeRequest): Promise<CliT
   const resolved = request.resolvedInputs ?? {};
   const args = (request.source.args ?? []).map((arg) => resolveArg(arg, resolved, request.inputs));
   const writablePaths = (request.source.sandbox?.writablePaths ?? []).map((writablePath) =>
-    resolveArg(writablePath, resolved, request.inputs));
+    resolveArg(writablePath, resolved, request.inputs))
+    .filter((writablePath) => writablePath.trim().length > 0);
   const sandbox = prepareLocalProcessSandbox({
     sandbox: request.source.sandbox,
     skillDirectory: request.skillDirectory,

--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -8,6 +8,24 @@ import { describe, expect, it } from "vitest";
 const toolPath = path.resolve("tools/thread/push_outbox/run.mjs");
 
 describe("thread.push_outbox tool", () => {
+  it("declares GitHub publish environment for sandboxed execution", async () => {
+    const manifest = JSON.parse(await readFile(path.resolve("tools/thread/push_outbox/manifest.json"), "utf8"));
+    expect(manifest.source.sandbox).toMatchObject({
+      profile: "workspace-write",
+      network: true,
+      writable_paths: ["{{workspace_path}}", "{{fixture}}"],
+    });
+    expect(manifest.source.sandbox.env_allowlist).toEqual(expect.arrayContaining([
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+      "RUNX_GITHUB_TOKEN",
+      "RUNX_GIT_AUTHOR_NAME",
+      "RUNX_GIT_AUTHOR_EMAIL",
+    ]));
+    expect(manifest.source.sandbox.env_allowlist).not.toContain("HOME");
+    expect(manifest.source.sandbox.env_allowlist).not.toContain("RUNX_GH_BIN");
+  });
+
   it("skips cleanly when thread is not present", () => {
     const result = runTool({
       outbox_entry: {

--- a/tools/thread/push_outbox/manifest.json
+++ b/tools/thread/push_outbox/manifest.json
@@ -7,7 +7,32 @@
     "command": "node",
     "args": [
       "./run.mjs"
-    ]
+    ],
+    "sandbox": {
+      "profile": "workspace-write",
+      "cwd_policy": "workspace",
+      "env_allowlist": [
+        "PATH",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "RUNX_GITHUB_TOKEN",
+        "RUNX_GIT_AUTHOR_NAME",
+        "RUNX_GIT_AUTHOR_EMAIL",
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+        "GITHUB_ACTIONS"
+      ],
+      "network": true,
+      "writable_paths": [
+        "{{workspace_path}}",
+        "{{fixture}}"
+      ]
+    }
   },
   "inputs": {
     "thread": {
@@ -53,7 +78,7 @@
       "./run.mjs"
     ]
   },
-  "source_hash": "sha256:b9281bfdb411fcc210f5e496506685c55dbbcc59d4d38c3f0fd8fb6e96a025f5",
+  "source_hash": "sha256:2b78bf392f47be293c8c43228d75ef2d96c9aab062273ab77e25986f5e3827fa",
   "schema_hash": "sha256:5c9657a19edc8d729e5bd37d6ef4f7912f0f060b1fc719bd822b85cc2fddf5dc",
   "toolkit_version": "0.1.3"
 }

--- a/tools/thread/push_outbox/src/index.ts
+++ b/tools/thread/push_outbox/src/index.ts
@@ -19,9 +19,38 @@ import {
   pushGitHubPullRequest,
 } from "../../github_adapter.mjs";
 
+const githubPublishEnvAllowlist = [
+  "PATH",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "RUNX_GITHUB_TOKEN",
+  "RUNX_GIT_AUTHOR_NAME",
+  "RUNX_GIT_AUTHOR_EMAIL",
+  "GIT_AUTHOR_NAME",
+  "GIT_AUTHOR_EMAIL",
+  "GIT_COMMITTER_NAME",
+  "GIT_COMMITTER_EMAIL",
+  "GITHUB_ACTIONS",
+];
+
 export default defineTool({
   name: "thread.push_outbox",
   description: "Push an outbox entry through the current thread adapter and return the refreshed thread.",
+  source: {
+    type: "cli-tool",
+    command: "node",
+    args: ["./run.mjs"],
+    sandbox: {
+      profile: "workspace-write",
+      cwd_policy: "workspace",
+      env_allowlist: githubPublishEnvAllowlist,
+      network: true,
+      writable_paths: ["{{workspace_path}}", "{{fixture}}"],
+    },
+  },
   inputs: {
     thread: recordInput({ optional: true, description: "Current hydrated thread for the bounded provider surface." }),
     outbox_entry: artifact({ description: "Outbox entry to push through the thread adapter." }),


### PR DESCRIPTION
## Summary
- declare a narrow sandbox contract for `thread.push_outbox` GitHub publishing
- allow only GitHub token and commit identity env needed at the provider push boundary
- filter empty optional writable paths so missing optional inputs do not create writable path placeholders
- assert the manifest excludes broad ambient auth env like `HOME` and `RUNX_GH_BIN`

## Security Shape
`thread.push_outbox` is the only issue-to-pr step that needs provider write credentials. Planning, scafld build/review, and package steps still run without publish secrets. The publish tool gets workspace-write + network with an explicit env allowlist, not ambient environment inheritance.

## Validation
- `pnpm test tests/thread-push-outbox-tool.test.ts packages/adapters/src/cli-tool/index.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm verify:fast`
- `git diff --check`
