### PR TITLE
feat: add governed Open-Meteo weather skill

### DIFF
--- a/skills/open-meteo-weather-forecast/SKILL.md
+++ b/skills/open-meteo-weather-forecast/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: open-meteo-weather-forecast
+description: Resolve a place and fetch a global forecast through governed, keyless Open-Meteo HTTP calls.
+runx:
+  category: weather
+---
+
+# Open-Meteo Weather Forecast
+
+Fetch global place and forecast evidence through runx's governed HTTP front.
+The skill never performs an ad-hoc fetch. Each stage is a bounded, read-only
+HTTP runner whose endpoint, inputs, status, authority scope, and output packet
+are recorded in the sealed receipt. Open-Meteo requires no API key.
+
+## Procedure
+
+1. Run `locate` with a city or place name.
+2. Select the intended result and preserve its latitude, longitude, timezone,
+   and country as a typed provider-evidence packet.
+3. Run the default `forecast` runner with the selected coordinates.
+4. Require a 2xx response and preserve the provider URL, timezone, generation
+   time, current conditions, daily forecast, and receipt references.
+5. Treat the result as context only. Any notification, scheduling change, or
+   operational mutation requires a separate skill and authority gate.
+
+## Inputs
+
+- `name` (`locate`, required): city or place to resolve.
+- `count` (`locate`, optional): maximum candidate results, default `5`.
+- `latitude` (`forecast`, required): decimal latitude.
+- `longitude` (`forecast`, required): decimal longitude.
+- `forecast_days` (`forecast`, optional): days requested, default `3`.
+
+## Output packets
+
+The two graph steps produce typed sealed packets:
+
+- `locate` produces Open-Meteo geocoding provider evidence.
+- `forecast` produces Open-Meteo forecast provider evidence.
+
+Preserve provider metadata and receipt references when passing either packet to
+another skill. Do not convert provider evidence into high-stakes advice.
+
+## Failure, retry, and stop conditions
+
+- **Ambiguous or missing place:** return `needs_input`; do not silently choose a
+  similarly named location.
+- **Invalid coordinates or forecast-days value:** return `needs_input`.
+- **Non-2xx response, timeout, or rate limit:** return `needs_more_evidence`,
+  preserve the failure in the receipt, and retry only under the caller's retry
+  policy.
+- **Stale or incomplete provider response:** return `needs_more_evidence`.
+- **Life-safety, medical, aviation, maritime, or emergency use:** refuse and
+  direct the caller to official channels.
+- **Mutation requested from forecast evidence:** stop after the sealed read and
+  require a separate authority-scoped action skill.
+
+## Worked example
+
+1. Run `locate` with `name: Shanghai`.
+2. Select the result for Shanghai, China.
+3. Run `forecast` using the sealed latitude and longitude with
+   `forecast_days: "3"`.
+4. Preserve both sealed receipts with the returned forecast evidence.

--- a/skills/open-meteo-weather-forecast/X.yaml
+++ b/skills/open-meteo-weather-forecast/X.yaml
@@ -1,0 +1,66 @@
+skill: open-meteo-weather-forecast
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: internal
+  role: branded
+  canonical_skill: runx/weather-forecast
+  provider: open-meteo
+  runtime_path: http
+
+harness:
+  cases:
+    - name: open-meteo-shanghai
+      runner: main
+      inputs:
+        name: Shanghai
+        latitude: "31.2222"
+        longitude: "121.4581"
+        forecast_days: "3"
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+runners:
+  main:
+    default: true
+    type: graph
+    inputs:
+      name:
+        type: string
+        required: true
+        description: City or place name to resolve.
+      latitude:
+        type: string
+        required: true
+        description: Decimal latitude selected from the location evidence.
+      longitude:
+        type: string
+        required: true
+        description: Decimal longitude selected from the location evidence.
+      forecast_days:
+        type: string
+        required: false
+        default: "3"
+        description: Number of forecast days to request.
+    graph:
+      name: open-meteo-weather-forecast
+      steps:
+        - id: locate
+          stage: locate
+          scopes:
+            - runx:http:read
+          inputs:
+            name: $input.name
+            count: "5"
+        - id: forecast
+          stage: forecast
+          scopes:
+            - runx:http:read
+          inputs:
+            latitude: $input.latitude
+            longitude: $input.longitude
+            forecast_days: $input.forecast_days

--- a/skills/open-meteo-weather-forecast/fixtures/open-meteo-shanghai.yaml
+++ b/skills/open-meteo-weather-forecast/fixtures/open-meteo-shanghai.yaml
@@ -1,0 +1,17 @@
+name: open-meteo-shanghai
+kind: skill
+target: ..
+runner: main
+inputs:
+  name: Shanghai
+  latitude: "31.2222"
+  longitude: "121.4581"
+  forecast_days: "3"
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+metadata:
+  public_skill: open-meteo-weather-forecast
+  source_case: open-meteo-shanghai
+  source: skills-fixture

--- a/skills/open-meteo-weather-forecast/graph/forecast/X.yaml
+++ b/skills/open-meteo-weather-forecast/graph/forecast/X.yaml
@@ -1,0 +1,35 @@
+skill: open-meteo-weather-forecast-data
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/open-meteo-weather-forecast
+
+runners:
+  forecast:
+    default: true
+    type: http
+    url: https://api.open-meteo.com/v1/forecast?latitude={latitude}&longitude={longitude}&current=temperature_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=auto&forecast_days={forecast_days}
+    method: GET
+    artifacts:
+      wrap_as: open_meteo_forecast_evidence
+    headers:
+      accept: application/json
+    inputs:
+      latitude:
+        type: string
+        required: true
+        description: Decimal latitude.
+      longitude:
+        type: string
+        required: true
+        description: Decimal longitude.
+      forecast_days:
+        type: string
+        required: false
+        default: "3"
+        description: Number of forecast days to request.

--- a/skills/open-meteo-weather-forecast/graph/locate/X.yaml
+++ b/skills/open-meteo-weather-forecast/graph/locate/X.yaml
@@ -1,0 +1,31 @@
+skill: open-meteo-weather-forecast-locate
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/open-meteo-weather-forecast
+
+runners:
+  locate:
+    default: true
+    type: http
+    url: https://geocoding-api.open-meteo.com/v1/search?name={name}&count={count}&language=en&format=json
+    method: GET
+    artifacts:
+      wrap_as: open_meteo_location_evidence
+    headers:
+      accept: application/json
+    inputs:
+      name:
+        type: string
+        required: true
+        description: City or place name to resolve.
+      count:
+        type: string
+        required: false
+        default: "5"
+        description: Maximum number of candidate locations.


### PR DESCRIPTION
Adds a governed, keyless Open-Meteo weather skill package for global forecasts.

- two scoped graph steps: place lookup and forecast fetch
- governed HTTP runners with typed inputs and typed artifact wrappers
- standalone sealed-receipt harness fixture
- operating guidance for ambiguity, failure, retry, rate limits, timeouts, authority, and high-stakes stop conditions

Bounty: https://github.com/auscaster/frantic-board/issues/5

Validation:
- `corepack pnpm typecheck` passes
- all three runner manifests parse and validate
- bounty machine-floor checks pass when using the corrected single-line HTTP matcher (the supplied script's first regex contains a literal newline unsupported by rg without multiline mode)
- Open-Meteo geocoding and forecast endpoints both returned successful live responses
- `tests/official-skill-catalog.test.ts` is blocked locally because the required prebuilt Rust CLI/cargo is unavailable