### PR TITLE
feat: add renewal risk judge skill

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -251,6 +251,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "20b8f78fee305165f010e501d5349897a384f323a1b98dbef864dbbc763c5a07",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/renewal-risk-judge",
+        version: "sha-e3e8a540f3cc",
+        digest: "fbe8ca17987b2e8998693036e268cd797f201ab6e186631fb61fb1d57113443c",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/research",
         version: "sha-65df55554027",
         digest: "4c729e750abddc00379902686439d90965e7c593b6bcb3606ef7e0bc66cecd66",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -336,6 +336,13 @@
     "catalog_role": "context"
   },
   {
+    "skill_id": "runx/renewal-risk-judge",
+    "version": "sha-e3e8a540f3cc",
+    "digest": "fbe8ca17987b2e8998693036e268cd797f201ab6e186631fb61fb1d57113443c",
+    "catalog_visibility": "public",
+    "catalog_role": "canonical"
+  },
+  {
     "skill_id": "runx/research",
     "version": "sha-65df55554027",
     "digest": "4c729e750abddc00379902686439d90965e7c593b6bcb3606ef7e0bc66cecd66",

--- a/skills/renewal-risk-judge/SKILL.md
+++ b/skills/renewal-risk-judge/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: renewal-risk-judge
+description: Judge renewal risk from sealed usage, support, and payment signals, then emit a read-only save-plan recommendation when warranted.
+runx:
+  category: ops
+---
+
+# Renewal Risk Judge
+
+## What this skill does
+
+`renewal-risk-judge` fuses three bounded inputs for one renewing account:
+usage signals, support history, and a payment snapshot. It emits one
+`runx.support.renewal_risk.v1` decision packet with a risk level, justification,
+signal weights, escalation path, and, only for high or critical risk, a bounded
+save-message plan.
+
+The skill is read-only over money and delivery. It does not quote prices, apply
+discounts, mutate billing, touch payment rails, send a message, or trigger a
+provider action. The save plan is data for a separate governed `send-as` lane
+that must run under its own authority and human approval.
+
+## When to use this skill
+
+Use this skill when an operator, support workflow, or renewal operations graph
+has receipt-backed signals for one account and needs a trustworthy renewal-risk
+verdict before deciding whether to prepare a save message.
+
+Good inputs are current, sealed, and account-scoped:
+
+- `usage_signals` with `trend` and `mau_pct_change`
+- `support_history` with `volume` and `ticket_severity_avg`
+- `payment_snapshot` with `days_late` and `churn_flag`
+- optional `operator_context` with policy, approval, or content reference rules
+
+## When not to use this skill
+
+Do not use this skill to send retention messages, apply discounts, approve
+refunds, change subscription state, change a price, charge a payment method, or
+make promises to the customer. Do not run it when the usage trend is missing or
+when the supplied signals contradict each other in a way that prevents a
+grounded verdict.
+
+If the account needs an actual message, hand the emitted save plan to a
+separate governed `send-as` run. If the account needs a commercial concession,
+billing mutation, or live outreach, stop for the appropriate human approval and
+provider-specific lane.
+
+## Procedure
+
+1. Confirm that the account scope is one bounded renewal decision and that all
+   inputs describe the same account and renewal window.
+2. Require `usage_signals.trend` and `usage_signals.mau_pct_change`. Without
+   usage trend data, return a refused packet and do not emit `save_plan`.
+3. Normalize support pressure from `support_history.volume` and
+   `support_history.ticket_severity_avg`.
+4. Normalize payment pressure from `payment_snapshot.days_late` and
+   `payment_snapshot.churn_flag`.
+5. Refuse contradictory signals when usage shows decline but payment shows no
+   lateness, no churn flag, and no other risk evidence.
+6. Compute a fused score with explicit weights:
+   usage trend `0.50`, support pressure `0.25`, payment pressure `0.25`.
+7. Map the fused score to `low`, `moderate`, `high`, or `critical`.
+8. For `high` or `critical`, emit one bounded `save_plan` with `channel`,
+   `audience`, and `content_ref`. The plan may name message content only; it
+   must not include amount, currency, counterparty, discount, quote, or send
+   authorization.
+9. For `moderate` or ambiguous edge cases, route to human approval with no
+   send-as dispatch.
+10. Record evidence refs, signal weights, missing signals, and the approval
+    posture in the packet so the receipt is auditable.
+
+## Edge cases and stop conditions
+
+- Missing `usage_signals`, `usage_signals.trend`, or
+  `usage_signals.mau_pct_change`: return `status: refused`, name the missing
+  signal, and omit `save_plan`.
+- Missing support or payment inputs: return `needs_input` or route to manual
+  review rather than inventing pressure.
+- Contradictory evidence: refuse to verdict when usage suggests decline but the
+  payment snapshot and support history show no corroborating risk.
+- Requested discount, quote, credit, payment action, or live send: refuse that
+  action and keep the packet recommendation-only.
+- Missing or mutable `content_ref`: for high-risk accounts, stop with no
+  dispatch-ready save plan until the content is digest-bound.
+- Raw customer data, secrets, tokens, or payment material: redact or replace
+  with stable refs. Do not put private material in the packet.
+
+## Output schema
+
+The runner emits `renewal_risk` as `runx.support.renewal_risk.v1`:
+
+```yaml
+schema: runx.support.renewal_risk.v1
+status: verdict | refused | needs_input
+account_ref: string
+decision:
+  risk_level: low | moderate | high | critical | null
+  justification: string
+score:
+  fused: number | null
+  weights:
+    usage_trend: 0.5
+    support_pressure: 0.25
+    payment_pressure: 0.25
+  components:
+    usage_trend: number | null
+    support_pressure: number | null
+    payment_pressure: number | null
+escalation:
+  route: none | human_approval | data_quality_review
+  approval_required: boolean
+  downstream_lane: send-as | null
+save_plan:
+  channel: email | support_thread | chat
+  audience: account_owner | renewal_owner | support_owner
+  content_ref: string
+refusal:
+  reason: string
+  missing_signals: [string]
+evidence_refs: [string]
+```
+
+`save_plan` is present only when `decision.risk_level` is `high` or `critical`
+and the content reference is stable. The packet must never include price,
+discount, amount, currency, counterparty, payment rail, provider token, or a
+send authorization.
+
+## Worked example
+
+High-risk input:
+
+```yaml
+usage_signals:
+  trend: declining
+  mau_pct_change: -42
+support_history:
+  volume: 18
+  ticket_severity_avg: 4.4
+payment_snapshot:
+  days_late: 17
+  churn_flag: true
+```
+
+Expected result: `status: verdict`, `decision.risk_level: high`, a fused score
+with the three signal weights, `escalation.downstream_lane: send-as`, and one
+bounded `save_plan` that names only channel, audience, and `content_ref`.
+
+Missing usage trend input:
+
+```yaml
+support_history:
+  volume: 8
+  ticket_severity_avg: 3.1
+payment_snapshot:
+  days_late: 9
+  churn_flag: false
+```
+
+Expected result: `status: refused`, `decision.risk_level: null`,
+`refusal.reason: missing_usage_signals`, and no `save_plan`.
+
+## Inputs
+
+- `account_ref` (optional): stable account or renewal reference.
+- `usage_signals` (required for verdict): object with `trend` and
+  `mau_pct_change`.
+- `support_history` (required): object with `volume` and
+  `ticket_severity_avg`.
+- `payment_snapshot` (required): object with `days_late` and `churn_flag`.
+- `operator_context` (optional): approval posture, content reference policy, or
+  downstream send-as constraints.
+
+## Outputs
+
+- `renewal_risk`: one `runx.support.renewal_risk.v1` packet containing the
+  grounded verdict or refusal.

--- a/skills/renewal-risk-judge/X.yaml
+++ b/skills/renewal-risk-judge/X.yaml
@@ -1,0 +1,41 @@
+skill: renewal-risk-judge
+version: "0.1.0"
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+runners:
+  judge:
+    default: true
+    type: agent-task
+    agent: reviewer
+    task: renewal-risk-judge
+    outputs:
+      renewal_risk: object
+    artifacts:
+      wrap_as: renewal_risk_packet
+      packet: runx.support.renewal_risk.v1
+    runx:
+      category: ops
+    inputs:
+      account_ref:
+        type: string
+        required: false
+        description: Stable account or renewal reference.
+      usage_signals:
+        type: json
+        required: false
+        description: Usage trend evidence with trend and mau_pct_change. Required for any verdict.
+      support_history:
+        type: json
+        required: true
+        description: Support pressure evidence with volume and ticket_severity_avg.
+      payment_snapshot:
+        type: json
+        required: true
+        description: Payment risk evidence with days_late and churn_flag.
+      operator_context:
+        type: json
+        required: false
+        description: Approval posture, content reference policy, and downstream send-as constraints.

--- a/skills/renewal-risk-judge/fixtures/high-risk-with-save-play.yaml
+++ b/skills/renewal-risk-judge/fixtures/high-risk-with-save-play.yaml
@@ -1,0 +1,62 @@
+name: high-risk-with-save-play
+kind: skill
+target: ..
+runner: judge
+inputs:
+  account_ref: acct_renewal_1042
+  usage_signals:
+    trend: declining
+    mau_pct_change: -42
+  support_history:
+    volume: 18
+    ticket_severity_avg: 4.4
+  payment_snapshot:
+    days_late: 17
+    churn_flag: true
+  operator_context:
+    content_ref_policy: digest-bound message content only
+    delivery: separate governed send-as run with human approval
+caller:
+  answers:
+    agent_task.renewal-risk-judge.output:
+      renewal_risk:
+        schema: runx.support.renewal_risk.v1
+        status: verdict
+        account_ref: acct_renewal_1042
+        decision:
+          risk_level: high
+          justification: Usage declined 42%, support volume and severity are high, and the account is 17 days late with churn flagged.
+        score:
+          fused: 0.86
+          weights:
+            usage_trend: 0.5
+            support_pressure: 0.25
+            payment_pressure: 0.25
+          components:
+            usage_trend: 0.9
+            support_pressure: 0.82
+            payment_pressure: 0.82
+        escalation:
+          route: human_approval
+          approval_required: true
+          downstream_lane: send-as
+          dispatch_name: send-as:renewal-risk-save-play
+        save_plan:
+          channel: email
+          audience: account_owner
+          content_ref: content:renewal-save-play:v1:sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        refusal: null
+        evidence_refs:
+          - usage_signals:sealed:acct_renewal_1042
+          - support_history:sealed:acct_renewal_1042
+          - payment_snapshot:sealed:acct_renewal_1042
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: renewal-risk-judge
+  source_case: high-risk-with-save-play
+  source: skills-fixture

--- a/skills/renewal-risk-judge/fixtures/missing-usage-signals-stop.yaml
+++ b/skills/renewal-risk-judge/fixtures/missing-usage-signals-stop.yaml
@@ -1,0 +1,56 @@
+name: missing-usage-signals-stop
+kind: skill
+target: ..
+runner: judge
+inputs:
+  account_ref: acct_renewal_2048
+  support_history:
+    volume: 8
+    ticket_severity_avg: 3.1
+  payment_snapshot:
+    days_late: 9
+    churn_flag: false
+  operator_context:
+    delivery: separate governed send-as run with human approval
+caller:
+  answers:
+    agent_task.renewal-risk-judge.output:
+      renewal_risk:
+        schema: runx.support.renewal_risk.v1
+        status: refused
+        account_ref: acct_renewal_2048
+        decision:
+          risk_level: null
+          justification: Renewal risk was not judged because usage trend data is missing.
+        score:
+          fused: null
+          weights:
+            usage_trend: 0.5
+            support_pressure: 0.25
+            payment_pressure: 0.25
+          components:
+            usage_trend: null
+            support_pressure: 0.46
+            payment_pressure: 0.28
+        escalation:
+          route: data_quality_review
+          approval_required: false
+          downstream_lane: null
+        refusal:
+          reason: missing_usage_signals
+          missing_signals:
+            - usage_signals.trend
+            - usage_signals.mau_pct_change
+        evidence_refs:
+          - support_history:sealed:acct_renewal_2048
+          - payment_snapshot:sealed:acct_renewal_2048
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: renewal-risk-judge
+  source_case: missing-usage-signals-stop
+  source: skills-fixture


### PR DESCRIPTION
## Summary

- Adds the official `runx/renewal-risk-judge` skill package for Frantic bounty #63.
- Replaces the previous dirty PR branch with the QA-approved clean repair commit `8dcc2294a3b12960b1ff6e919ddf53f3f4f9aa02`.
- Current review scope is one commit, 6 files, and `+348/-0`.

Links:
- Bounty issue: https://github.com/auscaster/frantic-board/issues/163
- Bounty proof: https://gofrantic.com/bounties/63

## Problem

The official skill catalog did not include a `renewal-risk-judge` package. The bounty asks for a read-only renewal-risk judge that evaluates usage, support, payment, and operator context signals, with evidence for a high-risk save-play path and a missing-usage-signals refusal path.

## Fix

- Adds `skills/renewal-risk-judge/SKILL.md` with the skill behavior, boundaries, inputs, outputs, and validation notes.
- Adds `skills/renewal-risk-judge/X.yaml` with a typed `agent-task` runner.
- Adds standalone fixture files for `high-risk-with-save-play` and `missing-usage-signals-stop`.
- Registers `runx/renewal-risk-judge` in the Rust and npm official skill catalog locks.

The skill is read-only. It does not apply discounts, quote prices, send messages, touch payment rails, publish packages, or change payout/KYC/tax/profile state.

## Validation

QA approved the clean repair candidate at `8dcc2294a3b12960b1ff6e919ddf53f3f4f9aa02`.

Commands and checks reviewed:
- `pnpm install --frozen-lockfile`
- `cargo build --manifest-path crates/Cargo.toml -p runx-cli`
- `pnpm bindings:check`
- JSON/YAML validation for `packages/cli/src/official-skills.lock.json`, `skills/renewal-risk-judge/X.yaml`, and both fixture files
- Official catalog entry assertion for the Node lockfile and Rust embedded list
- `runx harness skills/renewal-risk-judge/fixtures/high-risk-with-save-play.yaml --json`
- `runx harness skills/renewal-risk-judge/fixtures/missing-usage-signals-stop.yaml --json`
- `git diff --check origin/main...HEAD`
- Git identity verification for `Rajesh Digambar Bagul <102693488+Rajesh270712@users.noreply.github.com>`
- GitHub commit attribution check: author and committer both map to `Rajesh270712`

Known baseline limitation:
- `RUNX_RUST_CLI_BIN=... RUNX_KERNEL_EVAL_BIN=... pnpm vitest run tests/official-skill-catalog.test.ts` still fails on unrelated upstream catalog surfaces: `agency` has an inline harness and `ledger` is missing the standalone `read` fixture. `renewal-risk-judge` was not named in those failures.

## Risks / Limitations

- Full catalog test pass is not claimed because of the unrelated `agency`/`ledger` baseline failures above.
- Frantic delivery/claim is not complete just because this PR is open. It still needs the appropriate post-PR delivery/verification path after maintainer acceptance.
- Local harness fixture names use hyphens; delivery artifacts can map them to the bounty's underscore labels if needed.
