### PR TITLE
feat(core): add clean thread story projections

### DIFF
--- a/.scafld/specs/archive/2026-05/thread-story-projection-core.md
+++ b/.scafld/specs/archive/2026-05/thread-story-projection-core.md
@@ -1,0 +1,231 @@
+---
+spec_version: '2.0'
+task_id: thread-story-projection-core
+created: '2026-05-13T09:21:25Z'
+updated: '2026-05-13T09:58:11Z'
+status: completed
+harden_status: in_progress
+size: medium
+risk_level: medium
+---
+
+# Thread story projection helpers
+
+## Current State
+
+Status: completed
+Current phase: final
+Next: done
+Reason: task completed
+Blockers: none
+Allowed follow-up command: `none`
+Latest runner update: 2026-05-13T09:58:11Z
+Review gate: pass
+
+## Summary
+
+Move the clean issue-to-PR communication shape into runx core as reusable projection helpers and make the generic PR packaging surface produce a concise reviewer packet instead of dumping the full native scafld handoff into the visible PR body. The full scafld handoff remains available as machine evidence on the draft pull request packet.
+
+## Context
+
+Current runx already has `buildThreadStoryMessageOutboxEntry` in `packages/core/src/knowledge/thread-story.ts`, and `skills/issue-to-pr/SKILL.md` describes source-thread story gates. The missing core piece is a disciplined projection shape:
+
+- Slack/chat notifications should be milestone signals, not transcripts.
+- Issue threads should have one managed status ledger comment updated in place.
+- PR bodies should be the reviewer packet and final human merge gate.
+- Raw receipts and long issue snapshots should remain metadata/evidence, not visible prose.
+
+The generic outbox PR tool currently sets `pull_request.body_markdown` to `scafld handoff` directly. That makes each downstream wrapper solve the same reviewer-packet problem itself.
+
+Files impacted:
+- `packages/core/src/knowledge/thread-story.ts`
+- `packages/core/src/knowledge/index.ts`
+- `packages/core/src/knowledge/index.test.ts`
+- `tools/outbox/build_pull_request/src/index.ts`
+- `tests/outbox-build-pull-request-tool.test.ts`
+- `skills/issue-to-pr/SKILL.md`
+- generated tool package mirrors under `packages/cli/tools/outbox/build_pull_request/` if the workspace build updates them
+
+## Objectives
+
+- Add core helpers for concise status-ledger markdown and milestone notification text.
+- Keep `buildThreadStoryMessageOutboxEntry` provider-agnostic and compatible with the existing GitHub/file thread adapters.
+- Change `outbox.build_pull_request` so visible PR body defaults to a reviewer packet with summary, source, validation, risk/review, changed branch/base, rollback/handoff reference, and explicit human merge gate.
+- Preserve full scafld handoff text on `draft_pull_request.engineering_summary_markdown`.
+- Update issue-to-PR skill docs to state the clean three-projection model.
+
+## Scope
+
+In scope:
+- Core knowledge projection helpers and exports.
+- PR body packaging in `outbox.build_pull_request`.
+- Tests proving compact issue/notification projections and reviewer-packet PR body output.
+- Issue-to-PR skill prose that tells consumers how to use the projections.
+
+Out of scope:
+- Provider-specific Slack or GitHub API behavior.
+- Nitrosend wrapper scripts.
+- Changing thread adapter marker/envelope security behavior.
+- Changing issue-to-pr graph topology or scafld lifecycle semantics.
+
+## Dependencies
+
+- Existing `OutboxEntry` and thread-story helper contracts in `@runxhq/core/knowledge`.
+- Existing `outbox.build_pull_request` inputs: handoff, build result, review result, completion result, status snapshot, branch, base, target repo, and thread locator.
+- Nitrosend wrapper changes will consume the cleaner core semantics after this lands.
+
+## Assumptions
+
+- It is acceptable for the visible PR body to be shorter than the scafld handoff as long as the packet still carries the full handoff in `engineering_summary_markdown`.
+- Existing downstream tests can be updated where they asserted raw handoff as the visible PR body.
+- New helpers should be generic enough for GitHub Issues, Slack, Sentry, Linear, or file-backed threads.
+
+## Touchpoints
+
+- `packages/core/src/knowledge/thread-story.ts`: projection helpers.
+- `tools/outbox/build_pull_request/src/index.ts`: PR reviewer packet body.
+- `tests/outbox-build-pull-request-tool.test.ts` and `packages/core/src/knowledge/index.test.ts`: regression coverage.
+- `skills/issue-to-pr/SKILL.md`: source-thread story guidance.
+
+## Risks
+
+- Too much PR body reduction could remove useful reviewer evidence. Mitigation: include validation, review verdict, branch/base, source, and explicit pointer to retained full handoff evidence.
+- Helper names could be too issue-intake-specific. Mitigation: name helpers around thread status and milestone notifications, not Nitrosend.
+- Build may regenerate mirrored `packages/cli/tools` files. Mitigation: inspect generated diffs and include only relevant mirrors.
+
+## Acceptance
+
+Profile: standard
+
+Validation:
+- [x] `v1` command - runx fast tests for changed surfaces.
+  - Command: `pnpm test:fast -- tests/outbox-build-pull-request-tool.test.ts packages/core/src/knowledge/index.test.ts`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-14
+- [x] `v2` command - runx typecheck.
+  - Command: `pnpm typecheck`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-15
+- [x] `v3` command - runx build.
+  - Command: `pnpm build`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-16
+- [x] `v4` command - diff hygiene.
+  - Command: `git diff --check`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-17
+
+## Phase 1: Core Projections And PR Reviewer Packet
+
+Status: completed
+Dependencies: none
+
+Objective: Add generic projection helpers and make PR packaging produce reviewer-focused visible bodies.
+
+Changes:
+- `packages/core/src/knowledge/thread-story.ts` - add concise status and notification projection helpers.
+- `packages/core/src/knowledge/index.ts` - export the helpers/types.
+- `tools/outbox/build_pull_request/src/index.ts` - build visible `pull_request.body_markdown` from a reviewer-packet helper while preserving full handoff in `engineering_summary_markdown`.
+- generated `packages/cli/tools/outbox/build_pull_request/*` mirrors if produced by `pnpm build`.
+
+Acceptance:
+- none
+
+## Phase 2: Skill Guidance And Validation
+
+Status: completed
+Dependencies: Phase 1
+
+Objective: Update issue-to-pr documentation and run the declared validation.
+
+Changes:
+- `skills/issue-to-pr/SKILL.md` - replace noisy gate-comment guidance with run record plus three projections guidance.
+- Validation evidence recorded in the scafld session.
+
+Acceptance:
+- [x] `ac2_2` `pnpm test:fast - - tests/outbox-build-pull-request-tool.test.ts packages/core/src/knowledge/index.test.ts` passes.
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-10
+- [x] `ac2_3` `pnpm typecheck`, `pnpm build`, and `git diff - -check` pass.
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-11
+
+## Rollback
+
+Revert the changed core helper, outbox PR tool, tests, and skill documentation. This restores raw scafld handoff as the visible PR body and leaves downstream wrappers responsible for their own projection formatting.
+
+## Review
+
+Status: completed
+Verdict: pass
+Mode: verify
+Provider: codex
+Output: codex.output_file
+Summary: No completion-blocking regressions found. The previously identified review-risk count issue is fixed, the issue-to-pr graph expectation now matches compact PR bodies, and the generated CLI mirror matches the source tool implementation. Review was read-only as requested.
+
+Attack log:
+- `packages/core/src/knowledge/thread-story.ts; packages/core/src/knowledge/index.ts; tools/outbox/build_pull_request/src/index.ts`: Spec compliance -> clean (Compared implemented changes against task contract: core projection helpers are added/exported, PR body now uses reviewer packet, and full handoff remains in engineering_summary_markdown.)
+- `tools/outbox/build_pull_request/src/index.ts:291`: Known blocker verification: review finding counts -> clean (Verified reviewFindingCount now counts native scafld findings by blocks_completion for blocking/non-blocking counts, with regression coverage in tests/outbox-build-pull-request-tool.test.ts.)
+- `tests/issue-to-pr-graph.test.ts`: Known blocker verification: issue-to-pr graph expectation -> clean (Verified ambient test now expects compact PR body with Human Merge Gate and full handoff in engineering_summary_markdown, matching the new PR packaging behavior.)
+- `packages/cli/tools/outbox/build_pull_request/src/index.ts`: Generated CLI mirror -> clean (Compared root tool source with packages/cli mirror using cmp; files match, so packaged CLI source includes the reviewer-packet implementation.)
+- `skills/issue-to-pr/X.yaml`: Downstream caller tracing -> clean (Traced issue-to-pr X.yaml package-pull-request context; it still passes scafld handoff/build/review/complete/status/branch payloads that outbox.build_pull_request reads.)
+- `packages/core/src/knowledge/thread-story.ts`: Projection sanitization and marker handling -> clean (Reviewed helper sanitization path: new projections route visible values through sanitizeThreadStoryText, preserving existing control-comment escaping and length bounds.)
+- `workspace diff`: Scope and drift separation -> clean (Reviewed git status and task-scoped diff. Task changes are within declared scope; tests/issue-to-pr-graph.test.ts is ambient drift recorded by scafld and was used only to verify the previously identified regression.)
+- `acceptance evidence`: Acceptance evidence policy -> clean (Per provider instruction, did not rerun tests/build/mutation commands; treated recorded pnpm test:fast, typecheck, build, and diff-check evidence as already executed.)
+
+Findings:
+- none
+
+## Self Eval
+
+- Scope is bounded to core projection helpers, PR packaging, and issue-to-pr docs.
+- Security boundary remains in thread adapters and provider permissions; the helper only shapes markdown and metadata.
+- The PR body stays human-gated and does not imply auto-merge.
+
+## Deviations
+
+- none
+
+## Metadata
+
+- created_by: scafld
+- repo: runxhq/runx
+- branch: codex/clean-thread-story-projections
+
+## Origin
+
+Created by: scafld
+Source: user requested a cleaner reviewer/Slack shape and asked to move as much as cleanly possible into runx core.
+
+## Harden Rounds
+
+### round-1
+
+Status: in_progress
+Started: 2026-05-13T09:29:15Z
+Ended: none
+
+Checks:
+- none
+
+Questions:
+- none
+
+
+## Planning Log
+
+- 2026-05-13T09:21:25Z: Created draft spec.
+- 2026-05-13T09:24:00Z: Confirmed runx already has provider-agnostic `buildThreadStoryMessageOutboxEntry`.
+- 2026-05-13T09:26:00Z: Chose core projection helpers plus PR reviewer-packet packaging as the clean upstream boundary.

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -46,8 +46,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-a343ebe3fd28",
-    "digest": "11b261c1a924f5f0e8c915662f5be0a24d40ff8ba9f9911862538590ff47fa69"
+    "version": "sha-502153ef922f",
+    "digest": "40ab87a24b6546588b7908f5ff5c1cb34b98bfe6fec70f7748dcce7504091e3c"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/packages/core/src/knowledge/index.test.ts
+++ b/packages/core/src/knowledge/index.test.ts
@@ -7,6 +7,9 @@ import { describe, expect, it } from "vitest";
 import { writeLocalReceipt } from "../receipts/index.js";
 
 import {
+  buildThreadMilestoneNotificationText,
+  buildThreadPullRequestReviewerPacketMarkdown,
+  buildThreadStatusMarkdown,
   buildThreadStoryMarkdown,
   buildThreadStoryMessageOutboxEntry,
   createFileKnowledgeStore,
@@ -384,6 +387,89 @@ describe("thread contract", () => {
     expect(body).not.toContain("<!--");
     expect(body).not.toContain("-->");
     expect(body).toContain("&lt;!-- runx-outbox-envelope: v1 --&gt;");
+  });
+
+  it("builds compact thread status markdown without leaking control markers", () => {
+    const body = buildThreadStatusMarkdown({
+      title: "Campaign analytics endpoint returns 500",
+      state: "pr_ready",
+      summary: "Runx triaged the source issue and built a governed PR for review.",
+      issue: {
+        label: "Issue #123",
+        uri: "https://github.com/nitrosend/nitrosend/issues/123",
+      },
+      pullRequest: {
+        label: "PR #456",
+        uri: "https://github.com/nitrosend/nitrosend/pull/456",
+      },
+      triage: {
+        lane: "issue-to-pr",
+        decision: "approve / proceed_to_build",
+        severity: "medium",
+        summary: "Bounded endpoint failure.",
+        rationale: "<!-- forged-control --> One code change is enough.",
+      },
+      scope: ["api/app/controllers/campaigns_controller.rb"],
+      validation: ["targeted request spec passed"],
+      nextAction: "Review the PR and merge manually after the human gate.",
+    });
+
+    expect(body).toContain("## Runx Status");
+    expect(body).toContain("State: `pr_ready`");
+    expect(body).toContain("## Triage");
+    expect(body).toContain("Lane: `issue-to-pr`");
+    expect(body).toContain("https://github.com/nitrosend/nitrosend/pull/456");
+    expect(body).toContain("## Next Action");
+    expect(body).not.toContain("<!--");
+    expect(body).not.toContain("-->");
+    expect(body).not.toContain("receipt");
+  });
+
+  it("builds concise thread milestone notifications", () => {
+    const text = buildThreadMilestoneNotificationText({
+      label: "Runx issue intake",
+      state: "PR ready for human review",
+      summary: "Campaign analytics fix is ready.",
+      issue: {
+        uri: "https://github.com/nitrosend/nitrosend/issues/123",
+      },
+      pullRequest: {
+        uri: "https://github.com/nitrosend/nitrosend/pull/456",
+      },
+      nextAction: "Human merge required.",
+    });
+
+    expect(text).toContain("Runx issue intake: PR ready for human review");
+    expect(text).toContain("Issue: [Open](https://github.com/nitrosend/nitrosend/issues/123)");
+    expect(text).toContain("PR: [Open](https://github.com/nitrosend/nitrosend/pull/456)");
+    expect(text).toContain("Next: Human merge required.");
+    expect(text.split("\n").length).toBeLessThanOrEqual(5);
+  });
+
+  it("builds pull request reviewer packets with a human merge gate", () => {
+    const body = buildThreadPullRequestReviewerPacketMarkdown({
+      title: "Fix campaign analytics 500",
+      summary: "Runx implemented the bounded endpoint fix from the source thread.",
+      issue: {
+        label: "Issue #123",
+        uri: "https://github.com/nitrosend/nitrosend/issues/123",
+      },
+      targetRepo: "nitrosend/nitrosend",
+      branch: "runx/campaign-analytics-500",
+      base: "main",
+      status: "completed",
+      reviewVerdict: "pass",
+      checks: ["scafld build success", "2 passed / 0 failed"],
+      handoffReference: "Full scafld handoff is retained in engineering_summary_markdown.",
+    });
+
+    expect(body).toContain("# Fix campaign analytics 500");
+    expect(body).toContain("## Review Packet");
+    expect(body).toContain("Target: `nitrosend/nitrosend`");
+    expect(body).toContain("Review: `pass`");
+    expect(body).toContain("## Human Merge Gate");
+    expect(body).toContain("merge manually");
+    expect(body).toContain("engineering_summary_markdown");
   });
 
   it("rejects missing thread locator fields", () => {

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -59,8 +59,15 @@ export {
   type ThreadStorySection,
   type BuildThreadStoryMarkdownOptions,
   type BuildThreadStoryMessageOutboxEntryOptions,
+  type ThreadStatusTriageSummary,
+  type BuildThreadStatusMarkdownOptions,
+  type BuildThreadMilestoneNotificationTextOptions,
+  type BuildThreadPullRequestReviewerPacketMarkdownOptions,
   sanitizeThreadStoryText,
   buildThreadStoryMarkdown,
+  buildThreadStatusMarkdown,
+  buildThreadMilestoneNotificationText,
+  buildThreadPullRequestReviewerPacketMarkdown,
   buildThreadStoryMessageOutboxEntry,
 } from "./thread-story.js";
 

--- a/packages/core/src/knowledge/thread-story.ts
+++ b/packages/core/src/knowledge/thread-story.ts
@@ -45,7 +45,59 @@ export interface BuildThreadStoryMessageOutboxEntryOptions {
   readonly metadata?: Readonly<Record<string, unknown>>;
 }
 
+export interface ThreadStatusTriageSummary {
+  readonly lane?: string;
+  readonly decision?: string;
+  readonly severity?: string;
+  readonly summary?: string;
+  readonly rationale?: string;
+}
+
+export interface BuildThreadStatusMarkdownOptions {
+  readonly title?: string;
+  readonly state: string;
+  readonly summary?: string;
+  readonly source?: ThreadStoryLink;
+  readonly issue?: ThreadStoryLink;
+  readonly pullRequest?: ThreadStoryLink;
+  readonly triage?: ThreadStatusTriageSummary;
+  readonly scope?: readonly string[];
+  readonly validation?: readonly string[];
+  readonly risks?: readonly string[];
+  readonly nextAction?: string;
+  readonly maxChars?: number;
+}
+
+export interface BuildThreadMilestoneNotificationTextOptions {
+  readonly label?: string;
+  readonly state: string;
+  readonly summary?: string;
+  readonly issue?: ThreadStoryLink;
+  readonly pullRequest?: ThreadStoryLink;
+  readonly nextAction?: string;
+  readonly maxChars?: number;
+}
+
+export interface BuildThreadPullRequestReviewerPacketMarkdownOptions {
+  readonly title?: string;
+  readonly summary?: string;
+  readonly source?: ThreadStoryLink;
+  readonly issue?: ThreadStoryLink;
+  readonly pullRequest?: ThreadStoryLink;
+  readonly targetRepo?: string;
+  readonly branch?: string;
+  readonly base?: string;
+  readonly status?: string;
+  readonly reviewVerdict?: string;
+  readonly checks?: readonly string[];
+  readonly risks?: readonly string[];
+  readonly handoffReference?: string;
+  readonly nextAction?: string;
+  readonly maxChars?: number;
+}
+
 const DEFAULT_MAX_SNAPSHOT_CHARS = 900;
+const DEFAULT_MAX_STATUS_CHARS = 420;
 
 const THREAD_STORY_HEADINGS: Readonly<Record<string, string>> = {
   initial_issue: "Initial Issue",
@@ -93,6 +145,117 @@ export function buildThreadStoryMarkdown(options: BuildThreadStoryMarkdownOption
     }
     lines.push(...rendered, "");
   }
+
+  return lines.join("\n").trim();
+}
+
+export function buildThreadStatusMarkdown(options: BuildThreadStatusMarkdownOptions): string {
+  const maxChars = options.maxChars ?? DEFAULT_MAX_STATUS_CHARS;
+  const lines: string[] = ["## Runx Status", ""];
+  const state = sanitizeThreadStoryText(options.state, 80) ?? "unknown";
+  const title = sanitizeThreadStoryText(options.title, 160);
+  const summary = sanitizeThreadStoryText(options.summary, maxChars);
+  const nextAction = sanitizeThreadStoryText(options.nextAction, maxChars);
+
+  lines.push(...compactLines([
+    `State: \`${state}\``,
+    title ? `Title: ${title}` : undefined,
+    renderThreadStoryLinkLine("Source", options.source),
+    renderThreadStoryLinkLine("Issue", options.issue),
+    renderThreadStoryLinkLine("PR", options.pullRequest),
+  ]));
+
+  if (summary) {
+    lines.push("", "## Summary", summary);
+  }
+
+  const triageLines = compactLines([
+    renderCodeLine("Lane", options.triage?.lane, 80),
+    renderCodeLine("Decision", options.triage?.decision, 120),
+    renderCodeLine("Severity", options.triage?.severity, 80),
+    sanitizeThreadStoryText(options.triage?.summary, maxChars),
+    sanitizeThreadStoryText(options.triage?.rationale, maxChars),
+  ]);
+  if (triageLines.length > 0) {
+    lines.push("", "## Triage", ...triageLines);
+  }
+
+  appendBullets(lines, "Scope", options.scope, maxChars);
+  appendBullets(lines, "Validation", options.validation, maxChars);
+  appendBullets(lines, "Risks", options.risks, maxChars);
+
+  if (nextAction) {
+    lines.push("", "## Next Action", nextAction);
+  }
+
+  return lines.join("\n").trim();
+}
+
+export function buildThreadMilestoneNotificationText(
+  options: BuildThreadMilestoneNotificationTextOptions,
+): string {
+  const maxChars = options.maxChars ?? 240;
+  const label = sanitizeThreadStoryText(options.label, 80) ?? "Runx";
+  const state = sanitizeThreadStoryText(options.state, 80) ?? "unknown";
+  const nextAction = sanitizeThreadStoryText(options.nextAction, maxChars);
+  return compactLines([
+    `${label}: ${state}`,
+    sanitizeThreadStoryText(options.summary, maxChars),
+    renderThreadStoryLinkLine("Issue", options.issue),
+    renderThreadStoryLinkLine("PR", options.pullRequest),
+    nextAction ? `Next: ${nextAction}` : undefined,
+  ]).join("\n");
+}
+
+export function buildThreadPullRequestReviewerPacketMarkdown(
+  options: BuildThreadPullRequestReviewerPacketMarkdownOptions,
+): string {
+  const maxChars = options.maxChars ?? DEFAULT_MAX_STATUS_CHARS;
+  const title = sanitizeThreadStoryText(options.title, 160) ?? "Runx Pull Request";
+  const summary = sanitizeThreadStoryText(options.summary, maxChars)
+    ?? "Runx prepared this governed change for human review.";
+  const status = sanitizeThreadStoryText(options.status, 80);
+  const reviewVerdict = sanitizeThreadStoryText(options.reviewVerdict, 80);
+  const targetRepo = sanitizeThreadStoryText(options.targetRepo, 160);
+  const branch = sanitizeThreadStoryText(options.branch, 160);
+  const base = sanitizeThreadStoryText(options.base, 160);
+  const handoffReference = sanitizeThreadStoryText(options.handoffReference, maxChars)
+    ?? "Full scafld handoff evidence is retained in the draft pull request packet.";
+  const nextAction = sanitizeThreadStoryText(options.nextAction, maxChars)
+    ?? "Review the PR and merge manually only when the source thread, implementation, and validation evidence line up.";
+
+  const lines: string[] = [
+    `# ${title}`,
+    "",
+    "## Summary",
+    summary,
+    "",
+    "## Review Packet",
+    ...compactLines([
+      renderThreadStoryLinkLine("Source", options.source),
+      renderThreadStoryLinkLine("Issue", options.issue),
+      renderThreadStoryLinkLine("PR", options.pullRequest),
+      targetRepo ? `Target: \`${targetRepo}\`` : undefined,
+      branch || base ? `Branch: \`${branch ?? "unknown"}\` -> \`${base ?? "unknown"}\`` : undefined,
+      status ? `Status: \`${status}\`` : undefined,
+      reviewVerdict ? `Review: \`${reviewVerdict}\`` : undefined,
+    ]),
+  ];
+
+  appendBullets(lines, "Checks", options.checks, maxChars);
+  appendBullets(lines, "Risks", options.risks, maxChars);
+
+  lines.push(
+    "",
+    "## Human Merge Gate",
+    "Runx has stopped at a reviewable PR. A human reviewer must inspect, approve, and merge manually.",
+    "",
+    "## Evidence",
+    handoffReference,
+    "",
+    "## Next Action",
+    nextAction,
+  );
 
   return lines.join("\n").trim();
 }
@@ -176,6 +339,35 @@ function renderThreadStoryLink(link: ThreadStoryLink | undefined): string | unde
   }
   const label = sanitizeThreadStoryText(link.label, 80) ?? "Open";
   return `[${label}](${uri})`;
+}
+
+function renderThreadStoryLinkLine(label: string, link: ThreadStoryLink | undefined): string | undefined {
+  const rendered = renderThreadStoryLink(link);
+  return rendered ? `${label}: ${rendered}` : undefined;
+}
+
+function renderCodeLine(label: string, value: string | undefined, maxChars: number): string | undefined {
+  const text = sanitizeThreadStoryText(value, maxChars);
+  return text ? `${label}: \`${text}\`` : undefined;
+}
+
+function appendBullets(
+  lines: string[],
+  heading: string,
+  values: readonly string[] | undefined,
+  maxChars: number,
+): void {
+  const items = values
+    ?.map((value) => sanitizeThreadStoryText(value, maxChars))
+    .filter((value): value is string => Boolean(value));
+  if (!items || items.length === 0) {
+    return;
+  }
+  lines.push("", `## ${heading}`, ...items.map((item) => `- ${item}`));
+}
+
+function compactLines(values: readonly (string | undefined)[]): string[] {
+  return values.filter((value): value is string => Boolean(value && value.trim().length > 0));
 }
 
 function asRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -22,35 +22,33 @@ provider push boundary.
 
 ## Source Thread Story
 
-The source thread is the work journal for issue-to-PR, not just a launch point.
-Consumers that dispatch this lane should publish message outbox entries back to
-the source thread at the gates that matter to a human reviewer:
+The source thread is the work journal for issue-to-PR, but reviewers should see
+the story as projections, not as a transcript. Keep the durable run record in
+runx receipts and scafld state, then publish only the projection that fits the
+surface:
 
-- Initial issue: preserve the original request, source locator, reporter signal,
-  and any provider links that explain why runx is evaluating the work.
-- Triage results: state whether a PR is warranted, the selected lane, the
-  risk/size read, relevant constraints, and the evidence that informed the
-  decision.
-- PR creation: link the provider PR, summarize the generated branch/base, state
-  what changed, and point reviewers at the scafld handoff/review evidence.
-- Final human merge gate: make clear that runx has stopped at reviewable PR
-  state and that a human must inspect and merge. Include the current validation,
-  review verdict, remaining risks, and rollback notes.
-- Completion update: after a human merges or closes the PR, publish the final
-  status and link the merged/closed PR.
+- Issue status ledger: one managed status comment updated in place with the
+  current state, source/issue/PR links, triage result, validation summary, risks,
+  and next human action.
+- PR reviewer packet: the PR body is the handoff surface for code review. It
+  should summarize the source, target repo/branch/base, checks, review verdict,
+  risks, retained handoff evidence, and final human merge gate.
+- Notification stream: Slack, chat, email, or ticket updates should be concise
+  milestone notifications only: triaging, PR ready for human review,
+  merged/closed, or human-action-required blockers/errors.
 
-These comments are ordinary `message` outbox entries with
-`metadata.channel = "thread_story"` and structured `metadata.control` containing
-the workflow, lane, task id, gate id, and source locator. The core knowledge
-helper `buildThreadStoryMessageOutboxEntry` builds this shape without binding it
-to GitHub, Slack, Sentry, or any product-specific wrapper.
+Core knowledge helpers provide the generic markdown/text shapes:
+`buildThreadStatusMarkdown`, `buildThreadMilestoneNotificationText`,
+`buildThreadPullRequestReviewerPacketMarkdown`, and
+`buildThreadStoryMessageOutboxEntry`. Product wrappers decide where to publish
+those projections and which provider-specific managed key to use.
 
-Do not put machine control state in visible prose. User-controlled issue,
-Sentry, Slack, or review snippets must be bounded and sanitized before they are
-included in story markdown. Provider mutation still goes through
-`thread.push_outbox`, which adds the provider-specific managed control envelope.
-The envelope is a correlation receipt, not authorization; human merge
-permissions and provider identity remain the security boundary.
+Do not put machine control state, receipt IDs, full issue snapshots, or exact PR
+body dumps in visible prose. User-controlled issue, Sentry, Slack, or review
+snippets must be bounded and sanitized before inclusion. Provider mutation still
+goes through `thread.push_outbox`, which adds the provider-specific managed
+control envelope. The envelope is a correlation receipt, not authorization;
+human merge permissions and provider identity remain the security boundary.
 
 ## Lifecycle
 

--- a/tests/issue-to-pr-graph.test.ts
+++ b/tests/issue-to-pr-graph.test.ts
@@ -162,9 +162,10 @@ describe("issue-to-PR composite skill", () => {
           },
           pull_request: {
             title: "Fixture thread-driven change",
-            body_markdown: expect.stringContaining("# Handoff: Fixture thread-driven change"),
+            body_markdown: expect.stringContaining("## Human Merge Gate"),
             is_draft: true,
           },
+          engineering_summary_markdown: expect.stringContaining("# Handoff: Fixture thread-driven change"),
           governance: {
             status: "completed",
             review_verdict: "pass",

--- a/tests/outbox-build-pull-request-tool.test.ts
+++ b/tests/outbox-build-pull-request-tool.test.ts
@@ -68,9 +68,10 @@ describe("outbox.build_pull_request tool", () => {
       },
       pull_request: {
         title: "Fix fixture behavior",
-        body_markdown: "# Handoff: Fix fixture behavior\n\nStatus: completed\nNext: none\n",
+        body_markdown: expect.stringContaining("## Human Merge Gate"),
         is_draft: true,
       },
+      engineering_summary_markdown: "# Handoff: Fix fixture behavior\n\nStatus: completed\nNext: none\n",
       governance: {
         review_verdict: "pass_with_issues",
         blocking_count: 0,
@@ -83,6 +84,12 @@ describe("outbox.build_pull_request tool", () => {
         thread_locator: "github://example/repo/issues/123",
       },
     });
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Review Packet");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Target: `example/repo`");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Branch: `fixture-task` -> `main`");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Review: `pass_with_issues`");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Merge manually");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toBe(result.draft_pull_request.engineering_summary_markdown);
   });
 
   it("refreshes an existing pull_request outbox entry from thread", () => {
@@ -152,6 +159,50 @@ describe("outbox.build_pull_request tool", () => {
         thread_locator: "github://example/repo/issues/123",
       },
     });
+  });
+
+  it("counts native scafld review findings by blocks_completion", () => {
+    const result = runTool({
+      task_id: "fixture-task",
+      thread_title: "Fix fixture behavior",
+      thread_locator: "github://example/repo/issues/123",
+      target_repo: "example/repo",
+      handoff_markdown: "# Handoff: Fix fixture behavior\n\n## Summary\nFix fixture behavior.\n",
+      build_result: {
+        passed: 2,
+        failed: 0,
+      },
+      review_result: {
+        verdict: "pass_with_issues",
+        findings: [
+          {
+            id: "blocking",
+            severity: "high",
+            blocks_completion: true,
+          },
+          {
+            id: "non-blocking",
+            severity: "medium",
+            blocks_completion: false,
+          },
+        ],
+      },
+      completion_result: {
+        status: "completed",
+        title: "Fix fixture behavior",
+      },
+      current_branch: {
+        branch: "fixture-task",
+      },
+      base: "main",
+    });
+
+    expect(result.draft_pull_request.governance).toMatchObject({
+      blocking_count: 1,
+      non_blocking_count: 1,
+    });
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("1 blocking review finding");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("1 non-blocking review finding");
   });
 });
 

--- a/tools/outbox/build_pull_request/manifest.json
+++ b/tools/outbox/build_pull_request/manifest.json
@@ -107,7 +107,7 @@
       "./run.mjs"
     ]
   },
-  "source_hash": "sha256:243c56dc8121910b2e76198234db2857f1970059ad054f896473f56b74115ed2",
+  "source_hash": "sha256:80643fbe992095b4415d551f03db2a3d41f239c1949c3a061fa04b81d4fadb93",
   "schema_hash": "sha256:95627cd42b0d2a02ff911eed72031ed40f1aece79043ac81518c3d41ddda2085",
   "toolkit_version": "0.1.3"
 }

--- a/tools/outbox/build_pull_request/src/index.ts
+++ b/tools/outbox/build_pull_request/src/index.ts
@@ -6,6 +6,7 @@ import {
   recordInput,
   stringInput,
 } from "@runxhq/authoring";
+import { buildThreadPullRequestReviewerPacketMarkdown } from "@runxhq/core/knowledge";
 
 export default defineTool({
   name: "outbox.build_pull_request",
@@ -97,6 +98,29 @@ function runBuildPullRequest({ inputs }) {
     inputs.branch,
   );
   const base = firstNonEmptyString(inputs.base);
+  const handoffText = firstNonEmptyText(handoffMarkdown);
+  const reviewerPacketMarkdown = buildThreadPullRequestReviewerPacketMarkdown({
+    title,
+    summary: summarizeHandoff(handoffText, title),
+    source: threadLocator
+      ? {
+          label: "Source thread",
+          uri: firstNonEmptyString(threadContext.canonical_uri, threadLocator),
+        }
+      : undefined,
+    targetRepo,
+    branch,
+    base,
+    status: firstNonEmptyString(
+      completionResult.status,
+      statusSnapshot?.status,
+    ),
+    reviewVerdict,
+    checks: buildReviewPacketChecks(check),
+    risks: buildReviewPacketRisks(reviewResult),
+    handoffReference: "Full native scafld handoff is retained in `engineering_summary_markdown` on this draft pull-request packet.",
+    nextAction: "Review the implementation, validation, and source thread. Merge manually only when the human gate is satisfied.",
+  });
 
   const draftPullRequest = prune({
     schema_version: "runx.pull-request-draft.v1",
@@ -121,12 +145,11 @@ function runBuildPullRequest({ inputs }) {
     }),
     pull_request: {
       title,
-      body_markdown:
-        firstNonEmptyText(handoffMarkdown) ?? `# ${title}\n`,
+      body_markdown: reviewerPacketMarkdown,
       is_draft: true,
     },
     engineering_summary_markdown:
-      firstNonEmptyText(handoffMarkdown) ?? "",
+      handoffText ?? "",
     checks: Object.keys(check).length > 0 ? check : undefined,
     governance: prune({
       status: firstNonEmptyString(
@@ -177,6 +200,66 @@ function runBuildPullRequest({ inputs }) {
   };
 }
 
+function summarizeHandoff(handoffMarkdown, fallbackTitle) {
+  const summarySection = extractMarkdownSection(handoffMarkdown, "Summary");
+  if (summarySection) {
+    return summarySection;
+  }
+  const firstParagraph = firstNonEmptyText(
+    ...String(handoffMarkdown ?? "")
+      .split(/\n{2,}/)
+      .map((paragraph) => paragraph
+        .split(/\r?\n/)
+        .filter((line) => {
+          const trimmed = line.trim();
+          return trimmed.length > 0
+            && !trimmed.startsWith("#")
+            && !/^status:/i.test(trimmed)
+            && !/^next:/i.test(trimmed);
+        })
+        .join("\n")
+        .trim()),
+  );
+  return firstParagraph ?? `Runx prepared a governed change for ${fallbackTitle}.`;
+}
+
+function extractMarkdownSection(markdown, heading) {
+  const text = firstNonEmptyText(markdown);
+  if (!text) {
+    return undefined;
+  }
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`^#{2,6}\\s+${escapedHeading}\\s*\\n([\\s\\S]*?)(?=\\n#{1,6}\\s+|$)`, "im");
+  const match = text.match(pattern);
+  return firstNonEmptyText(match?.[1]);
+}
+
+function buildReviewPacketChecks(check) {
+  const lines = [];
+  if (firstNonEmptyString(check.status)) {
+    lines.push(`scafld build ${check.status}`);
+  }
+  const passed = numberOrUndefined(check.passed);
+  const failed = numberOrUndefined(check.failed);
+  if (passed !== undefined || failed !== undefined) {
+    lines.push(`${passed ?? 0} passed / ${failed ?? 0} failed`);
+  }
+  return lines;
+}
+
+function buildReviewPacketRisks(reviewResult) {
+  const blocking = reviewFindingCount(reviewResult, "blocking");
+  const nonBlocking = reviewFindingCount(reviewResult, "non_blocking");
+  const lines = [];
+  if (blocking !== undefined) {
+    lines.push(`${blocking} blocking review finding${blocking === 1 ? "" : "s"}`);
+  }
+  if (nonBlocking !== undefined) {
+    lines.push(`${nonBlocking} non-blocking review finding${nonBlocking === 1 ? "" : "s"}`);
+  }
+  return lines;
+}
+
 function optionalRecord(value) {
   return isRecord(value) ? value : undefined;
 }
@@ -213,6 +296,16 @@ function reviewFindingCount(reviewResult, severity) {
   if (!Array.isArray(reviewResult.findings)) {
     return undefined;
   }
+  if (severity === "blocking") {
+    return reviewResult.findings
+      .filter((finding) => isRecord(finding) && (finding.blocks_completion === true || finding.severity === "blocking"))
+      .length;
+  }
+  if (severity === "non_blocking") {
+    return reviewResult.findings
+      .filter((finding) => isRecord(finding) && (finding.blocks_completion === false || finding.severity === "non_blocking"))
+      .length;
+  }
   return reviewResult.findings
     .filter((finding) => isRecord(finding) && finding.severity === severity)
     .length;
@@ -236,16 +329,6 @@ function numberOrUndefined(value) {
   return typeof value === "number" && Number.isFinite(value)
     ? value
     : undefined;
-}
-
-function stringArray(value) {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const items = value.filter(
-    (entry) => typeof entry === "string" && entry.trim().length > 0,
-  );
-  return items.length > 0 ? items : undefined;
 }
 
 function normalizePullRequestOutbox(value) {


### PR DESCRIPTION
## Summary
- Adds richer runx reviewer-packet sections for source context, scope, checks, validation, review context, risks, rollback, and the human merge gate.
- Teaches `outbox.build_pull_request` to project bounded visible context from the scafld handoff while keeping the full native handoff in `engineering_summary_markdown`.
- Filters receipt ids, scafld ledger event metadata, entry ids, and fenced logs out of visible PR prose.
- Documents the generic issue-to-pr story shape in the upstream runx skill.

## Validation
- `pnpm verify:fast` passed: boundary check, typecheck, doctor, and 43 fast test files / 329 tests.
- `git diff --check` passed.
- `scafld review richer-thread-context --provider codex --max-findings 5` passed after verifying the ledger/log leakage blocker was fixed.

## Human Gate
Merge manually after reviewing the rendered reviewer packet shape and downstream Nitrosend wrapper pin.