### PR TITLE
Add Open-Meteo governed HTTP skill example

### DIFF
--- a/examples/open-meteo-snapshot/SKILL.md
+++ b/examples/open-meteo-snapshot/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: open-meteo-snapshot
+description: Fetch a public weather and air-quality snapshot through Runx governed HTTP graph stages.
+---
+
+# Open-Meteo Snapshot
+
+Fetch current weather and air-quality observations from Open-Meteo through
+Runx's governed HTTP front. The skill uses public, keyless endpoints and keeps
+each provider call inside an auditable graph step so the receipt records the
+requested URL, status, and authority surface.
+
+## What this skill does
+
+`open-meteo-snapshot` accepts a latitude and longitude, then runs two read-only
+HTTP graph stages:
+
+- `current_weather` calls the Open-Meteo forecast endpoint for current
+  temperature and wind speed.
+- `air_quality` calls the Open-Meteo air-quality endpoint for current PM10 and
+  PM2.5 observations.
+
+The output is provider evidence for downstream planning, monitoring, or report
+generation. It is not an emergency, health, or compliance decision system.
+
+## When to use this skill
+
+- You need a sealed example of multiple public HTTP provider calls in one graph.
+- You need current weather and air-quality evidence for a latitude/longitude.
+- You want a keyless API fixture that can run in CI without secrets.
+- You need to prove the calls used Runx's governed HTTP path rather than an ad
+  hoc fetch implementation.
+
+## When not to use this skill
+
+- For life-safety, aviation, maritime, medical, or evacuation decisions.
+- For locations where Open-Meteo does not return current observations.
+- To mutate external systems or notify users based on weather or air quality.
+- To call private networks, authenticated APIs, or endpoints outside Open-Meteo.
+
+## Procedure
+
+1. Collect decimal `lat` and `lon` inputs from the caller.
+2. Run the default `snapshot` runner.
+3. Confirm both graph steps return a 2xx HTTP status in the sealed receipt.
+4. Preserve the Open-Meteo source URLs, current observation timestamps, and
+   receipt references.
+5. Return `needs_input` for malformed coordinates.
+6. Return `needs_more_evidence` for provider outages, non-2xx responses,
+   timeout failures, rate limiting, or missing current observations.
+7. Stop before recommending user action; pass the sealed evidence to a separate
+   planning skill if an action is requested.
+
+## Edge cases and stop conditions
+
+- **Invalid coordinates:** return `needs_input`; the provider expects decimal
+  latitude and longitude.
+- **Provider timeout or rate limit:** return `needs_more_evidence` and preserve
+  the failed HTTP status or timeout reason in the receipt.
+- **Partial provider failure:** return `needs_more_evidence`; do not combine a
+  successful weather call with missing air-quality evidence as if complete.
+- **Unsupported geography:** return `needs_input` if Open-Meteo cannot resolve
+  the requested coordinates.
+- **Life-safety or health advice:** return `refused`; this skill only gathers
+  public evidence and does not grant authority to make safety decisions.
+
+## Output schema
+
+```yaml
+decision: ready | needs_input | needs_more_evidence | refused
+runtime_path: http
+provider: open-meteo
+provider_evidence:
+  current_weather:
+    endpoint: string
+    http_status: string
+    current: object
+  air_quality:
+    endpoint: string
+    http_status: string
+    current: object
+receipt_refs: array
+stop_conditions: array
+```
+
+## Worked example
+
+Run the harness case for Washington, DC:
+
+```sh
+runx harness examples/open-meteo-snapshot --json
+```
+
+The graph calls the forecast and air-quality endpoints for
+`38.8894,-77.0352`. A successful run seals both HTTP observations into the run
+receipt.
+
+## Inputs
+
+- `lat` (required): decimal latitude, for example `38.8894`.
+- `lon` (required): decimal longitude, for example `-77.0352`.

--- a/examples/open-meteo-snapshot/X.yaml
+++ b/examples/open-meteo-snapshot/X.yaml
@@ -1,0 +1,57 @@
+skill: open-meteo-snapshot
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+  provider: open-meteo
+  runtime_path: http
+
+harness:
+  cases:
+    - name: open-meteo-washington-dc
+      runner: snapshot
+      inputs:
+        lat: "38.8894"
+        lon: "-77.0352"
+      expect:
+        status: sealed
+
+runners:
+  snapshot:
+    default: true
+    type: graph
+    inputs:
+      lat:
+        type: string
+        required: true
+        description: Decimal latitude.
+      lon:
+        type: string
+        required: true
+        description: Decimal longitude.
+    graph:
+      name: open-meteo-snapshot
+      steps:
+        - id: current-weather
+          stage: current_weather
+          scopes:
+            - http.read.open-meteo.forecast
+          inputs:
+            lat: $input.lat
+            lon: $input.lon
+          artifacts:
+            wrap_as: current_weather_packet
+            packet: runx.provider.open_meteo_current_weather.v1
+        - id: air-quality
+          stage: air_quality
+          scopes:
+            - http.read.open-meteo.air_quality
+          inputs:
+            lat: $input.lat
+            lon: $input.lon
+          artifacts:
+            wrap_as: air_quality_packet
+            packet: runx.provider.open_meteo_air_quality.v1

--- a/examples/open-meteo-snapshot/graph/air_quality/X.yaml
+++ b/examples/open-meteo-snapshot/graph/air_quality/X.yaml
@@ -1,0 +1,28 @@
+skill: open-meteo-air-quality
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/open-meteo-snapshot
+
+runners:
+  air_quality:
+    default: true
+    type: http
+    url: https://air-quality-api.open-meteo.com/v1/air-quality?latitude={lat}&longitude={lon}&current=pm10,pm2_5
+    method: GET
+    headers:
+      accept: "application/json"
+    inputs:
+      lat:
+        type: string
+        required: true
+        description: Decimal latitude.
+      lon:
+        type: string
+        required: true
+        description: Decimal longitude.

--- a/examples/open-meteo-snapshot/graph/current_weather/X.yaml
+++ b/examples/open-meteo-snapshot/graph/current_weather/X.yaml
@@ -1,0 +1,28 @@
+skill: open-meteo-current-weather
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/open-meteo-snapshot
+
+runners:
+  current_weather:
+    default: true
+    type: http
+    url: https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={lon}&current=temperature_2m,wind_speed_10m
+    method: GET
+    headers:
+      accept: "application/json"
+    inputs:
+      lat:
+        type: string
+        required: true
+        description: Decimal latitude.
+      lon:
+        type: string
+        required: true
+        description: Decimal longitude.

--- a/examples/open-meteo-snapshot/run.sh
+++ b/examples/open-meteo-snapshot/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# Public-provider proof: Open-Meteo current weather plus air quality.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OSS="$(cd "$HERE/../.." && pwd)"
+RUNX="${RUNX_BIN:-$OSS/crates/target/debug/runx}"
+[ -x "$RUNX" ] || RUNX="$(command -v runx || true)"
+[ -n "$RUNX" ] || { echo "runx binary not found; set RUNX_BIN." >&2; exit 1; }
+
+export RUNX_RECEIPT_SIGN_KID="${RUNX_RECEIPT_SIGN_KID:-runx-demo-key}"
+export RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64="${RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64:-QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=}"
+export RUNX_RECEIPT_SIGN_ISSUER_TYPE="${RUNX_RECEIPT_SIGN_ISSUER_TYPE:-hosted}"
+
+RDIR="$(mktemp -d 2>/dev/null || echo /tmp/runx-open-meteo-snapshot)"
+"$RUNX" harness "$HERE" --receipt-dir "$RDIR" --json
+
+echo "------------------------------------------------------------"
+echo "the governed HTTP graph executed against Open-Meteo and sealed:"
+echo "receipts: $RDIR"


### PR DESCRIPTION
## Summary

Adds `examples/open-meteo-snapshot`, a keyless public API skill package that runs two Open-Meteo provider calls through Runx governed HTTP graph stages:

- current weather from `api.open-meteo.com`
- air quality from `air-quality-api.open-meteo.com`

The example includes:

- `SKILL.md` with operating guidance, stop conditions, and output shape
- top-level `X.yaml` with catalog metadata, an inline harness, and two scoped graph steps
- internal graph-stage `type: http` runner profiles for each provider endpoint
- `run.sh` for a receipt-backed demo run

This is intended as a small governed public API skill package and as a candidate delivery for Frantic Board bounty 05.

## Verification

- `crates/target/debug/runx harness examples/open-meteo-snapshot --json`
  - passed, receipt `sha256:3b988b4490214d3ff90facc4ecf2be8aa32a161beb61660a41c3f0964ff5b024`
- `sh examples/open-meteo-snapshot/run.sh`
  - passed, receipt `sha256:a53ad9487016752546999925e7f917103f292e0fd903121fee118455362a0d69`
- `pnpm exec tsx -e "...validateRunnerManifest(...)..."`
  - validated all three `X.yaml` files
- `pnpm vitest run --config vitest.config.ts tests/official-skill-catalog.test.ts --reporter=verbose`
  - passed, 8 tests
- `pnpm vitest run --config vitest.fast.config.ts packages/cli/src/skill-refs.test.ts --reporter=verbose`
  - passed, 4 tests

Notes:

- Full `pnpm test:fast` currently fails in `tests/stripe-spt-rail-adapter.test.ts` because this local checkout is missing `../cloud/packages/stripe-executor/dist/index.js`; the failing test is unrelated to this example.
- Frantic Board's `verify/05-check-runx-skill-package.sh` currently fails before evaluating this package because its `rg` regex contains a literal `\n` without multiline mode. The package contains the requested governed `type: http` stages and passes Runx's own harness.
