### PR TITLE
Add oncall alert triage skill

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -196,6 +196,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "382cdef84f660e7cfdc2dbbfd7e8382d204d1f4ee46ffa019549615f9c2f745c",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/oncall-alert-triage",
+        version: "sha-d833f21279a7",
+        digest: "2c1d1c260809f0f7e20b4f74b34f59fa3813197c2deccb1e4bd8ab8bfd61c752",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/open-meteo-weather-forecast",
         version: "sha-5d9f95438c9a",
         digest: "041e0ec18fa4b646b46b72d34662eabbbfbc43ab5a3a65423b49b3e94e81d159",

--- a/dist/packets/oncall.triage.v1.schema.json
+++ b/dist/packets/oncall.triage.v1.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.runx.dev/runx/oncall/triage/v1.json",
+  "x-runx-packet-id": "runx.oncall.triage.v1",
+  "type": "object",
+  "properties": {
+    "decision": { "type": "object", "additionalProperties": true },
+    "page_target": { "type": "string" },
+    "incident_pr_target": { "type": "string" },
+    "pr_review_note_body": { "type": "string" },
+    "fix_bundle": { "type": "object", "additionalProperties": true },
+    "escalation": { "type": "object", "additionalProperties": true },
+    "source_url": { "type": "string" },
+    "evidence_json": { "type": "object", "additionalProperties": true },
+    "report": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -259,6 +259,13 @@
     "catalog_role": "branded"
   },
   {
+    "skill_id": "runx/oncall-alert-triage",
+    "version": "sha-d833f21279a7",
+    "digest": "2c1d1c260809f0f7e20b4f74b34f59fa3813197c2deccb1e4bd8ab8bfd61c752",
+    "catalog_visibility": "public",
+    "catalog_role": "canonical"
+  },
+  {
     "skill_id": "runx/open-meteo-weather-forecast",
     "version": "sha-5d9f95438c9a",
     "digest": "041e0ec18fa4b646b46b72d34662eabbbfbc43ab5a3a65423b49b3e94e81d159",

--- a/skills/oncall-alert-triage/SKILL.md
+++ b/skills/oncall-alert-triage/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: oncall-alert-triage
+description: Classify a sealed on-call alert into a read-only triage packet for downstream incident lanes.
+runx:
+  category: ops
+---
+
+# Oncall Alert Triage
+
+## What this skill does
+
+Classify one pager alert against a sealed runbook and service on-call policy.
+When the alert is eligible for downstream action, emit exactly one
+`runx.oncall.triage.v1` packet that names the action, sealed runbook digest,
+policy clauses applied, page target, incident PR target, and review-note body.
+
+The skill performs a thin `review` act only. It never pages anyone, opens a PR,
+posts a comment, applies a fix, mints authority, or runs a downstream lane.
+Downstream drivers may consume the packet by name under their own authority,
+gate, and receipt policy.
+
+## When to use this skill
+
+Use this skill when an operator or governed workflow has:
+
+- a pager alert with `id`, `service`, `severity`, and `signal`;
+- a runbook reference with a seal state and digest;
+- an on-call policy declaring the service and escalation rules;
+- an operator-safe `source_url` for provenance; and
+- a need to separate triage judgment from page, PR, comment, or remediation
+  effects.
+
+## When not to use this skill
+
+Do not use this skill to execute incident effects. Do not use it when the
+service is undeclared, the runbook is missing or unsealed, a page target or
+incident PR target cannot be bound for an eligible action, the requested action
+is outside policy, or the alert cannot be tied to the provided source.
+
+Return `needs_agent` rather than a packet when evidence is incomplete or unsafe.
+
+## Procedure
+
+1. Confirm the alert is tied to `source_url` and includes `id`, `service`,
+   `severity`, and `signal`.
+2. Confirm `oncall_policy.services` declares the alert service.
+3. Confirm `runbook_ref.sealed` is true and `runbook_ref.digest` is present.
+4. Match the alert to one policy clause and choose exactly one action:
+   `acknowledge`, `escalate`, `auto_remediate`, or `suppress`.
+5. For `escalate` or `auto_remediate`, bind both `page_target` and
+   `incident_pr_target` before emitting a packet.
+6. Record the sealed runbook digest in `decision.reason`,
+   `triage_packet.runbook.digest`, and
+   `evidence_json.observations.sealed_runbook_digest`.
+7. Return `decision`, `escalation`, `triage_packet`, `evidence_json`,
+   `verification_json`, `report`, and `reason`.
+
+## Edge cases and stop conditions
+
+- Unknown service: return `needs_agent` and do not emit a packet.
+- Missing or unsealed runbook: return `needs_agent` and do not emit a packet.
+- Missing page target or incident PR target for `escalate` or
+  `auto_remediate`: return `needs_agent`.
+- Suppressed or acknowledged alert: return the decision and evidence, but do
+  not emit a dispatch packet.
+- Attempted page, PR, comment, fix, authority mint, `AttenuationRequest`, or
+  nested downstream execution: return `needs_agent`.
+- Credential, token, private URL, raw pager secret, or contact identity data in
+  inputs: refuse to include it in output and stop for agent review.
+
+## Output schema
+
+Return a `triage_packet` only for `escalate` or `auto_remediate`:
+
+```json
+{
+  "schema": "runx.oncall.triage.v1",
+  "alert": {
+    "id": "alert-123",
+    "service": "checkout-api",
+    "severity": "sev2",
+    "signal": "5xx burn rate above policy"
+  },
+  "decision": {
+    "action": "escalate",
+    "reason": "checkout-api sev2 burn rate matches policy clause sev2-escalate and runbook digest sha256:..."
+  },
+  "runbook": {
+    "ref": "runbook://checkout-api/5xx-burn",
+    "digest": "sha256:..."
+  },
+  "policy_clauses_applied": ["sev2-escalate"],
+  "packet": {
+    "page_target": "oncall://payments-primary",
+    "incident_pr_target": "github://runxhq/runx/incidents/checkout-api-alert-123",
+    "pr_review_note_body": "Escalate checkout-api alert alert-123: sev2 burn rate over policy; sealed runbook sha256:...",
+    "fix_bundle": null
+  },
+  "dispatch": {
+    "mode": "by_name",
+    "downstream_runs": ["issue-to-pr", "pr-review-note", "send-as"]
+  }
+}
+```
+
+Also return:
+
+- `decision`: object with `action` and `reason`.
+- `escalation`: object naming the field, target, incident PR target, and human
+  gate when applicable.
+- `evidence_json`: machine-checkable observations including source URL, exact
+  alert fields, sealed runbook digest, policy clauses, harness case names,
+  receipt id when available, and inferred targets.
+- `verification_json`: checks for package name, no authority minted, no effect
+  executed, packet emission, and packet schema.
+- `report`: concise operator-facing summary.
+- `reason`: the receipt reason string.
+
+## Worked example
+
+An alert for `checkout-api` reports a `sev2` 5xx burn-rate signal. The service
+policy has clause `sev2-escalate`, and the sealed runbook digest is
+`sha256:6aaf...1a34`. Because both `oncall://payments-primary` and the incident
+PR target are bound, the skill returns `decision.action: escalate`, emits a
+`runx.oncall.triage.v1` packet, and reports that no page, PR, comment, or
+remediation was executed by this review-only run.
+
+If the same alert lacks a sealed runbook or uses an undeclared service, the
+skill returns `needs_agent` and emits no packet.
+
+## Inputs
+
+- `alert`: object with `id`, `service`, `severity`, and `signal`.
+- `runbook_ref`: object naming the runbook locator, `sealed` boolean, digest,
+  and any allowed remediation notes or bounded targets.
+- `oncall_policy`: object with declared services and escalation rules.
+- `source_url`: public or operator-safe URL for alert provenance.
+- Optional act metadata: `target_ref`, `authority_ref`, `actor_ref`,
+  `previous_receipt_ref`, and `act_decision`.

--- a/skills/oncall-alert-triage/X.yaml
+++ b/skills/oncall-alert-triage/X.yaml
@@ -1,0 +1,105 @@
+skill: oncall-alert-triage
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+
+runners:
+  triage:
+    default: true
+    type: graph
+    act:
+      form: review
+      purpose: Review a sealed on-call alert and emit a read-only triage packet only when policy and runbook evidence bind the route.
+      legitimacy: The graph holds review-only authority; downstream page, PR, comment, and remediation effects require separate governed runs.
+      target_from: target_ref
+      decision_from: act_decision
+      authority_from: authority_ref
+      actor_from: actor_ref
+      previous_from: previous_receipt_ref
+      reason_step: triage
+      reason_from: reason
+    inputs:
+      alert:
+        type: json
+        required: true
+        description: "Alert object with id, service, severity, and signal."
+      runbook_ref:
+        type: json
+        required: true
+        description: "Runbook locator, seal state, digest, and bounded targets."
+      oncall_policy:
+        type: json
+        required: true
+        description: "Declared service policy and escalation rules."
+      source_url:
+        type: string
+        required: true
+        description: "Public or operator-safe source URL for the alert context."
+      target_ref:
+        type: string
+        required: false
+        description: "Reference sealed into the review act as the target."
+      authority_ref:
+        type: string
+        required: false
+        description: "Review-only authority reference for the act receipt."
+      actor_ref:
+        type: string
+        required: false
+        description: "Principal reference for the reviewer."
+      previous_receipt_ref:
+        type: string
+        required: false
+        description: "Optional prior receipt this review chains from."
+      act_decision:
+        type: string
+        required: false
+        default: close
+        description: "Receipt decision choice for the review act."
+    graph:
+      name: oncall-alert-triage
+      steps:
+        - id: triage
+          label: review alert against sealed runbook and policy
+          run:
+            type: agent-task
+            agent: reviewer
+            task: oncall-alert-triage
+            outputs:
+              decision: object
+              escalation: object
+              triage_packet: object
+              evidence_json: object
+              verification_json: object
+              report: string
+              reason: string
+          instructions: >
+            Review the alert, runbook_ref, oncall_policy, and source_url. Return
+            needs_agent instead of a packet when the service is undeclared, the
+            runbook is missing or unsealed, an eligible action cannot bind both
+            page and incident PR targets, or the requested route would execute an
+            effect. For escalate or auto_remediate, emit exactly one
+            runx.oncall.triage.v1 triage_packet with page_target,
+            incident_pr_target, pr_review_note_body, optional fix_bundle,
+            sealed runbook digest, policy clauses applied, and dispatch-by-name
+            downstream_runs. Do not page, open a PR, post a comment, apply a
+            fix, mint authority, request AttenuationRequest, or consume the
+            packet as an effect in this graph.
+          allowed_tools:
+            - fs.read
+          scopes:
+            - runx:oncall:triage:review
+          inputs:
+            alert: "$input.alert"
+            runbook_ref: "$input.runbook_ref"
+            oncall_policy: "$input.oncall_policy"
+            source_url: "$input.source_url"
+          artifacts:
+            named_emits:
+              triage_packet: runx.oncall.triage.v1
+              evidence_json: runx.oncall.triage_evidence.v1
+              verification_json: runx.oncall.triage_verification.v1

--- a/skills/oncall-alert-triage/fixtures/sealed-escalate.yaml
+++ b/skills/oncall-alert-triage/fixtures/sealed-escalate.yaml
@@ -1,0 +1,110 @@
+name: oncall-alert-triage-sealed-escalate
+kind: skill
+target: ..
+runner: triage
+inputs:
+  target_ref: github://auscaster/frantic-board/issues/164
+  authority_ref: runx:grant:oncall-alert-triage:review-only
+  actor_ref: runx:principal:local_runtime
+  act_decision: close
+  source_url: https://gofrantic.com/bounties/64
+  alert:
+    id: pager-evt-2026-06-25-001
+    service: checkout-api
+    severity: sev2
+    signal: 5xx burn rate above threshold for 12 minutes
+  runbook_ref:
+    ref: runbook://checkout-api/5xx-burn-rate
+    sealed: true
+    digest: sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34
+    allowed_actions:
+      - escalate
+    page_target: oncall://payments-primary
+    incident_pr_target: github://runxhq/runx/incidents/checkout-api-pager-evt-2026-06-25-001
+    pr_review_note_body: "Escalate checkout-api alert pager-evt-2026-06-25-001: sev2 burn rate over policy; sealed runbook sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34."
+  oncall_policy:
+    services:
+      checkout-api:
+        page_target: oncall://payments-primary
+        incident_pr_target: github://runxhq/runx/incidents/checkout-api-pager-evt-2026-06-25-001
+    escalation_rules:
+      - id: sev2-escalate
+        service: checkout-api
+        severity: sev2
+        action: escalate
+        reason: Sustained 5xx burn rate requires human escalation.
+caller:
+  answers:
+    agent_task.oncall-alert-triage.output:
+      decision:
+        action: escalate
+        reason: checkout-api sev2 burn rate matches policy clause sev2-escalate and sealed runbook sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34.
+      escalation:
+        field: oncall
+        target: oncall://payments-primary
+        incident_pr_target: github://runxhq/runx/incidents/checkout-api-pager-evt-2026-06-25-001
+        human_gate: true
+      triage_packet:
+        schema: runx.oncall.triage.v1
+        alert:
+          id: pager-evt-2026-06-25-001
+          service: checkout-api
+          severity: sev2
+          signal: 5xx burn rate above threshold for 12 minutes
+        decision:
+          action: escalate
+          reason: checkout-api sev2 burn rate matches policy clause sev2-escalate and sealed runbook sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34.
+        runbook:
+          ref: runbook://checkout-api/5xx-burn-rate
+          digest: sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34
+        policy_clauses_applied:
+          - sev2-escalate
+        packet:
+          page_target: oncall://payments-primary
+          incident_pr_target: github://runxhq/runx/incidents/checkout-api-pager-evt-2026-06-25-001
+          pr_review_note_body: "Escalate checkout-api alert pager-evt-2026-06-25-001: sev2 burn rate over policy; sealed runbook sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34."
+          fix_bundle: null
+        dispatch:
+          mode: by_name
+          downstream_runs:
+            - issue-to-pr
+            - pr-review-note
+            - send-as
+      evidence_json:
+        schema: runx.oncall.triage_evidence.v1
+        observations:
+          runx_version: captured by the caller environment
+          source_url: https://gofrantic.com/bounties/64
+          decision_action: escalate
+          decision_reason: checkout-api sev2 burn rate matches policy clause sev2-escalate and sealed runbook digest.
+          sealed_runbook_digest: sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34
+          policy_clauses_applied:
+            - sev2-escalate
+          packet_targets:
+            page_target: oncall://payments-primary
+            incident_pr_target: github://runxhq/runx/incidents/checkout-api-pager-evt-2026-06-25-001
+          harness_cases:
+            - oncall-alert-triage-sealed-escalate
+            - oncall-alert-triage-unsealed-runbook-stops
+          receipt_id: runx:harness:pending
+      verification_json:
+        schema: runx.oncall.triage_verification.v1
+        verdict: sealed
+        checks:
+          package_name: oncall-alert-triage
+          no_authority_minted: true
+          no_effect_executed: true
+          packet_emitted: true
+          packet_schema: runx.oncall.triage.v1
+      report: "Escalate checkout-api alert pager-evt-2026-06-25-001. The sealed runbook digest and policy clause sev2-escalate bind the page and incident PR targets; no page, PR, comment, or remediation is executed by this skill."
+      reason: checkout-api sev2 burn rate matches policy clause sev2-escalate and sealed runbook sha256:6aaf7d5d3d1bf6d1b3e02f4fd6f19fc37fbc0d4f6d78ce5f9915d5f4b96d1a34.
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: oncall-alert-triage
+  source_case: oncall-alert-triage-sealed-escalate
+  source: skills-fixture

--- a/skills/oncall-alert-triage/fixtures/unsealed-runbook-stops.yaml
+++ b/skills/oncall-alert-triage/fixtures/unsealed-runbook-stops.yaml
@@ -1,0 +1,34 @@
+name: oncall-alert-triage-unsealed-runbook-stops
+kind: skill
+target: ..
+runner: triage
+inputs:
+  target_ref: github://auscaster/frantic-board/issues/164
+  authority_ref: runx:grant:oncall-alert-triage:review-only
+  actor_ref: runx:principal:local_runtime
+  act_decision: close
+  source_url: https://gofrantic.com/bounties/64
+  alert:
+    id: pager-evt-2026-06-25-002
+    service: unknown-worker
+    severity: sev1
+    signal: queue depth rising without declared service policy
+  runbook_ref:
+    ref: runbook://unknown-worker/missing
+    sealed: false
+    digest: null
+  oncall_policy:
+    services:
+      checkout-api:
+        page_target: oncall://payments-primary
+    escalation_rules:
+      - id: checkout-sev2-escalate
+        service: checkout-api
+        severity: sev2
+        action: escalate
+expect:
+  status: needs_agent
+metadata:
+  public_skill: oncall-alert-triage
+  source_case: oncall-alert-triage-unsealed-runbook-stops
+  source: skills-fixture


### PR DESCRIPTION
## Summary

Adds the official `oncall-alert-triage` skill for Frantic bounty #64.

Links:
- Mirror issue: https://github.com/auscaster/frantic-board/issues/164
- Bounty source: https://gofrantic.com/bounties/64

## Problem

The bounty requests a first-party runx skill for on-call alert triage. The skill needs to gather incident severity, service state, runbook availability, escalation context, and produce a structured triage packet with next actions.

## Fix

This PR adds:
- `skills/oncall-alert-triage/SKILL.md`
- `skills/oncall-alert-triage/X.yaml`
- standalone runner fixtures for sealed escalation and unsealed runbook-stop cases
- the generated packet schema and official skill catalog/lock entries

## Tests

Verified by QA:
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm contracts:schemas:check`
- `pnpm typecheck`
- `cargo build --manifest-path crates/runx-cli/Cargo.toml`
- `pnpm test:fast` passed: 28 files / 277 tests
- `pnpm exec vitest run tests/official-skill-catalog.test.ts` passed: 8 tests
- `git diff --check origin/main...HEAD`

Additional patch evidence used the published `runx-cli 0.6.13` binary for Frantic-required dogfood validation. The branch-local native binary used for repo tests reports `runx-cli 0.6.6`.

## Risks / Notes

- Full `pnpm test` was not rerun after the final fixture cleanup; QA verified the relevant build, schema, typecheck, fast test, and focused official-catalog lanes.
- This PR only submits the code review artifact. I have not submitted or claimed the bounty on Frantic from this PR-opening step.
