### PR TITLE
Add ci-failure-triage skill

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -31,6 +31,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "c151b98be3a2a7ccd306d7395d906ffd1fc22e45a7d94ffe34c294e9db1c47ce",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/ci-failure-triage",
+        version: "sha-00166ed3ca13",
+        digest: "16584524cecb56e651952d5174be2d507f4aa71b6cd7f6110011ef63fcddc557",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/content-pipeline",
         version: "sha-0efcbf2abed1",
         digest: "b93475f254b458a92936cd4612b8d01a59c371876b810eb242b06ce184f2b798",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -28,6 +28,13 @@
     "catalog_role": "canonical"
   },
   {
+    "skill_id": "runx/ci-failure-triage",
+    "version": "sha-00166ed3ca13",
+    "digest": "16584524cecb56e651952d5174be2d507f4aa71b6cd7f6110011ef63fcddc557",
+    "catalog_visibility": "public",
+    "catalog_role": "context"
+  },
+  {
     "skill_id": "runx/content-pipeline",
     "version": "sha-0efcbf2abed1",
     "digest": "b93475f254b458a92936cd4612b8d01a59c371876b810eb242b06ce184f2b798",

--- a/skills/ci-failure-triage/SKILL.md
+++ b/skills/ci-failure-triage/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: ci-failure-triage
+description: Classify CI failures from supplied logs and emit a read-only routing packet for downstream issue-intake.
+runx:
+  category: code
+---
+
+# CI Failure Triage
+
+Classify one CI failure from the supplied logs, commit context, repository
+state, and escalation policy. The skill emits a typed triage packet for a
+separate governed issue-intake, issue-to-pr, or pr-review-note run. It does not
+rerun CI, open tracking items, page operators, mutate repositories, or claim
+that any downstream lane has acted on its recommendation.
+
+## What This Skill Does
+
+`ci-failure-triage` makes the first incident-response decision for a failed CI
+run. It reads the failure evidence and returns one of four verdicts:
+
+- `flake`: a transient or nondeterministic signal, such as a timeout, network
+  interruption, scheduler cancellation, or known intermittent test symptom.
+- `infra`: a runner, service, cache, quota, secret, or dependency-hosting issue
+  unrelated to the submitted code.
+- `real-break`: a code, test, type, lint, build, or contract failure that is
+  visible in the supplied logs or commit context.
+- `dep`: a dependency, lockfile, toolchain, version, registry, or external
+  package break with direct evidence in the supplied inputs.
+
+The output is always read-only. For `flake` it may include a rerun verdict. For
+`infra` it may include an operator page note. For `real-break` or `dep` it may
+include a routing decision recommending `issue-to-pr`. Under-threshold,
+truncated, conflicting, or unsupported evidence must stop with `needs_agent`
+instead of emitting a lane recommendation.
+
+## When To Use
+
+- A pull request, branch, or scheduled build failed and a downstream system
+  needs a grounded first classification.
+- The operator has enough log, commit, and repository-state evidence to decide
+  whether the next governed step should be retry, infra observation, or issue
+  intake.
+- The caller needs a stable `runx.ci.triage.v1` packet for later review.
+
+## When Not To Use
+
+- To rerun CI, change build settings, open issues, post comments, page humans,
+  merge code, or otherwise perform an effect.
+- To classify from a screenshot, short status badge, or missing/truncated log
+  that cannot support the requested confidence threshold.
+- To infer a root cause from project history, maintainer intent, or unstated
+  repository facts not supplied in the inputs.
+
+## Inputs
+
+- `ci_failure`: object containing:
+  - `logs`: raw or summarized CI log evidence.
+  - `commit`: commit SHA, title, changed files, or relevant diff summary.
+  - `repo_state`: branch, workflow name, matrix job, retry history, or current
+    repository state.
+- `repo_config`: CI provider, important commands, protected-branch policy,
+  known flaky jobs, owned paths, or routing lanes.
+- `escalation_policy`: object containing `min_confidence` and any lane
+  constraints.
+
+## Output
+
+Emit `triage_packet` using schema `runx.ci.triage.v1`:
+
+```yaml
+triage_packet:
+  schema: runx.ci.triage.v1
+  classification:
+    verdict: flake | infra | real-break | dep
+    confidence: number
+    evidence_refs: array
+  read_only_rerun_verdict:
+    allowed: boolean
+    rationale: string
+  read_only_page_note:
+    target: string
+    rationale: string
+  routing_decision:
+    recommended_lane: issue-intake | issue-to-pr | pr-review-note | hold
+    rationale: string
+  handoff:
+    seam: dispatch-by-naming
+    downstream_candidates: array
+  refusals: array
+```
+
+Exactly one of `read_only_rerun_verdict`, `read_only_page_note`, or
+`routing_decision` should be populated. The packet must include cited evidence
+refs for each material claim. Do not include a mint request, attenuation
+request, or any effect authorization.
+
+## Procedure
+
+1. Parse the failure logs first. Treat logs as the highest-signal source and
+   cite stable snippets, step names, file paths, or exit codes.
+2. Compare log evidence with commit and repo state. Do not attribute a root
+   cause to changed files unless the supplied evidence links them.
+3. Apply the classification taxonomy:
+   - flake: transient job/runner/network symptoms with no deterministic code
+     failure.
+   - infra: external service, runner, cache, secret, quota, or environment
+     break outside the change surface.
+   - real-break: deterministic compile, type, test, lint, build, or contract
+     failure visible in the supplied evidence.
+   - dep: dependency or toolchain resolution/version failure visible in the
+     supplied evidence.
+4. Estimate confidence from directness, specificity, repeatability, and
+   completeness of the evidence.
+5. If confidence is below `escalation_policy.min_confidence`, or if logs are
+   truncated before the failing command, stop with `needs_agent` and name the
+   missing evidence.
+6. Emit the read-only packet for a downstream governed run. The venue or driver
+   dispatches that later run by name; this skill never starts it.
+
+## Stop Conditions
+
+Return `needs_agent` when:
+
+- logs are truncated, missing, contradictory, or too generic;
+- the proposed verdict would require repository facts not supplied in the
+  inputs;
+- confidence is below `escalation_policy.min_confidence`;
+- the caller asks the skill to rerun CI, open an issue or PR, page an operator,
+  mutate a repository, or claim a lane effect;
+- more than one action family would need to be populated.
+
+## Harness Coverage
+
+The harness declares exactly two cases:
+
+- `real_break_clear_logs`: a clear TypeScript compile error seals as
+  `real-break` with a routing decision recommending `issue-to-pr`.
+- `ambiguous_truncated_logs`: a truncated log cannot support the minimum
+  confidence and stops with `needs_agent`.

--- a/skills/ci-failure-triage/X.yaml
+++ b/skills/ci-failure-triage/X.yaml
@@ -1,0 +1,164 @@
+skill: ci-failure-triage
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: context
+
+runx:
+  category: code
+  mutating: false
+  idempotency:
+    key: ci_failure.commit.sha
+  policy:
+    reads:
+      - supplied CI logs
+      - supplied commit metadata
+      - supplied repository state
+      - supplied CI configuration context
+    disallows:
+      - rerunning CI
+      - opening issues or pull requests
+      - posting comments
+      - paging operators
+      - mutating repositories
+      - inventing root causes or lane recommendations
+    verifier_notes:
+      - The packet is a read-only draft routing decision.
+      - Downstream issue-intake, issue-to-pr, or pr-review-note runs must be dispatched separately.
+  artifacts:
+    emits:
+      - triage_packet
+
+harness:
+  cases:
+    - name: real_break_clear_logs
+      runner: triage
+      inputs:
+        ci_failure:
+          logs: |
+            job: test / typecheck
+            command: pnpm typecheck
+            src/workflows/issue-intake.ts(42,19): error TS2339: Property 'title' does not exist on type 'IssuePayload'.
+            src/workflows/issue-intake.ts(42,19): error TS2339: Property 'title' does not exist on type 'IssuePayload'.
+            error Command failed with exit code 2.
+          commit:
+            sha: 4d2c9a7
+            message: refactor issue intake payload parsing
+            changed_files:
+              - src/workflows/issue-intake.ts
+              - src/workflows/issue-payload.ts
+          repo_state:
+            repository: runxhq/runx
+            branch: ci-payload-refactor
+            workflow: pull-request
+            job: test / typecheck
+            retry_history:
+              attempts: 2
+              same_failure: true
+        repo_config:
+          ci_provider: github-actions
+          protected_branch: main
+          known_flaky_jobs:
+            - e2e/browser
+          downstream_lanes:
+            - issue-intake
+            - issue-to-pr
+            - pr-review-note
+        escalation_policy:
+          min_confidence: 0.8
+      caller:
+        answers:
+          agent_task.ci-failure-triage.output:
+            triage_packet:
+              schema: runx.ci.triage.v1
+              classification:
+                verdict: real-break
+                confidence: 0.94
+                evidence_refs:
+                  - log:typecheck:TS2339:src/workflows/issue-intake.ts:42
+                  - commit:4d2c9a7:changed_files:src/workflows/issue-intake.ts
+                  - repo_state:retry_history:same_failure
+              routing_decision:
+                recommended_lane: issue-to-pr
+                rationale: The same deterministic type error appears on repeated attempts and points at a changed source file, so a downstream governed issue-to-pr lane is appropriate.
+              handoff:
+                seam: dispatch-by-naming
+                downstream_candidates:
+                  - issue-intake
+                  - issue-to-pr
+                  - pr-review-note
+              read_only:
+                reran_ci: false
+                opened_tracking_item: false
+                paged_operator: false
+              refusal_reason: null
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: ambiguous_truncated_logs
+      runner: triage
+      inputs:
+        ci_failure:
+          logs: |
+            job: test / linux
+            command: pnpm test
+            ...
+            output truncated after 4096 bytes
+          commit:
+            sha: 9ac781d
+            message: update workflow fixtures
+            changed_files:
+              - tests/workflow-fixtures.test.ts
+          repo_state:
+            repository: runxhq/runx
+            branch: workflow-fixture-update
+            workflow: pull-request
+            job: test / linux
+            retry_history:
+              attempts: 1
+              same_failure: null
+        repo_config:
+          ci_provider: github-actions
+          protected_branch: main
+          known_flaky_jobs:
+            - test / linux
+          downstream_lanes:
+            - issue-intake
+            - issue-to-pr
+            - pr-review-note
+        escalation_policy:
+          min_confidence: 0.8
+      expect:
+        status: needs_agent
+
+runners:
+  triage:
+    default: true
+    type: agent-task
+    agent: incident-analyst
+    task: ci-failure-triage
+    outputs:
+      triage_packet: object
+    artifacts:
+      wrap_as: ci_failure_triage_packet
+      packet: runx.ci.triage.v1
+    runx:
+      category: code
+    inputs:
+      ci_failure:
+        type: json
+        required: true
+        description: CI failure packet with logs, commit metadata, and repo_state.
+      repo_config:
+        type: json
+        required: true
+        description: Repository CI configuration, known flakes, and available downstream lanes.
+      escalation_policy:
+        type: json
+        required: true
+        description: Minimum confidence and refusal constraints for routing.

--- a/skills/ci-failure-triage/fixtures/ambiguous_truncated_logs.yaml
+++ b/skills/ci-failure-triage/fixtures/ambiguous_truncated_logs.yaml
@@ -1,0 +1,41 @@
+name: ambiguous_truncated_logs
+kind: skill
+target: ..
+runner: triage
+inputs:
+  ci_failure:
+    logs: |
+      job: test / linux
+      command: pnpm test
+      ...
+      output truncated after 4096 bytes
+    commit:
+      sha: 9ac781d
+      message: update workflow fixtures
+      changed_files:
+        - tests/workflow-fixtures.test.ts
+    repo_state:
+      repository: runxhq/runx
+      branch: workflow-fixture-update
+      workflow: pull-request
+      job: test / linux
+      retry_history:
+        attempts: 1
+        same_failure: null
+  repo_config:
+    ci_provider: github-actions
+    protected_branch: main
+    known_flaky_jobs:
+      - test / linux
+    downstream_lanes:
+      - issue-intake
+      - issue-to-pr
+      - pr-review-note
+  escalation_policy:
+    min_confidence: 0.8
+expect:
+  status: needs_agent
+metadata:
+  public_skill: ci-failure-triage
+  source_case: ambiguous_truncated_logs
+  source: skills-fixture

--- a/skills/ci-failure-triage/fixtures/harness-evidence.md
+++ b/skills/ci-failure-triage/fixtures/harness-evidence.md
@@ -1,0 +1,41 @@
+# ci-failure-triage Harness Evidence
+
+Validated locally with the published `runx` CLI required by Frantic.
+
+```bash
+pnpm dlx @runxhq/cli@0.6.13 --version
+```
+
+Output:
+
+```text
+runx-cli 0.6.13
+```
+
+Harness command:
+
+```bash
+RUNX_RECEIPT_SIGN_KID=ci-failure-triage-test-key \
+RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=<redacted test seed> \
+RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted \
+pnpm dlx @runxhq/cli@0.6.13 harness ./skills/ci-failure-triage --json
+```
+
+Result:
+
+```json
+{
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "assertion_errors": [],
+  "case_names": [
+    "real_break_clear_logs",
+    "ambiguous_truncated_logs"
+  ],
+  "receipt_ids": [
+    "sha256:7755badf3297aa9402481ba47575a580c8ab76833acb04e273b1fd6352f4e727"
+  ],
+  "graph_case_count": 0
+}
+```

--- a/skills/ci-failure-triage/fixtures/real_break_clear_logs.yaml
+++ b/skills/ci-failure-triage/fixtures/real_break_clear_logs.yaml
@@ -1,0 +1,71 @@
+name: real_break_clear_logs
+kind: skill
+target: ..
+runner: triage
+inputs:
+  ci_failure:
+    logs: |
+      job: test / typecheck
+      command: pnpm typecheck
+      src/workflows/issue-intake.ts(42,19): error TS2339: Property 'title' does not exist on type 'IssuePayload'.
+      src/workflows/issue-intake.ts(42,19): error TS2339: Property 'title' does not exist on type 'IssuePayload'.
+      error Command failed with exit code 2.
+    commit:
+      sha: 4d2c9a7
+      message: refactor issue intake payload parsing
+      changed_files:
+        - src/workflows/issue-intake.ts
+        - src/workflows/issue-payload.ts
+    repo_state:
+      repository: runxhq/runx
+      branch: ci-payload-refactor
+      workflow: pull-request
+      job: test / typecheck
+      retry_history:
+        attempts: 2
+        same_failure: true
+  repo_config:
+    ci_provider: github-actions
+    protected_branch: main
+    known_flaky_jobs:
+      - e2e/browser
+    downstream_lanes:
+      - issue-intake
+      - issue-to-pr
+      - pr-review-note
+  escalation_policy:
+    min_confidence: 0.8
+caller:
+  answers:
+    agent_task.ci-failure-triage.output:
+      triage_packet:
+        schema: runx.ci.triage.v1
+        classification:
+          verdict: real-break
+          confidence: 0.94
+          evidence_refs:
+            - log:typecheck:TS2339:src/workflows/issue-intake.ts:42
+            - commit:4d2c9a7:changed_files:src/workflows/issue-intake.ts
+            - repo_state:retry_history:same_failure
+        routing_decision:
+          recommended_lane: issue-to-pr
+          rationale: The same deterministic type error appears on repeated attempts and points at a changed source file, so a downstream governed issue-to-pr lane is appropriate.
+        handoff:
+          seam: dispatch-by-naming
+          downstream_candidates:
+            - issue-intake
+            - issue-to-pr
+            - pr-review-note
+        read_only:
+          reran_ci: false
+          opened_tracking_item: false
+          paged_operator: false
+        refusal_reason: null
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+metadata:
+  public_skill: ci-failure-triage
+  source_case: real_break_clear_logs
+  source: skills-fixture


### PR DESCRIPTION
## Summary

Adds a focused `ci-failure-triage` official skill for Frantic bounty #61.

Refs:
- https://github.com/auscaster/frantic-board/issues/161
- https://gofrantic.com/bounties/61

## Problem

The bounty asks for a runx skill that classifies CI failures as flake, infra, real break, or dependency break and emits a governed triage packet. The skill should not take operational action, and ambiguous or truncated logs need to stop rather than over-classify.

## Fix

- Adds `skills/ci-failure-triage/SKILL.md` with the operator-facing triage workflow.
- Adds `skills/ci-failure-triage/X.yaml` with the typed input/output contract and two harness cases.
- Adds fixtures for `real_break_clear_logs` and `ambiguous_truncated_logs`.
- Refreshes the official skill catalog lock files so the skill is discoverable.

## Tests

QA approved this branch at commit `540902bd1a712d8744adaea2fda9b97a74e8318f` with these checks:

- `pnpm dlx @runxhq/cli@0.6.13 --version` -> `runx-cli 0.6.13`
- `RUNX_RECEIPT_SIGN_KID=ci-failure-triage-qa-key RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=<demo seed> RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted pnpm dlx @runxhq/cli@0.6.13 harness ./skills/ci-failure-triage --json` -> passed, 2 cases, 0 assertion errors
- `RUNX_RUST_CLI_BIN=$PWD/crates/target/debug/runx RUNX_KERNEL_EVAL_BIN=$PWD/crates/target/debug/runx RUNX_DEV_RUST_CLI_BIN=$PWD/crates/target/debug/runx RUNX_RECEIPT_SIGN_KID=official-skill-catalog-qa-key RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=<demo seed> RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted pnpm vitest run tests/official-skill-catalog.test.ts tests/skill-search.test.ts` -> passed, 12/12
- `RUNX_RUST_CLI_BIN=$PWD/crates/target/debug/runx RUNX_KERNEL_EVAL_BIN=$PWD/crates/target/debug/runx RUNX_DEV_RUST_CLI_BIN=$PWD/crates/target/debug/runx RUNX_RECEIPT_SIGN_KID=test-fast-qa-key RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=<demo seed> RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted pnpm test:fast` -> passed, 28 files, 277 tests
- `pnpm typecheck` -> passed
- `pnpm build` -> passed
- `cargo check --manifest-path crates/Cargo.toml -p runx-cli` -> passed
- `git diff --check main...HEAD` -> passed

## Risk Notes

Risk is limited to a new isolated skill package plus catalog registration. The skill is designed to summarize and classify evidence only; it does not rerun jobs, open issues, merge code, page responders, or mutate external systems.

## Maintainer Attention

The ambiguous/truncated-log fixture intentionally returns `needs_agent` instead of forcing a classification. I did not submit a Frantic delivery packet or claim request from this PR.
