### PR TITLE
fix(authoring): preserve POSIX RUNX_CWD on Windows

### DIFF
--- a/packages/authoring/src/index.test.ts
+++ b/packages/authoring/src/index.test.ts
@@ -166,6 +166,10 @@ describe("@runxhq/authoring", () => {
     expect(() => resolveInsideRepo("/tmp/repo", "../escape")).toThrow(/escapes repo_root/);
   });
 
+  it("preserves POSIX absolute RUNX_CWD values on Windows hosts", () => {
+    expect(resolveRepoRoot({}, { RUNX_CWD: "/tmp/project/../repo" } as NodeJS.ProcessEnv)).toBe("/tmp/repo");
+  });
+
   it("parses tool inputs from a spill file when RUNX_INPUTS_PATH is provided", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "runx-authoring-inputs-"));
     const inputsPath = path.join(tempDir, "inputs.json");

--- a/packages/authoring/src/index.ts
+++ b/packages/authoring/src/index.ts
@@ -599,14 +599,25 @@ export function resolveRepoRoot(
   inputs: Readonly<Record<string, unknown>> = {},
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  return path.resolve(
+  return resolveRunxPath(
     String(
       inputs.repo_root
-        || inputs.fixture
-        || env.RUNX_CWD
-        || process.cwd(),
+      || inputs.fixture
+      || env.RUNX_CWD
+      || process.cwd(),
     ),
   );
+}
+
+function resolveRunxPath(value: string): string {
+  if (process.platform === "win32" && isPosixAbsolutePath(value)) {
+    return path.posix.normalize(value);
+  }
+  return path.resolve(value);
+}
+
+function isPosixAbsolutePath(value: string): boolean {
+  return value.startsWith("/") && !value.startsWith("//");
 }
 
 export function resolveInsideRepo(repoRoot: string, targetPath: string): string {


### PR DESCRIPTION
## Summary

- Preserve POSIX-style absolute `RUNX_CWD` values when `resolveRepoRoot` runs on Windows.
- Add a focused regression test for `/tmp/project/../repo` normalization.

This addresses the behavior required by the existing authoring helper tests: a POSIX absolute `RUNX_CWD` should remain rooted at `/`, not be reinterpreted as `C:\tmp\...` on Windows.

## Verification

```sh
pnpm exec vitest run packages/authoring/src/index.test.ts --config vitest.fast.config.ts -t "preserves POSIX absolute RUNX_CWD values"
pnpm exec vitest run packages/authoring/src/index.test.ts --config vitest.fast.config.ts -t "exports shared authoring helpers"
```

Both targeted tests pass locally on Windows.

Note: full `pnpm test:fast` still fails in this Windows environment because some suites require a prebuilt Rust binary and another existing Windows process-spawn issue (`spawn EINVAL`) is unrelated to this path-resolution fix.

Bounty context: auscaster/frantic-board#2
