### PR TITLE
Require scafld 2.4 runner contracts

### DIFF
--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -41,8 +41,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-794e28b7e05f",
-    "digest": "9a8ffe8acd19c3c5270539fc50d5358c498130a45ca102cb5b4ae9c43c18f295"
+    "version": "sha-e99fd6b784a9",
+    "digest": "4c8efce1a74d2772b7c2c35a4debc399cd5cd14b2641403017c488c8162e64eb"
   },
   {
     "skill_id": "runx/issue-triage",
@@ -91,8 +91,8 @@
   },
   {
     "skill_id": "runx/scafld",
-    "version": "sha-c05d20e151b5",
-    "digest": "148db9da65d217e8cbb4bbad8d663e087d74e1fc35c8e110cf843add461044c0"
+    "version": "sha-8ada4e3e2d9e",
+    "digest": "1186646398703a68d2eb02f045d014518c47c481ec4ffe721538db1023abe223"
   },
   {
     "skill_id": "runx/skill-lab",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Govern a scafld-backed issue-to-PR lane with native scafld review a
 
 # Issue to PR
 
-Drive one bounded thread-driven change through the scafld 2.2 lifecycle and
+Drive one bounded thread-driven change through the scafld 2.4 lifecycle and
 package the result as a provider-agnostic draft pull-request packet.
 
 The graph separates cognition from mutation. Agent phases author the scafld
@@ -37,7 +37,7 @@ the native review boundary.
 ## Quality Profile
 
 - Purpose: turn one bounded thread-driven change into a visible, reviewable
-  draft PR through native scafld 2.2 surfaces.
+  draft PR through native scafld 2.4 surfaces.
 - Audience: maintainers reviewing the issue, spec, code change, native review,
   handoff, and draft PR.
 - Artifact contract: markdown scafld spec, authored change bundle, build

--- a/skills/issue-to-pr/X.yaml
+++ b/skills/issue-to-pr/X.yaml
@@ -297,7 +297,7 @@ runners:
         status: governed
         rationale: >
           This graph keeps cognition and mutation separate while treating
-          scafld 2.2 as the workflow kernel. Agent phases author the markdown
+          scafld 2.4 as the workflow kernel. Agent phases author the markdown
           spec and bounded fix bundle. Deterministic fs.write phases perform
           mutations. Native scafld plan, validate, approve, build, review,
           complete, status, and handoff surfaces stay visible instead of being

--- a/skills/scafld/SKILL.md
+++ b/skills/scafld/SKILL.md
@@ -8,7 +8,7 @@ description: Run existing scafld v2 lifecycle commands under runx governance.
 Use this skill when runx needs to govern an existing scafld lifecycle or
 projection command.
 
-The skill does not replace scafld. It calls the scafld v2 CLI with explicit
+The skill does not replace scafld. It calls the scafld 2.4.0+ CLI with explicit
 argv, requires native JSON output for machine-readable commands, records the
 runx receipt for the hop, and lets the graph define which command is allowed at
 each step.
@@ -101,12 +101,16 @@ matter:
   build advances.
 - `scafld_bin`: explicit scafld executable path. Defaults to `SCAFLD_BIN` or
   `scafld` on PATH.
+- `scafld_min_version`: optional minimum accepted scafld version; defaults to
+  `2.4.0`.
 
 ## Structured Output
 
 runx does not rebuild scafld state locally. For commands with native JSON
 contracts, the wrapper forwards the scafld payload directly after argv/env
-sanitization. `build_to_review` is a bounded lifecycle driver over native
-`scafld build` outputs, not a local state reconstruction. `handoff` is the
-exception: it forwards native Markdown because handoff is model transport, not
-lifecycle state.
+sanitization. scafld 2.4.0 command providers may print provider progress before
+the final JSON envelope; the runner extracts and forwards that native envelope.
+`build_to_review` is a bounded lifecycle driver over native `scafld build`
+outputs, not a local state reconstruction. `handoff` is the exception: it
+forwards native Markdown because handoff is model transport, not lifecycle
+state.

--- a/skills/scafld/X.yaml
+++ b/skills/scafld/X.yaml
@@ -93,6 +93,10 @@ runners:
         type: string
         required: false
         description: "Explicit scafld executable path; defaults to SCAFLD_BIN or scafld on PATH."
+      scafld_min_version:
+        type: string
+        required: false
+        description: "Minimum accepted scafld version for this runner; defaults to 2.4.0."
     runtime:
       requirements:
-        - "scafld CLI with native JSON contracts available on PATH, via SCAFLD_BIN, or through explicit scafld_bin input"
+        - "scafld CLI 2.4.0 or newer with native JSON contracts available on PATH, via SCAFLD_BIN, or through explicit scafld_bin input"

--- a/skills/scafld/run.mjs
+++ b/skills/scafld/run.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 const inputs = loadInputs();
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const scafld = resolveBinary(String(inputs.scafld_bin || process.env.SCAFLD_BIN || "scafld"));
+const minimumScafldVersion = String(inputs.scafld_min_version || "2.4.0");
 const cwd = path.resolve(String(
   inputs.fixture
     || inputs.cwd
@@ -127,6 +128,13 @@ for (const key of Object.keys(env)) {
 }
 if (path.isAbsolute(scafld) || scafld.includes(path.sep)) {
   env.PATH = `${path.dirname(scafld)}${path.delimiter}${env.PATH || "/usr/local/bin:/usr/bin:/bin"}`;
+}
+
+try {
+  ensureScafldVersion({ scafld, cwd, env, minimum: minimumScafldVersion });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
 }
 
 if (command === "build_to_review") {
@@ -323,6 +331,52 @@ function positiveInteger(value, fallback) {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function ensureScafldVersion({ scafld, cwd, env, minimum }) {
+  const result = spawnSync(scafld, ["--version"], {
+    cwd,
+    env,
+    encoding: "utf8",
+    shell: false,
+  });
+  if (result.error) {
+    throw new Error(`could not resolve scafld ${minimum} or newer: ${result.error.message}`);
+  }
+  const exitCode = result.status ?? 1;
+  const rawVersion = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+  if (exitCode !== 0) {
+    throw new Error(`scafld --version failed with exit ${exitCode}: ${rawVersion}`);
+  }
+
+  const actual = parseSemver(rawVersion);
+  const required = parseSemver(minimum);
+  if (!required) {
+    throw new Error(`invalid required scafld version: ${minimum}`);
+  }
+  if (!actual || compareSemver(actual, required) < 0) {
+    throw new Error(
+      `scafld ${minimum} or newer is required by this runx runner; ` +
+      `resolved ${scafld} reported ${rawVersion || "no version"}`,
+    );
+  }
+}
+
+function parseSemver(value) {
+  const match = String(value).match(/\bv?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?\b/);
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] > right[index] ? 1 : -1;
+    }
+  }
+  return 0;
+}
+
 function parseJsonPayload(commandName, rawStdout) {
   const trimmed = rawStdout.trim();
   if (!trimmed) {
@@ -331,6 +385,18 @@ function parseJsonPayload(commandName, rawStdout) {
   try {
     return JSON.parse(trimmed);
   } catch (error) {
+    const jsonLine = trimmed
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .reverse()
+      .find((line) => line.startsWith("{") && line.endsWith("}"));
+    if (jsonLine) {
+      try {
+        return JSON.parse(jsonLine);
+      } catch (lineError) {
+        // Continue to the contract error below with the original output preview.
+      }
+    }
     const preview = trimmed.length > 240 ? `${trimmed.slice(0, 240)}...` : trimmed;
     throw new Error(
       `scafld ${commandName} did not emit valid JSON. ` +

--- a/tests/issue-to-pr-graph.test.ts
+++ b/tests/issue-to-pr-graph.test.ts
@@ -85,7 +85,7 @@ describe("issue-to-PR composite skill", () => {
     });
   });
 
-  it.skipIf(!hasScafld())("completes the canonical issue-to-pr lane through scafld 2.2 build, review, complete, and handoff", async () => {
+  it.skipIf(!hasScafld())("completes the canonical issue-to-pr lane through scafld 2.4 build, review, complete, and handoff", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-issue-to-pr-skill-"));
     const runtime = await createExternalRuntime("runx-issue-to-pr-runtime-");
     const taskId = "issue-to-pr-skill-fixture";
@@ -122,7 +122,7 @@ describe("issue-to-PR composite skill", () => {
         },
         caller,
         adapters: runtime.adapters,
-        env: runtime.env,
+        env: { ...runtime.env, RUNX_CWD: tempDir },
         receiptDir: runtime.paths.receiptDir,
         runxHome: runtime.paths.runxHome,
       });
@@ -252,7 +252,7 @@ describe("issue-to-PR composite skill", () => {
         },
         caller: blockedCaller,
         adapters: runtime.adapters,
-        env: runtime.env,
+        env: { ...runtime.env, RUNX_CWD: tempDir },
         receiptDir: runtime.paths.receiptDir,
         runxHome: runtime.paths.runxHome,
       });

--- a/tests/scafld-skill.test.ts
+++ b/tests/scafld-skill.test.ts
@@ -31,6 +31,10 @@ import { dirname, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const argv = process.argv.slice(2);
+if (argv[0] === "--version") {
+  process.stdout.write("2.4.0\\n");
+  process.exit(0);
+}
 writeFileSync(join(__dirname, \`\${argv[0] || "unknown"}-trace.json\`), JSON.stringify({
   argv,
   leakedEnv: Object.keys(process.env)
@@ -89,6 +93,60 @@ process.exit(1);
     }
   });
 
+  it("fails closed when the resolved scafld is older than 2.4.0", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-scafld-old-version-"));
+    const fakeScafld = path.join(tempDir, "fake-scafld.mjs");
+
+    try {
+      await writeFile(
+        fakeScafld,
+        `#!/usr/bin/env node
+const argv = process.argv.slice(2);
+if (argv[0] === "--version") {
+  process.stdout.write("2.3.12\\n");
+  process.exit(0);
+}
+if ((argv[0] || "") === "validate") {
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    command: "validate",
+    result: { task_id: "fixture-task", valid: true, errors: null },
+  }) + "\\n");
+  process.exit(0);
+}
+process.stderr.write(\`unsupported command: \${argv[0] || ""}\\n\`);
+process.exit(1);
+`,
+        { mode: 0o755 },
+      );
+
+      const result = await runLocalSkill({
+        skillPath: path.resolve("skills/scafld"),
+        runner: "scafld-cli",
+        inputs: {
+          command: "validate",
+          task_id: "fixture-task",
+          fixture: tempDir,
+          scafld_bin: fakeScafld,
+        },
+        caller,
+        adapters: createDefaultSkillAdapters(),
+        receiptDir: path.join(tempDir, "receipts"),
+        runxHome: path.join(tempDir, "home"),
+        env: process.env,
+      });
+
+      expect(result.status).toBe("failure");
+      if (result.status !== "failure") {
+        return;
+      }
+      expect(result.execution.stderr).toContain("scafld 2.4.0 or newer is required");
+      expect(result.execution.stderr).toContain("2.3.12");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("forwards native review and complete payloads without local reconstruction", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-scafld-native-"));
     const fakeScafld = path.join(tempDir, "fake-scafld.mjs");
@@ -106,6 +164,10 @@ import { dirname, join } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const argv = process.argv.slice(2);
 const command = argv[0] || "";
+if (command === "--version") {
+  process.stdout.write("2.4.0\\n");
+  process.exit(0);
+}
 const tracePath = join(__dirname, \`\${command}-trace.json\`);
 writeFileSync(tracePath, JSON.stringify({
   argv,
@@ -114,6 +176,8 @@ writeFileSync(tracePath, JSON.stringify({
     .sort(),
 }));
 if (command === "review") {
+  process.stdout.write("scafld review[command] started node reviewer.mjs\\n");
+  process.stdout.write("scafld review[command] completed exit=0 elapsed=4ms last_output=0s\\n");
   process.stdout.write(JSON.stringify({
     ok: true,
     command: "review",
@@ -228,6 +292,10 @@ process.exit(1);
         fakeScafld,
         `#!/usr/bin/env node
 const argv = process.argv.slice(2);
+if (argv[0] === "--version") {
+  process.stdout.write("2.4.0\\n");
+  process.exit(0);
+}
 if ((argv[0] || "") === "validate") {
   process.stdout.write(JSON.stringify({
     ok: true,
@@ -282,6 +350,10 @@ process.exit(1);
         fakeScafld,
         `#!/usr/bin/env node
 const argv = process.argv.slice(2);
+if (argv[0] === "--version") {
+  process.stdout.write("2.4.0\\n");
+  process.exit(0);
+}
 if ((argv[0] || "") === "validate") {
   process.stdout.write(JSON.stringify({
     ok: true,
@@ -342,6 +414,10 @@ import { dirname, join } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const countPath = join(__dirname, "build-count.txt");
 const argv = process.argv.slice(2);
+if (argv[0] === "--version") {
+  process.stdout.write("2.4.0\\n");
+  process.exit(0);
+}
 if ((argv[0] || "") === "build") {
   const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) + 1 : 1;
   writeFileSync(countPath, String(count));
@@ -438,6 +514,10 @@ process.exit(1);
         fakeScafld,
         `#!/usr/bin/env node
 const argv = process.argv.slice(2);
+if (argv[0] === "--version") {
+  process.stdout.write("2.4.0\\n");
+  process.exit(0);
+}
 if ((argv[0] || "") === "build") {
   process.stdout.write(JSON.stringify({
     ok: false,

--- a/tests/thread-push-outbox-tool.test.ts
+++ b/tests/thread-push-outbox-tool.test.ts
@@ -12,6 +12,7 @@ describe("thread.push_outbox tool", () => {
     const manifest = JSON.parse(await readFile(path.resolve("tools/thread/push_outbox/manifest.json"), "utf8"));
     expect(manifest.source.sandbox).toMatchObject({
       profile: "workspace-write",
+      cwd_policy: "skill-directory",
       network: true,
       writable_paths: ["{{workspace_path}}", "{{fixture}}"],
     });

--- a/tools/thread/push_outbox/manifest.json
+++ b/tools/thread/push_outbox/manifest.json
@@ -10,7 +10,7 @@
     ],
     "sandbox": {
       "profile": "workspace-write",
-      "cwd_policy": "workspace",
+      "cwd_policy": "skill-directory",
       "env_allowlist": [
         "PATH",
         "TMPDIR",
@@ -78,7 +78,7 @@
       "./run.mjs"
     ]
   },
-  "source_hash": "sha256:2b78bf392f47be293c8c43228d75ef2d96c9aab062273ab77e25986f5e3827fa",
+  "source_hash": "sha256:1aa977f48e96d2b5ef8ed4ea808d7bde1b39d69ffe906981f38c48b43648d12e",
   "schema_hash": "sha256:5c9657a19edc8d729e5bd37d6ef4f7912f0f060b1fc719bd822b85cc2fddf5dc",
   "toolkit_version": "0.1.3"
 }

--- a/tools/thread/push_outbox/src/index.ts
+++ b/tools/thread/push_outbox/src/index.ts
@@ -45,7 +45,7 @@ export default defineTool({
     args: ["./run.mjs"],
     sandbox: {
       profile: "workspace-write",
-      cwd_policy: "workspace",
+      cwd_policy: "skill-directory",
       env_allowlist: githubPublishEnvAllowlist,
       network: true,
       writable_paths: ["{{workspace_path}}", "{{fixture}}"],


### PR DESCRIPTION
## Summary\n- require scafld 2.4.0+ in the scafld runx runner\n- parse the native scafld JSON envelope when provider progress logs precede it\n- keep thread.push_outbox executing from its skill directory while only the workspace is writable\n\n## Validation\n- pnpm test tests/scafld-skill.test.ts tests/scafld-issue-to-pr-parser.test.ts tests/issue-to-pr-graph.test.ts tests/thread-push-outbox-tool.test.ts\n- pnpm build\n- pnpm typecheck\n- pnpm verify:fast\n- git diff --check