### PR TITLE
feat(core): enrich thread reviewer context

### DIFF
--- a/.scafld/specs/archive/2026-05/richer-thread-context.md
+++ b/.scafld/specs/archive/2026-05/richer-thread-context.md
@@ -1,0 +1,157 @@
+---
+spec_version: '2.0'
+task_id: richer-thread-context
+created: '2026-05-13T14:05:38Z'
+updated: '2026-05-13T14:52:37Z'
+status: completed
+harden_status: not_run
+size: small
+risk_level: low
+---
+
+# Richer thread context projections
+
+## Current State
+
+Status: completed
+Current phase: final
+Next: done
+Reason: task completed
+Blockers: none
+Allowed follow-up command: `none`
+Latest runner update: 2026-05-13T14:52:37Z
+Review gate: pass
+
+## Summary
+
+Keep the clean three-projection model, but make the PR reviewer packet more comprehensive. The packet should show meaty source/context/reasoning data from the scafld handoff without returning to raw full-handoff dumps, receipt IDs, logs, or duplicated comments.
+
+## Objectives
+
+- Add bounded contextual sections to the generic PR reviewer packet helper.
+- Extract useful sections from `scafld handoff` into the visible PR body: context, objectives/scope, validation, review findings, and rollback when available.
+- Preserve full handoff in `engineering_summary_markdown`.
+- Keep visible PR body concise enough to scan and free of machine receipts/log dumps.
+
+## Scope
+
+- `packages/core/src/knowledge/thread-story.ts`
+- `packages/core/src/knowledge/index.test.ts`
+- `tools/outbox/build_pull_request/src/index.ts`
+- `tests/outbox-build-pull-request-tool.test.ts`
+- `skills/issue-to-pr/SKILL.md`
+- generated manifest/lock updates if verify requires them
+
+## Dependencies
+
+- Existing runx core projection helpers.
+- Existing scafld handoff markdown input.
+
+## Assumptions
+
+- PR body should include bounded handoff-derived context, not the entire raw handoff.
+- Receipt identifiers and full logs remain evidence, not visible reviewer prose.
+
+## Touchpoints
+
+- `buildThreadPullRequestReviewerPacketMarkdown`
+- `outbox.build_pull_request`
+- issue-to-pr docs/tests
+
+## Risks
+
+- Over-enriching the packet can recreate noise. Mitigation: cap extracted sections and use named sections only.
+- Under-enriching the packet leaves reviewers without state. Mitigation: include source, reasoning, scope, validation, review/risk, rollback, and next action.
+
+## Acceptance
+
+Profile: standard
+
+Validation:
+- [x] `v1` command - runx focused tests.
+  - Command: `pnpm test:fast -- tests/outbox-build-pull-request-tool.test.ts packages/core/src/knowledge/index.test.ts`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-15
+- [x] `v2` command - runx verify.
+  - Command: `pnpm verify:fast`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-16
+- [x] `v3` command - diff hygiene.
+  - Command: `git diff --check`
+  - Expected kind: `exit_code_zero`
+  - Status: pass
+  - Evidence: exit code was 0
+  - Source event: entry-17
+
+## Phase 1: Richer Reviewer Packet
+
+Status: completed
+Dependencies: none
+
+Objective: Add bounded but useful context to the visible PR reviewer packet.
+
+Changes:
+- Extend the core reviewer packet helper with optional context/scope/validation/review/rollback sections.
+- Have `outbox.build_pull_request` extract those sections from the handoff and review/build payloads.
+- Update tests and docs to require a comprehensive but non-noisy reviewer packet.
+
+Acceptance:
+- none
+
+## Rollback
+
+Revert this task's helper/tool/test/doc changes. The prior clean but thinner reviewer packet remains.
+
+## Review
+
+Status: completed
+Verdict: pass
+Mode: verify
+Provider: codex
+Output: codex.output_file
+Summary: Review passed. The known validation-section leakage blocker is fixed: fenced logs and machine ledger/receipt identifiers are filtered before handoff-derived lines are rendered into the visible reviewer packet. The richer PR packet surfaces the requested context/scope/validation/review/rollback sections while preserving the full handoff in engineering_summary_markdown, and caller/test coverage matches the new projection contract. No completion-blocking findings remain.
+
+Attack log:
+- `tools/outbox/build_pull_request/src/index.ts:320`: Known blocker verification: ledger/log leakage -> clean (Verified the previous blocker is repaired: sectionToVisibleLines now skips fenced code block contents, and isVisibleHandoffLine filters Source event, Last attempt, Checked at, entry-* ids, receipt ids, rx_* and gx_* markers before values reach the visible PR body.)
+- `tools/outbox/build_pull_request/src/index.ts:255`: Validation extraction path -> clean (Traced buildReviewPacketValidation through buildHandoffSectionLines and extractMarkdownSection for Validation and Acceptance sections; extracted lines are bounded and then sanitized by the core reviewer packet helper.)
+- `tools/outbox/build_pull_request/src/index.ts:395`: Review-result accounting -> clean (Verified prior native scafld review finding counting remains fixed: reviewFindingCount counts blocks_completion true/false as blocking/non-blocking when explicit counts are absent.)
+- `packages/core/src/knowledge/thread-story.ts:215`: Core packet rendering -> clean (Reviewed buildThreadPullRequestReviewerPacketMarkdown and appendBullets; new source context, scope, validation, review context, risks, and rollback sections are optional, bounded through sanitizeThreadStoryText, and preserve the human merge gate/evidence sections.)
+- `@runxhq/core/knowledge callers and tests/issue-to-pr-graph.test.ts`: Regression and caller surface -> clean (Searched direct callers/importers of buildThreadPullRequestReviewerPacketMarkdown and outbox.build_pull_request; no incompatible helper call sites were introduced, and issue-to-pr graph coverage already expects the compact reviewer packet plus engineering_summary_markdown retention.)
+- `tests/outbox-build-pull-request-tool.test.ts:9`: Test coverage adequacy -> clean (Reviewed focused tool/core tests. The outbox tool test now covers source context, scope, validation, review context, rollback, full handoff retention, and negative assertions for receipt ids, source-event metadata, checked timestamps, entry ids, and fenced log contents.)
+- `workspace status`: Scope and ambient drift -> clean (Compared git status/diff stat against declared task scope. Task changes are in the scoped files; manifest/lock drift matches the context packet's ambient/generated classification and was not treated as a finding by itself.)
+- `validation commands`: Acceptance evidence policy -> skipped (Did not rerun tests, builds, or mutation commands per provider instruction; treated recorded pnpm test:fast, pnpm verify:fast, and git diff --check evidence as already executed.)
+
+Findings:
+- none
+
+## Self Eval
+
+- Preserves the clean surface model while addressing missing reviewer context.
+- Adds no provider-specific posting behavior.
+
+## Deviations
+
+- none
+
+## Metadata
+
+- created_by: scafld
+- repo: runxhq/runx
+- branch: codex/clean-thread-story-projections
+
+## Origin
+
+Created by: scafld
+Source: user requested comprehensive but non-noisy issue/PR context.
+
+## Harden Rounds
+
+- none
+
+## Planning Log
+
+- 2026-05-14T00:10:00Z: Drafted after reviewing current PR packet helper and outbox packaging.

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -46,8 +46,8 @@
   },
   {
     "skill_id": "runx/issue-to-pr",
-    "version": "sha-502153ef922f",
-    "digest": "40ab87a24b6546588b7908f5ff5c1cb34b98bfe6fec70f7748dcce7504091e3c"
+    "version": "sha-f76f6411abb1",
+    "digest": "a46b0a69f410ce977d7b7e97f6121ea6206bcc38aeb97082021c0041ba723d43"
   },
   {
     "skill_id": "runx/issue-triage",

--- a/packages/core/src/knowledge/index.test.ts
+++ b/packages/core/src/knowledge/index.test.ts
@@ -454,17 +454,34 @@ describe("thread contract", () => {
         label: "Issue #123",
         uri: "https://github.com/nitrosend/nitrosend/issues/123",
       },
+      sourceContext: [
+        "Source issue reports campaign analytics 500s for account exports.",
+        "The issue includes a Sentry link and Slack support thread.",
+      ],
       targetRepo: "nitrosend/nitrosend",
       branch: "runx/campaign-analytics-500",
       base: "main",
       status: "completed",
       reviewVerdict: "pass",
+      scope: ["api/app/controllers/campaigns_controller.rb"],
       checks: ["scafld build success", "2 passed / 0 failed"],
+      validation: ["request spec covers the failing endpoint"],
+      reviewContext: ["AI reasoning: one controller guard fixes the reported failure."],
+      rollback: "Revert the controller guard.",
       handoffReference: "Full scafld handoff is retained in engineering_summary_markdown.",
     });
 
     expect(body).toContain("# Fix campaign analytics 500");
     expect(body).toContain("## Review Packet");
+    expect(body).toContain("## Source Context");
+    expect(body).toContain("Sentry link and Slack support thread");
+    expect(body).toContain("## Scope");
+    expect(body).toContain("api/app/controllers/campaigns_controller.rb");
+    expect(body).toContain("## Validation");
+    expect(body).toContain("request spec covers the failing endpoint");
+    expect(body).toContain("## Review Context");
+    expect(body).toContain("one controller guard fixes the reported failure");
+    expect(body).toContain("## Rollback");
     expect(body).toContain("Target: `nitrosend/nitrosend`");
     expect(body).toContain("Review: `pass`");
     expect(body).toContain("## Human Merge Gate");

--- a/packages/core/src/knowledge/thread-story.ts
+++ b/packages/core/src/knowledge/thread-story.ts
@@ -81,6 +81,7 @@ export interface BuildThreadMilestoneNotificationTextOptions {
 export interface BuildThreadPullRequestReviewerPacketMarkdownOptions {
   readonly title?: string;
   readonly summary?: string;
+  readonly sourceContext?: readonly string[];
   readonly source?: ThreadStoryLink;
   readonly issue?: ThreadStoryLink;
   readonly pullRequest?: ThreadStoryLink;
@@ -89,8 +90,12 @@ export interface BuildThreadPullRequestReviewerPacketMarkdownOptions {
   readonly base?: string;
   readonly status?: string;
   readonly reviewVerdict?: string;
+  readonly scope?: readonly string[];
   readonly checks?: readonly string[];
+  readonly validation?: readonly string[];
+  readonly reviewContext?: readonly string[];
   readonly risks?: readonly string[];
+  readonly rollback?: string;
   readonly handoffReference?: string;
   readonly nextAction?: string;
   readonly maxChars?: number;
@@ -242,8 +247,17 @@ export function buildThreadPullRequestReviewerPacketMarkdown(
     ]),
   ];
 
+  appendBullets(lines, "Source Context", options.sourceContext, maxChars);
+  appendBullets(lines, "Scope", options.scope, maxChars);
   appendBullets(lines, "Checks", options.checks, maxChars);
+  appendBullets(lines, "Validation", options.validation, maxChars);
+  appendBullets(lines, "Review Context", options.reviewContext, maxChars);
   appendBullets(lines, "Risks", options.risks, maxChars);
+
+  const rollback = sanitizeThreadStoryText(options.rollback, maxChars);
+  if (rollback) {
+    lines.push("", "## Rollback", rollback);
+  }
 
   lines.push(
     "",

--- a/skills/issue-to-pr/SKILL.md
+++ b/skills/issue-to-pr/SKILL.md
@@ -31,8 +31,9 @@ surface:
   current state, source/issue/PR links, triage result, validation summary, risks,
   and next human action.
 - PR reviewer packet: the PR body is the handoff surface for code review. It
-  should summarize the source, target repo/branch/base, checks, review verdict,
-  risks, retained handoff evidence, and final human merge gate.
+  should be comprehensive but bounded: source context, AI/scafld reasoning,
+  target repo/branch/base, scope, checks, validation, review verdict/findings,
+  risks, rollback, retained handoff evidence, and final human merge gate.
 - Notification stream: Slack, chat, email, or ticket updates should be concise
   milestone notifications only: triaging, PR ready for human review,
   merged/closed, or human-action-required blockers/errors.
@@ -43,12 +44,14 @@ Core knowledge helpers provide the generic markdown/text shapes:
 `buildThreadStoryMessageOutboxEntry`. Product wrappers decide where to publish
 those projections and which provider-specific managed key to use.
 
-Do not put machine control state, receipt IDs, full issue snapshots, or exact PR
-body dumps in visible prose. User-controlled issue, Sentry, Slack, or review
-snippets must be bounded and sanitized before inclusion. Provider mutation still
-goes through `thread.push_outbox`, which adds the provider-specific managed
-control envelope. The envelope is a correlation receipt, not authorization;
-human merge permissions and provider identity remain the security boundary.
+Do not put machine control state, receipt IDs, raw logs, or exact PR body dumps
+in visible prose. Do include the meaty reasoning a reviewer needs, but pull it
+into named sections and cap extracted snippets. User-controlled issue, Sentry,
+Slack, or review snippets must be bounded and sanitized before inclusion.
+Provider mutation still goes through `thread.push_outbox`, which adds the
+provider-specific managed control envelope. The envelope is a correlation
+receipt, not authorization; human merge permissions and provider identity remain
+the security boundary.
 
 ## Lifecycle
 

--- a/tests/outbox-build-pull-request-tool.test.ts
+++ b/tests/outbox-build-pull-request-tool.test.ts
@@ -12,7 +12,42 @@ describe("outbox.build_pull_request tool", () => {
       thread_title: "Fix fixture behavior",
       thread_locator: "github://example/repo/issues/123",
       target_repo: "example/repo",
-      handoff_markdown: "# Handoff: Fix fixture behavior\n\nStatus: completed\nNext: none\n",
+      handoff_markdown: [
+        "# Handoff: Fix fixture behavior",
+        "",
+        "Status: completed",
+        "Next: none",
+        "",
+        "## Summary",
+        "Fixes the fixture behavior reported in the source issue.",
+        "",
+        "## Context",
+        "The source issue reports a bounded fixture regression in the public workflow.",
+        "receipt_id: rx_hidden",
+        "",
+        "## Scope",
+        "- Update the fixture behavior implementation.",
+        "- Preserve the existing public contract.",
+        "",
+        "## Validation",
+        "- Targeted test passed.",
+        "",
+        "## Acceptance",
+        "- Source event: entry-8",
+        "- Last attempt: entry-9",
+        "- Checked at: 2026-05-14T00:00:00Z",
+        "- Workflow acceptance passed.",
+        "```",
+        "private log output should not appear",
+        "```",
+        "",
+        "## Review",
+        "Review found one non-blocking follow-up.",
+        "",
+        "## Rollback",
+        "Revert the fixture behavior change.",
+        "",
+      ].join("\n"),
       build_result: {
         status: "review",
         passed: 2,
@@ -71,7 +106,7 @@ describe("outbox.build_pull_request tool", () => {
         body_markdown: expect.stringContaining("## Human Merge Gate"),
         is_draft: true,
       },
-      engineering_summary_markdown: "# Handoff: Fix fixture behavior\n\nStatus: completed\nNext: none\n",
+      engineering_summary_markdown: expect.stringContaining("# Handoff: Fix fixture behavior"),
       governance: {
         review_verdict: "pass_with_issues",
         blocking_count: 0,
@@ -85,10 +120,26 @@ describe("outbox.build_pull_request tool", () => {
       },
     });
     expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Review Packet");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Source Context");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("bounded fixture regression");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Scope");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Preserve the existing public contract");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Validation");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Targeted test passed");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Workflow acceptance passed");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Review Context");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("Review found one non-blocking follow-up");
+    expect(result.draft_pull_request.pull_request.body_markdown).toContain("## Rollback");
     expect(result.draft_pull_request.pull_request.body_markdown).toContain("Target: `example/repo`");
     expect(result.draft_pull_request.pull_request.body_markdown).toContain("Branch: `fixture-task` -> `main`");
     expect(result.draft_pull_request.pull_request.body_markdown).toContain("Review: `pass_with_issues`");
     expect(result.draft_pull_request.pull_request.body_markdown).toContain("Merge manually");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toContain("rx_hidden");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toContain("Source event");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toContain("Last attempt");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toContain("Checked at");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toContain("entry-9");
+    expect(result.draft_pull_request.pull_request.body_markdown).not.toContain("private log output");
     expect(result.draft_pull_request.pull_request.body_markdown).not.toBe(result.draft_pull_request.engineering_summary_markdown);
   });
 

--- a/tools/outbox/build_pull_request/manifest.json
+++ b/tools/outbox/build_pull_request/manifest.json
@@ -107,7 +107,7 @@
       "./run.mjs"
     ]
   },
-  "source_hash": "sha256:80643fbe992095b4415d551f03db2a3d41f239c1949c3a061fa04b81d4fadb93",
+  "source_hash": "sha256:c801ea419e111db9b8e1186db335d89f18c1019ad98f75b6669840c8395e31f3",
   "schema_hash": "sha256:95627cd42b0d2a02ff911eed72031ed40f1aece79043ac81518c3d41ddda2085",
   "toolkit_version": "0.1.3"
 }

--- a/tools/outbox/build_pull_request/src/index.ts
+++ b/tools/outbox/build_pull_request/src/index.ts
@@ -102,6 +102,7 @@ function runBuildPullRequest({ inputs }) {
   const reviewerPacketMarkdown = buildThreadPullRequestReviewerPacketMarkdown({
     title,
     summary: summarizeHandoff(handoffText, title),
+    sourceContext: buildHandoffSectionLines(handoffText, ["Context", "Current State", "Origin"], 6),
     source: threadLocator
       ? {
           label: "Source thread",
@@ -116,8 +117,12 @@ function runBuildPullRequest({ inputs }) {
       statusSnapshot?.status,
     ),
     reviewVerdict,
+    scope: buildHandoffSectionLines(handoffText, ["Objectives", "Scope", "Touchpoints"], 8),
     checks: buildReviewPacketChecks(check),
+    validation: buildReviewPacketValidation(handoffText, check),
+    reviewContext: buildReviewPacketReviewContext(reviewResult, handoffText),
     risks: buildReviewPacketRisks(reviewResult),
+    rollback: extractMarkdownSection(handoffText, "Rollback"),
     handoffReference: "Full native scafld handoff is retained in `engineering_summary_markdown` on this draft pull-request packet.",
     nextAction: "Review the implementation, validation, and source thread. Merge manually only when the human gate is satisfied.",
   });
@@ -247,6 +252,23 @@ function buildReviewPacketChecks(check) {
   return lines;
 }
 
+function buildReviewPacketValidation(handoffMarkdown, check) {
+  const lines = [
+    firstNonEmptyString(check.summary),
+    ...buildHandoffSectionLines(handoffMarkdown, ["Validation", "Acceptance"], 8),
+  ];
+  return uniqueStrings(lines);
+}
+
+function buildReviewPacketReviewContext(reviewResult, handoffMarkdown) {
+  const lines = [
+    firstNonEmptyString(reviewResult.summary),
+    ...buildHandoffSectionLines(handoffMarkdown, ["Review", "Self Eval", "Deviations"], 8),
+    ...reviewFindingSummaries(reviewResult, 6),
+  ];
+  return uniqueStrings(lines);
+}
+
 function buildReviewPacketRisks(reviewResult) {
   const blocking = reviewFindingCount(reviewResult, "blocking");
   const nonBlocking = reviewFindingCount(reviewResult, "non_blocking");
@@ -256,6 +278,88 @@ function buildReviewPacketRisks(reviewResult) {
   }
   if (nonBlocking !== undefined) {
     lines.push(`${nonBlocking} non-blocking review finding${nonBlocking === 1 ? "" : "s"}`);
+  }
+  return lines;
+}
+
+function reviewFindingSummaries(reviewResult, maxFindings) {
+  if (!Array.isArray(reviewResult.findings)) {
+    return [];
+  }
+  return reviewResult.findings
+    .filter(isRecord)
+    .slice(0, maxFindings)
+    .map((finding) => {
+      const summary = firstNonEmptyString(finding.summary, finding.title, finding.id);
+      if (!summary) {
+        return undefined;
+      }
+      const status = finding.blocks_completion === true ? "blocking" : "non-blocking";
+      return `${status}: ${summary}`;
+    })
+    .filter((line) => Boolean(line));
+}
+
+function buildHandoffSectionLines(markdown, headings, maxLines) {
+  const lines = [];
+  for (const heading of headings) {
+    const section = extractMarkdownSection(markdown, heading);
+    if (!section) {
+      continue;
+    }
+    for (const line of sectionToVisibleLines(section)) {
+      lines.push(line);
+      if (lines.length >= maxLines) {
+        return lines;
+      }
+    }
+  }
+  return lines;
+}
+
+function sectionToVisibleLines(section) {
+  const lines = [];
+  let inFence = false;
+  for (const rawLine of String(section).split(/\r?\n/)) {
+    const rawTrimmed = rawLine.trim();
+    if (/^(```|~~~)/.test(rawTrimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      continue;
+    }
+    const line = rawLine
+      .replace(/^[-*]\s+/, "")
+      .replace(/^\d+\.\s+/, "")
+      .replace(/^>\s?/, "")
+      .trim();
+    if (isVisibleHandoffLine(line)) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+function isVisibleHandoffLine(line) {
+  return line.length > 0
+    && !/^(source event|session event|ledger event|last attempt|checked at|run id|run_id)\s*:/i.test(line)
+    && !/\bentry-\d+\b/i.test(line)
+    && !/\breceipt(?:_id)?\b\s*[:=]/i.test(line)
+    && !/\brx_[a-z0-9_]+/i.test(line)
+    && !/\bgx_[a-z0-9_]+/i.test(line);
+}
+
+function uniqueStrings(values) {
+  const seen = new Set();
+  const lines = [];
+  for (const value of values) {
+    const text = firstNonEmptyText(value);
+    if (!text || seen.has(text)) {
+      continue;
+    }
+    seen.add(text);
+    lines.push(text);
   }
   return lines;
 }


### PR DESCRIPTION
## Summary
- Adds richer runx reviewer-packet sections for source context, scope, checks, validation, review context, risks, rollback, and the human merge gate.
- Teaches `outbox.build_pull_request` to project bounded visible context from the scafld handoff while keeping the full native handoff in `engineering_summary_markdown`.
- Filters receipt ids, scafld ledger event metadata, entry ids, and fenced logs out of visible PR prose.
- Documents the generic issue-to-pr story shape in the upstream runx skill.

## Downstream
- Nitrosend follow-up: https://github.com/nitrosend/nitrosend/pull/156 pins this runx commit.

## Validation
- `pnpm verify:fast` passed: boundary check, typecheck, doctor, and 43 fast test files / 329 tests.
- `git diff --check` passed.
- `scafld review richer-thread-context --provider codex --max-findings 5` passed after verifying the ledger/log leakage blocker was fixed.

## Human Gate
Merge manually after reviewing the rendered reviewer packet shape and downstream Nitrosend wrapper pin.