### PR TITLE
feat: add dependency CVE audit skill

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -31,6 +31,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "08cefe802c15e5be7d32ae9a363a6c42168e86f7fab92890e5ce5c994af367c9",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/dependency-cve-audit",
+        version: "sha-e9e461e41ea3",
+        digest: "c19ec9fdeb088daab950b7c2e1f3757880de9702e31e40b57e2f65c0c4033348",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/design-skill",
         version: "sha-0353a69bc33f",
         digest: "da1eae6fa3016c24dd3347082fe8639577a0b169ebfa63050f0df145e448b82b",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -28,6 +28,13 @@
     "catalog_role": "context"
   },
   {
+    "skill_id": "runx/dependency-cve-audit",
+    "version": "sha-e9e461e41ea3",
+    "digest": "c19ec9fdeb088daab950b7c2e1f3757880de9702e31e40b57e2f65c0c4033348",
+    "catalog_visibility": "public",
+    "catalog_role": "canonical"
+  },
+  {
     "skill_id": "runx/design-skill",
     "version": "sha-0353a69bc33f",
     "digest": "da1eae6fa3016c24dd3347082fe8639577a0b169ebfa63050f0df145e448b82b",

--- a/packages/cli/src/skill-refs.test.ts
+++ b/packages/cli/src/skill-refs.test.ts
@@ -14,6 +14,7 @@ const publicOfficialCatalogSkills = [
   "charge",
   "content-pipeline",
   "deep-research-brief",
+  "dependency-cve-audit",
   "design-skill",
   "dispute-respond",
   "draft-content",

--- a/skills/dependency-cve-audit/SKILL.md
+++ b/skills/dependency-cve-audit/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: dependency-cve-audit
+description: Audit locked npm dependencies against OSV advisories and emit exact-version CVE evidence.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+runx:
+  tags:
+    - security
+    - dependencies
+    - osv
+links:
+  source: https://github.com/RYDE-PLAY/runx-dependency-cve-audit-skill
+  advisory_source: https://osv.dev
+---
+
+## What this skill does
+
+This skill audits a Node.js project's committed `package-lock.json` for known
+vulnerabilities in npm dependencies. It extracts exact installed package
+versions, queries the OSV API for each exact `{ ecosystem, package, version }`
+tuple, and emits a machine-checkable evidence packet plus a concise Markdown
+report.
+
+The skill is read-only. It does not install dependencies, execute target code,
+modify repositories, open issues, submit advisories, or claim that a package is
+safe when OSV returns no matching record. A zero-finding result means only that
+OSV did not return advisories for the exact versions scanned under the selected
+scope.
+
+## When to use this skill
+
+Use this skill when an agent needs a reproducible dependency vulnerability
+snapshot for a public Node.js project, release candidate, benchmark fixture, or
+security review packet. It is appropriate when the lockfile is public or has
+been explicitly cleared for disclosure to OSV, and when the review needs exact
+installed-version evidence rather than semver range guesses.
+
+The skill is especially useful before triage, upgrade planning, advisory
+drafting, or reviewer handoff because it preserves the lockfile SHA-256, the
+scan policy, the OSV query tuple for every finding, and references for each
+advisory.
+
+## When not to use this skill
+
+Do not use this skill for private lockfiles unless the package names, versions,
+and lockfile URL/path are approved for disclosure to the advisory source. Do not
+use it as a full application security review, source-code audit, exploitability
+assessment, SBOM generator, package installer, or automated remediation tool.
+
+Do not use the output as proof that a project is vulnerability-free. The result
+depends on OSV coverage at run time, the selected dependency scope, and the
+contents of the supplied lockfile.
+
+## Procedure
+
+1. Read `package_lock_path` or `package_lock_url`.
+2. Record byte length and SHA-256 for the lockfile input.
+3. Extract exact installed package versions from the lockfile.
+4. Limit the scan to the declared `scan_scope` and `include_dev` policy.
+5. Query OSV only with exact npm package names and exact installed versions.
+6. Keep only vulnerabilities returned by OSV for that exact version query.
+7. Emit `dependency.cve.audit.result.v1` with findings, query evidence, and validation.
+8. Write `evidence.json` and `report.md` when `output_dir` is provided.
+
+## Edge cases and stop conditions
+
+Stop with an error when neither `package_lock_path` nor `package_lock_url` is
+provided, when the lockfile cannot be read, when the URL is not HTTPS, when the
+lockfile is not valid JSON, or when it does not contain a `packages` object.
+
+For local paths and output paths, the resolved path must stay inside the skill
+directory. This prevents the runner from reading or writing unrelated workspace
+files.
+
+If an OSV request fails, stop instead of returning a partial success packet. If
+`scan_scope` is `direct`, skip direct dependencies whose installed package entry
+is missing from `packages`; do not invent versions from semver declarations.
+
+The output is evidence for dependency triage, not an authorization to publish a
+security advisory or mutate a repository. Any later issue filing, advisory
+publication, or remediation PR needs its own gate.
+
+## Output schema
+
+The primary output is `dependency_cve_audit_result`, with schema
+`dependency.cve.audit.result.v1`:
+
+```json
+{
+  "schema": "dependency.cve.audit.result.v1",
+  "data": {
+    "target": {
+      "name": "string | null",
+      "repo": "string | null",
+      "ref": "string | null"
+    },
+    "source": {
+      "kind": "file | url",
+      "ref": "string",
+      "bytes": 0,
+      "sha256": "hex"
+    },
+    "scanner": {
+      "name": "dependency-cve-audit",
+      "version": "0.1.1",
+      "advisory_source": "OSV.dev v1 query API",
+      "advisory_endpoint": "https://api.osv.dev/v1/query"
+    },
+    "policy": {
+      "ecosystem": "npm",
+      "scan_scope": "direct | all",
+      "include_dev": false,
+      "target_code_executed": false,
+      "target_packages_installed": false,
+      "finding_rule": "string"
+    },
+    "summary": {
+      "dependencies_scanned": 0,
+      "packages_with_findings": 0,
+      "findings": 0
+    },
+    "dependencies": [],
+    "findings": [],
+    "validation": {
+      "valid": true,
+      "every_finding_has_exact_version": true,
+      "every_finding_has_reference": true,
+      "every_finding_has_advisory_id": true,
+      "zero_false_hit_control": "string"
+    }
+  }
+}
+```
+
+When `output_dir` is provided, the runner also writes `evidence.json` and
+`report.md` inside that directory and returns their relative paths in
+`data.artifacts`.
+
+## Worked example
+
+The harness scans OWASP NodeGoat at commit
+`c5cb68a7084e4ae7dcc60e6a98768720a81841e8` using the committed
+`package-lock.json`:
+
+```bash
+runx skill "$PWD" \
+  --input target_name="OWASP NodeGoat" \
+  --input target_repo=https://github.com/OWASP/NodeGoat \
+  --input target_ref=c5cb68a7084e4ae7dcc60e6a98768720a81841e8 \
+  --input package_lock_url=https://raw.githubusercontent.com/OWASP/NodeGoat/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/package-lock.json \
+  --input scan_scope=direct \
+  --input include_dev=false \
+  --input output_dir=artifacts/nodegoat \
+  --json
+```
+
+Expected evidence shape:
+
+- `source.sha256` records the fetched lockfile hash.
+- `summary.dependencies_scanned` is the number of direct production npm
+  dependencies found in the lockfile.
+- Each finding contains the exact installed version, OSV advisory id, aliases,
+  fixed versions when listed, affected ranges, and references.
+- `validation.valid` is true only when every finding includes an exact version,
+  advisory id, and at least one reference.
+
+## Inputs
+
+- `target_name`: human-readable project name.
+- `target_repo`: source repository URL.
+- `target_ref`: immutable commit or release reference.
+- `package_lock_path`: local path to a `package-lock.json`.
+- `package_lock_url`: public URL for a `package-lock.json`.
+- `scan_scope`: `direct` or `all`; defaults to `direct`.
+- `include_dev`: include dev dependencies when true; defaults to false.
+- `output_dir`: optional directory for `evidence.json` and `report.md`.
+
+## Outputs
+
+- `dependency_cve_audit_result`: complete packet.
+- `evidence_json`: same evidence as machine-checkable JSON.
+- `report_md`: concise report with exact version findings and references.

--- a/skills/dependency-cve-audit/X.yaml
+++ b/skills/dependency-cve-audit/X.yaml
@@ -1,0 +1,113 @@
+skill: dependency-cve-audit
+version: "0.1.1"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+runx:
+  mutating: false
+  idempotency:
+    key: lockfile_sha256
+  scopes:
+    - dependencies.read
+    - advisories.osv.query
+  policy:
+    data_classification: public_dependency_metadata
+    network:
+      allowed:
+        - https://api.osv.dev/v1/query
+        - https://raw.githubusercontent.com/
+      forbidden:
+        - private repositories
+        - package installation
+        - source code execution
+    verifier_notes:
+      - Every finding is produced from an exact package name and exact installed version query.
+      - The dogfood fixture pins the target repository to an immutable commit URL.
+  artifacts:
+    emits:
+      - dependency_cve_audit_result
+      - evidence_json
+      - report_md
+    wrap_as: dependency_cve_audit_packet
+
+harness:
+  cases:
+    - name: nodegoat-direct-production
+      runner: default
+      inputs:
+        target_name: OWASP NodeGoat
+        target_repo: https://github.com/OWASP/NodeGoat
+        target_ref: c5cb68a7084e4ae7dcc60e6a98768720a81841e8
+        package_lock_url: https://raw.githubusercontent.com/OWASP/NodeGoat/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/package-lock.json
+        scan_scope: direct
+        include_dev: false
+        output_dir: artifacts/nodegoat
+      expect:
+        status: sealed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: /usr/bin/env
+    args:
+      - node
+      - run.mjs
+    scopes:
+      - dependencies.read
+      - advisories.osv.query
+    policy:
+      reads:
+        - public npm package lockfiles
+      calls:
+        - OSV exact-version query API
+      writes:
+        - evidence.json
+        - report.md
+      disallows:
+        - installing target packages
+        - executing target project code
+        - using private repository contents
+    inputs:
+      target_name:
+        type: string
+        required: true
+        description: Human-readable project name.
+      target_repo:
+        type: string
+        required: true
+        description: Public source repository URL.
+      target_ref:
+        type: string
+        required: false
+        description: Immutable commit, tag, or release reference.
+      package_lock_path:
+        type: string
+        required: false
+        description: Local package-lock.json path inside the skill directory.
+      package_lock_url:
+        type: string
+        required: false
+        description: Public package-lock.json URL.
+      scan_scope:
+        type: string
+        required: false
+        default: direct
+        description: direct or all dependencies.
+      include_dev:
+        type: boolean
+        required: false
+        default: false
+        description: Include development dependencies.
+      output_dir:
+        type: string
+        required: false
+        description: Directory inside the skill directory where artifacts should be written.
+    outputs:
+      dependency_cve_audit_result: object
+      evidence_json: object
+      report_md: string

--- a/skills/dependency-cve-audit/run.mjs
+++ b/skills/dependency-cve-audit/run.mjs
@@ -1,0 +1,399 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const OSV_QUERY_URL = "https://api.osv.dev/v1/query";
+const SCHEMA = "dependency.cve.audit.result.v1";
+
+const inputs = readInputs();
+const skillRoot = process.cwd();
+const scanScope = inputs.scan_scope || "direct";
+const includeDev = inputs.include_dev === true;
+
+if (!["direct", "all"].includes(scanScope)) {
+  throw new Error("scan_scope must be direct or all");
+}
+
+const source = await readLockfile(inputs, skillRoot);
+const lockfile = JSON.parse(source.text);
+const dependencies = collectDependencies(lockfile, { scanScope, includeDev });
+const findings = await queryFindings(dependencies);
+const evidence = buildEvidence({ inputs, source, dependencies, findings, scanScope, includeDev });
+const report = renderReport(evidence);
+
+writeArtifacts(inputs.output_dir, evidence, report, skillRoot);
+
+process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+async function readLockfile(rawInputs, root) {
+  if (typeof rawInputs.package_lock_path === "string" && rawInputs.package_lock_path.length > 0) {
+    const resolved = path.resolve(root, rawInputs.package_lock_path);
+    ensureInside(root, resolved, "package_lock_path");
+    const text = fs.readFileSync(resolved, "utf8");
+    return { kind: "file", ref: rawInputs.package_lock_path, text };
+  }
+  if (typeof rawInputs.package_lock_url === "string" && rawInputs.package_lock_url.length > 0) {
+    const url = new URL(rawInputs.package_lock_url);
+    if (!["https:"].includes(url.protocol)) {
+      throw new Error("package_lock_url must be https");
+    }
+    const response = await fetch(url, { headers: { accept: "application/json,text/plain,*/*" } });
+    if (!response.ok) {
+      throw new Error(`GET ${url.href} returned ${response.status}`);
+    }
+    return { kind: "url", ref: url.href, text: await response.text() };
+  }
+  throw new Error("package_lock_path or package_lock_url is required");
+}
+
+function collectDependencies(lockfile, { scanScope, includeDev }) {
+  if (!lockfile || typeof lockfile !== "object") {
+    throw new Error("package-lock.json must be a JSON object");
+  }
+  if (!lockfile.packages || typeof lockfile.packages !== "object") {
+    throw new Error("package-lock.json packages object is required");
+  }
+
+  const root = lockfile.packages[""] || {};
+  const prodDirect = new Set(Object.keys(root.dependencies || {}));
+  const devDirect = new Set(Object.keys(root.devDependencies || {}));
+  const directNames = new Set([...prodDirect, ...(includeDev ? devDirect : [])]);
+  const results = [];
+
+  if (scanScope === "direct") {
+    for (const name of directNames) {
+      const pkgPath = `node_modules/${name}`;
+      const pkg = lockfile.packages[pkgPath];
+      if (!pkg || typeof pkg !== "object" || typeof pkg.version !== "string") {
+        continue;
+      }
+      results.push(dependencyRecord({
+        name,
+        pkg,
+        pkgPath,
+        prodDirect,
+        devDirect,
+      }));
+    }
+    return dedupeDependencies(results).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  for (const [pkgPath, pkg] of Object.entries(lockfile.packages)) {
+    if (!pkgPath || !pkgPath.startsWith("node_modules/") || !pkg || typeof pkg !== "object") {
+      continue;
+    }
+    if (!pkg.version || typeof pkg.version !== "string") {
+      continue;
+    }
+    if (pkg.dev === true && !includeDev) {
+      continue;
+    }
+
+    const name = packageNameFromLockPath(pkgPath);
+    results.push(dependencyRecord({
+      name,
+      pkg,
+      pkgPath,
+      prodDirect,
+      devDirect,
+    }));
+  }
+
+  return dedupeDependencies(results).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function packageNameFromLockPath(pkgPath) {
+  const marker = "node_modules/";
+  const rest = pkgPath.slice(pkgPath.lastIndexOf(marker) + marker.length);
+  if (rest.startsWith("@")) {
+    const [scope, name] = rest.split("/");
+    return `${scope}/${name}`;
+  }
+  return rest.split("/")[0];
+}
+
+function dependencyRecord({ name, pkg, pkgPath, prodDirect, devDirect }) {
+  const isProdDirect = prodDirect.has(name) && pkgPath === `node_modules/${name}`;
+  const isDevDirect = devDirect.has(name) && pkgPath === `node_modules/${name}`;
+  return {
+    ecosystem: "npm",
+    name,
+    version: pkg.version,
+    relation: isProdDirect ? "direct-production" : isDevDirect ? "direct-development" : "transitive",
+    lockfile_path: pkgPath,
+    resolved: typeof pkg.resolved === "string" ? pkg.resolved : null,
+    integrity: typeof pkg.integrity === "string" ? pkg.integrity : null,
+  };
+}
+
+function dedupeDependencies(dependencies) {
+  const seen = new Set();
+  const results = [];
+  for (const dep of dependencies) {
+    const key = `${dep.name}@${dep.version}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      results.push(dep);
+    }
+  }
+  return results;
+}
+
+async function queryFindings(dependencies) {
+  const findings = [];
+  for (const dependency of dependencies) {
+    const response = await fetch(OSV_QUERY_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({
+        version: dependency.version,
+        package: {
+          ecosystem: dependency.ecosystem,
+          name: dependency.name,
+        },
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`OSV query for ${dependency.name}@${dependency.version} returned ${response.status}`);
+    }
+    const payload = await response.json();
+    for (const vuln of payload.vulns || []) {
+      findings.push(normalizeVulnerability(dependency, vuln));
+    }
+  }
+  return findings.sort((a, b) =>
+    `${a.dependency.name}:${a.advisory_id}`.localeCompare(`${b.dependency.name}:${b.advisory_id}`),
+  );
+}
+
+function normalizeVulnerability(dependency, vuln) {
+  const references = (vuln.references || [])
+    .map((ref) => ({ type: ref.type || "WEB", url: ref.url }))
+    .filter((ref) => typeof ref.url === "string" && ref.url.startsWith("http"));
+  const severities = (vuln.severity || []).map((entry) => `${entry.type}:${entry.score}`);
+  const aliases = Array.isArray(vuln.aliases) ? vuln.aliases : [];
+
+  return {
+    dependency,
+    query: {
+      ecosystem: dependency.ecosystem,
+      package: dependency.name,
+      version: dependency.version,
+      advisory_source: OSV_QUERY_URL,
+    },
+    advisory_id: vuln.id,
+    cve_ids: aliases.filter((alias) => alias.startsWith("CVE-")),
+    aliases,
+    summary: vuln.summary || "",
+    severity: severityLabel(vuln),
+    severity_vectors: severities,
+    fixed_versions: fixedVersions(vuln),
+    affected_ranges: affectedRangesForPackage(vuln, dependency.name),
+    published: vuln.published || null,
+    modified: vuln.modified || null,
+    references,
+    source_records: sourceRecords(vuln),
+  };
+}
+
+function severityLabel(vuln) {
+  const specific = vuln.database_specific || {};
+  if (typeof specific.severity === "string" && specific.severity.length > 0) {
+    return specific.severity.toLowerCase();
+  }
+  if (Array.isArray(vuln.severity) && vuln.severity.length > 0) {
+    return vuln.severity[0].score;
+  }
+  return "unknown";
+}
+
+function fixedVersions(vuln) {
+  const versions = new Set();
+  for (const affected of vuln.affected || []) {
+    for (const range of affected.ranges || []) {
+      for (const event of range.events || []) {
+        if (event.fixed) versions.add(event.fixed);
+      }
+    }
+  }
+  return [...versions].sort(compareVersionish);
+}
+
+function affectedRangesForPackage(vuln, packageName) {
+  const ranges = [];
+  for (const affected of vuln.affected || []) {
+    if (affected.package?.name !== packageName) continue;
+    for (const range of affected.ranges || []) {
+      ranges.push({
+        type: range.type || null,
+        events: (range.events || []).map((event) => ({ ...event })),
+      });
+    }
+  }
+  return ranges;
+}
+
+function sourceRecords(vuln) {
+  const records = new Set();
+  for (const affected of vuln.affected || []) {
+    const source = affected.database_specific?.source;
+    if (source) records.add(source);
+  }
+  return [...records].sort();
+}
+
+function compareVersionish(a, b) {
+  return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: "base" });
+}
+
+function buildEvidence({ inputs, source, dependencies, findings, scanScope, includeDev }) {
+  const uniquePackagesWithFindings = new Set(findings.map((finding) => finding.dependency.name));
+  const everyFindingHasExactVersion = findings.every((finding) =>
+    finding.query.version === finding.dependency.version
+    && finding.query.package === finding.dependency.name
+    && finding.dependency.version.length > 0,
+  );
+  const everyFindingHasReference = findings.every((finding) => finding.references.length > 0);
+  const everyFindingHasAdvisoryId = findings.every((finding) => finding.advisory_id.length > 0);
+
+  return {
+    schema: SCHEMA,
+    data: {
+      target: {
+        name: inputs.target_name || null,
+        repo: inputs.target_repo || null,
+        ref: inputs.target_ref || null,
+      },
+      source: {
+        kind: source.kind,
+        ref: source.ref,
+        bytes: Buffer.byteLength(source.text),
+        sha256: sha256(source.text),
+      },
+      scanner: {
+        name: "dependency-cve-audit",
+        version: "0.1.1",
+        advisory_source: "OSV.dev v1 query API",
+        advisory_endpoint: OSV_QUERY_URL,
+      },
+      policy: {
+        ecosystem: "npm",
+        scan_scope: scanScope,
+        include_dev: includeDev,
+        target_code_executed: false,
+        target_packages_installed: false,
+        finding_rule: "A finding is included only when OSV returns it for the exact npm package name and exact installed version from package-lock.json.",
+      },
+      summary: {
+        dependencies_scanned: dependencies.length,
+        packages_with_findings: uniquePackagesWithFindings.size,
+        findings: findings.length,
+      },
+      dependencies,
+      findings,
+      validation: {
+        valid: everyFindingHasExactVersion && everyFindingHasReference && everyFindingHasAdvisoryId,
+        every_finding_has_exact_version: everyFindingHasExactVersion,
+        every_finding_has_reference: everyFindingHasReference,
+        every_finding_has_advisory_id: everyFindingHasAdvisoryId,
+        zero_false_hit_control: "Each OSV request uses only the exact package name and version read from the lockfile; no inferred ranges or guessed versions are reported.",
+      },
+    },
+  };
+}
+
+function renderReport(packet) {
+  const data = packet.data;
+  const lines = [];
+  lines.push("# Dependency CVE Audit Report");
+  lines.push("");
+  lines.push(`Target: ${data.target.name}`);
+  lines.push(`Repository: ${data.target.repo}`);
+  lines.push(`Reference: ${data.target.ref}`);
+  lines.push(`Lockfile: ${data.source.ref}`);
+  lines.push(`Lockfile SHA-256: \`${data.source.sha256}\``);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- Advisory source: ${data.scanner.advisory_source} (${data.scanner.advisory_endpoint})`);
+  lines.push(`- Scan scope: ${data.policy.scan_scope} npm dependencies`);
+  lines.push(`- Include dev dependencies: ${data.policy.include_dev}`);
+  lines.push(`- Dependencies scanned: ${data.summary.dependencies_scanned}`);
+  lines.push(`- Packages with findings: ${data.summary.packages_with_findings}`);
+  lines.push(`- Exact-version findings: ${data.summary.findings}`);
+  lines.push(`- Target code executed: ${data.policy.target_code_executed}`);
+  lines.push(`- Target packages installed: ${data.policy.target_packages_installed}`);
+  lines.push("");
+  lines.push("## Findings");
+  lines.push("");
+
+  if (data.findings.length === 0) {
+    lines.push("No OSV vulnerabilities were returned for the scanned exact versions.");
+  } else {
+    lines.push("| Package | Version | Advisory | CVE aliases | Severity | Fixed versions | Primary reference |");
+    lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+    for (const finding of data.findings) {
+      lines.push([
+        finding.dependency.name,
+        finding.dependency.version,
+        finding.advisory_id,
+        finding.cve_ids.join(", ") || "none",
+        finding.severity,
+        finding.fixed_versions.join(", ") || "not listed",
+        finding.references[0]?.url || "not listed",
+      ].map(markdownCell).join(" | ").replace(/^/, "| ").replace(/$/, " |"));
+    }
+  }
+
+  lines.push("");
+  lines.push("## Reproducibility Controls");
+  lines.push("");
+  lines.push("- The lockfile URL is pinned to an immutable Git commit.");
+  lines.push("- Every dependency version comes from `package-lock.json`, not semver range resolution.");
+  lines.push("- Every finding is returned by OSV for an exact npm package and version query.");
+  lines.push("- The audit does not install packages or execute target project code.");
+  lines.push("- `evidence.json` contains the full dependency list, OSV query tuple, advisory IDs, aliases, references, and validation booleans.");
+  lines.push("");
+
+  return `${lines.join("\n")}\n`;
+}
+
+function markdownCell(value) {
+  return String(value).replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function writeArtifacts(outputDir, evidence, report, root) {
+  if (!outputDir) {
+    evidence.data.artifacts = {};
+    return;
+  }
+  const resolved = path.resolve(root, outputDir);
+  ensureInside(root, resolved, "output_dir");
+  fs.mkdirSync(resolved, { recursive: true });
+  const evidencePath = path.join(resolved, "evidence.json");
+  const reportPath = path.join(resolved, "report.md");
+  evidence.data.artifacts = {
+    evidence_json: path.relative(root, evidencePath),
+    report_md: path.relative(root, reportPath),
+  };
+  fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+  fs.writeFileSync(reportPath, report);
+}
+
+function ensureInside(root, resolved, label) {
+  const normalizedRoot = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  if (resolved !== root && !resolved.startsWith(normalizedRoot)) {
+    throw new Error(`${label} must stay inside the skill directory`);
+  }
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}


### PR DESCRIPTION
## Summary
- Add a non-connector governed runx skill: `dependency-cve-audit`.
- Audits direct npm production dependencies from a `package-lock.json` against OSV exact-version advisories.
- Includes typed inputs/outputs, declared scopes, policy, emits, and a real harness fixture.

## Frantic #10 evidence
- Source repo: https://github.com/RYDE-PLAY/runx-dependency-cve-audit-skill
- Source commit: d2d07e1122e26c47d113a4b982a9b838b5dff489
- Registry listing: https://runx.ai/x/ryde-play/dependency-cve-audit
- Registry API detail: https://api.runx.ai/v1/skills/ryde-play/dependency-cve-audit
- Harness output: `artifacts/nodegoat/runx-harness.json` in the source repo
- Sealed receipt: `sha256:8a39bfc0299aef29972bcc6834ca08b09b12d551d5b601c3d27eacdfec791fed`
- Receipt file: `artifacts/nodegoat/runx-receipt.json`
- Verification output: `artifacts/nodegoat/runx-verify.json`

## Verification
- `runx doctor --json`
- `runx tool build --all --json`
- `runx harness --json`
- `runx verify --receipt artifacts/nodegoat/runx-receipt.json --json`
