### PR TITLE
fix(authoring): reject symlink repo path escapes

### DIFF
--- a/packages/authoring/src/index.test.ts
+++ b/packages/authoring/src/index.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -164,6 +164,23 @@ describe("@runxhq/authoring", () => {
       "/tmp/project",
     );
     expect(() => resolveInsideRepo("/tmp/repo", "../escape")).toThrow(/escapes repo_root/);
+  });
+
+  it("rejects existing symlink targets that resolve outside the repo root", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-authoring-repo-root-"));
+    const repoRoot = path.join(tempDir, "repo");
+    const outsideFile = path.join(tempDir, "outside.txt");
+    const linkPath = path.join(repoRoot, "outside-link.txt");
+
+    try {
+      await mkdir(repoRoot);
+      await writeFile(outsideFile, "outside", "utf8");
+      await symlink(outsideFile, linkPath, "file");
+
+      expect(() => resolveInsideRepo(repoRoot, "outside-link.txt")).toThrow(/escapes repo_root/);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("parses tool inputs from a spill file when RUNX_INPUTS_PATH is provided", async () => {

--- a/packages/authoring/src/index.ts
+++ b/packages/authoring/src/index.ts
@@ -612,8 +612,8 @@ export function resolveRepoRoot(
 export function resolveInsideRepo(repoRoot: string, targetPath: string): string {
   const resolvedPath = path.resolve(repoRoot, targetPath);
   const realRepoRoot = realpathOrResolved(repoRoot);
-  const realParent = realExistingAncestor(path.dirname(resolvedPath));
-  if (!realParent.startsWith(`${realRepoRoot}${path.sep}`) && realParent !== realRepoRoot) {
+  const realTarget = realpathOrExistingAncestor(resolvedPath);
+  if (!realTarget.startsWith(`${realRepoRoot}${path.sep}`) && realTarget !== realRepoRoot) {
     throw new Error(`path escapes repo_root: ${targetPath}`);
   }
   return resolvedPath;
@@ -624,6 +624,14 @@ function realpathOrResolved(targetPath: string): string {
     return realpathSync.native(targetPath);
   } catch {
     return path.resolve(targetPath);
+  }
+}
+
+function realpathOrExistingAncestor(targetPath: string): string {
+  try {
+    return realpathSync.native(targetPath);
+  } catch {
+    return realExistingAncestor(path.dirname(targetPath));
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve existing target paths before accepting them as inside repo_root
- reject symlinks inside the repo when their real target escapes repo_root
- add a regression test for a repo-local symlink pointing to an outside file

## Verification
- pnpm vitest run packages/authoring/src/index.test.ts --config vitest.fast.config.ts -t "rejects existing symlink targets"

Fixes auscaster/frantic-board#2