### PR TITLE
Add deliverability judge skill

### DIFF
--- a/skills/deliverability-judge/SKILL.md
+++ b/skills/deliverability-judge/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: deliverability-judge
+description: Fuse sealed deliverability signals into a read-only verdict and recommendation.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 10
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+runx:
+  category: deliverability
+  tags:
+    - deliverability
+    - reputation
+    - placement
+links:
+  source: https://github.com/Li-AmG/deliverability-judge-skill
+---
+
+# Deliverability Judge
+
+`deliverability-judge` is a read-only SHAPE-A judgment skill. It accepts sealed
+postmaster, bounce, complaint, and placement-probe evidence plus a policy, then
+emits a typed deliverability verdict and a recommendation only when every signal
+is sealed and non-contradictory.
+
+The skill never sends mail, never throttles a campaign, never changes DNS,
+never mutates a subscriber list, never holds state, and never mints authority.
+If a live throttle lane exists later, that is a separate governed run dispatched
+by naming. This skill only emits a decision packet a human or downstream lane can
+read.
+
+## Inputs
+
+- `evidence.postmaster_report{sealed, source, timestamp, reputation_score}`
+- `evidence.bounce_metrics{sealed, source, timestamp, bounce_pct}`
+- `evidence.complaint_metrics{sealed, source, timestamp, complaint_pct}`
+- `evidence.placement_probe{sealed, source, timestamp, inbox_placement_pct}`
+- `policy{min_reputation_score, max_bounce_pct, max_complaint_pct, min_inbox_placement_pct}`
+
+## Output
+
+The skill writes one JSON object to stdout containing:
+
+- `verdict{state, confidence_window, reason}`
+- `recommendation{action, signal_bindings, evidence_hash}` only for a healthy,
+  fully sealed, non-contradictory signal set
+- `escalation_record{reason, signals}` when evidence is missing, unsealed, or
+  contradictory
+- `evidence_json` and `report_md` for delivery review
+
+## Decision Contract
+
+- `verdict.state=healthy` is allowed only when all four signals are sealed,
+  present, within policy, and non-contradictory.
+- `recommendation.action=continue` is emitted only with a deterministic
+  `evidence_hash` over the signal values and policy.
+- Contradictory evidence such as high reputation with high bounce rate, high
+  complaints, or poor inbox placement escalates to a human reviewer and emits no
+  recommendation.
+- Partial, unsealed, malformed, or timestamp-less evidence escalates.
+- The output is a read-only recommendation, not an Effect, operational proposal,
+  or AttenuationRequest.
+
+## Harness Cases
+
+- `sealed_healthy_signals_continue`: sealed healthy reputation, low bounce, low
+  complaints, and strong placement produce `verdict.healthy` and
+  `recommendation.action=continue`.
+- `contradictory_signals_escalate`: high reputation conflicts with high bounce
+  and weak placement, so no recommendation is emitted and the refusal still
+  seals as an escalation record.

--- a/skills/deliverability-judge/X.yaml
+++ b/skills/deliverability-judge/X.yaml
@@ -1,0 +1,159 @@
+skill: deliverability-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+runx:
+  mutating: false
+  scopes:
+    - deliverability.signals.read
+    - policy.read
+  policy:
+    data_classification: deliverability_metadata
+    network:
+      allowed: []
+      forbidden:
+        - sending email
+        - throttling live traffic
+        - changing DNS or sender authentication
+        - modifying subscriber lists
+        - minting operational authority
+    verifier_notes:
+      - The skill emits a read-only deliverability verdict and optional recommendation.
+      - Live throttling is a separate governed run dispatched by naming, never by this skill.
+      - Contradictory or unsealed evidence escalates without recommendation.
+  artifacts:
+    emits:
+      - verdict
+      - recommendation
+      - escalation_record
+      - evidence_json
+      - report_md
+    wrap_as: deliverability_judgment_packet
+
+harness:
+  cases:
+    - name: sealed_healthy_signals_continue
+      runner: default
+      inputs:
+        evidence:
+          postmaster_report:
+            sealed: true
+            source: postmaster.example.com/domain/example.com
+            timestamp: "2026-06-26T00:00:00Z"
+            reputation_score: 93
+          bounce_metrics:
+            sealed: true
+            source: esp.example.com/metrics/bounce/2026-06-26
+            timestamp: "2026-06-26T00:01:00Z"
+            bounce_pct: 0.6
+          complaint_metrics:
+            sealed: true
+            source: esp.example.com/metrics/complaint/2026-06-26
+            timestamp: "2026-06-26T00:02:00Z"
+            complaint_pct: 0.03
+          placement_probe:
+            sealed: true
+            source: seedlist.example.com/probe/abc123
+            timestamp: "2026-06-26T00:03:00Z"
+            inbox_placement_pct: 96
+        policy:
+          min_reputation_score: 80
+          max_bounce_pct: 2
+          max_complaint_pct: 0.1
+          min_inbox_placement_pct: 90
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+    - name: contradictory_signals_escalate
+      runner: default
+      inputs:
+        evidence:
+          postmaster_report:
+            sealed: true
+            source: postmaster.example.com/domain/example.net
+            timestamp: "2026-06-26T00:10:00Z"
+            reputation_score: 92
+          bounce_metrics:
+            sealed: true
+            source: esp.example.com/metrics/bounce/2026-06-26
+            timestamp: "2026-06-26T00:11:00Z"
+            bounce_pct: 5.4
+          complaint_metrics:
+            sealed: true
+            source: esp.example.com/metrics/complaint/2026-06-26
+            timestamp: "2026-06-26T00:12:00Z"
+            complaint_pct: 0.04
+          placement_probe:
+            sealed: true
+            source: seedlist.example.com/probe/def456
+            timestamp: "2026-06-26T00:13:00Z"
+            inbox_placement_pct: 62
+        policy:
+          min_reputation_score: 80
+          max_bounce_pct: 2
+          max_complaint_pct: 0.1
+          min_inbox_placement_pct: 90
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    policy:
+      reads:
+        - sealed postmaster report
+        - sealed bounce metrics
+        - sealed complaint metrics
+        - sealed placement probe
+        - deliverability policy thresholds
+      writes:
+        - verdict
+        - recommendation
+        - escalation_record
+        - evidence_json
+        - report_md
+      disallows:
+        - public_send effects
+        - live throttling
+        - DNS or sender-auth changes
+        - subscriber list mutation
+        - invented deliverability signals
+        - AttenuationRequest emission
+    artifacts:
+      named_emits:
+        verdict: verdict
+        recommendation: recommendation
+        escalation_record: escalation_record
+        evidence_json: evidence_json
+        report_md: report_md
+    inputs:
+      evidence:
+        type: object
+        required: true
+        description: evidence{postmaster_report,bounce_metrics,complaint_metrics,placement_probe}
+      policy:
+        type: object
+        required: false
+        description: Optional deliverability policy thresholds.
+      output_dir:
+        type: string
+        required: false
+        description: Optional directory inside the skill directory for evidence.json and report.md.
+    outputs:
+      verdict: object
+      recommendation: object
+      escalation_record: object
+      evidence_json: object
+      report_md: string

--- a/skills/deliverability-judge/fixtures/contradictory-signals-escalate.json
+++ b/skills/deliverability-judge/fixtures/contradictory-signals-escalate.json
@@ -1,0 +1,34 @@
+{
+  "evidence": {
+    "postmaster_report": {
+      "sealed": true,
+      "source": "postmaster.example.com/domain/example.net",
+      "timestamp": "2026-06-26T00:10:00Z",
+      "reputation_score": 92
+    },
+    "bounce_metrics": {
+      "sealed": true,
+      "source": "esp.example.com/metrics/bounce/2026-06-26",
+      "timestamp": "2026-06-26T00:11:00Z",
+      "bounce_pct": 5.4
+    },
+    "complaint_metrics": {
+      "sealed": true,
+      "source": "esp.example.com/metrics/complaint/2026-06-26",
+      "timestamp": "2026-06-26T00:12:00Z",
+      "complaint_pct": 0.04
+    },
+    "placement_probe": {
+      "sealed": true,
+      "source": "seedlist.example.com/probe/def456",
+      "timestamp": "2026-06-26T00:13:00Z",
+      "inbox_placement_pct": 62
+    }
+  },
+  "policy": {
+    "min_reputation_score": 80,
+    "max_bounce_pct": 2,
+    "max_complaint_pct": 0.1,
+    "min_inbox_placement_pct": 90
+  }
+}

--- a/skills/deliverability-judge/fixtures/harness-evidence.md
+++ b/skills/deliverability-judge/fixtures/harness-evidence.md
@@ -1,0 +1,6 @@
+# Deliverability Judge Harness Evidence
+
+- `sealed_healthy_signals_continue` covers a fully sealed healthy signal set: strong postmaster reputation, low bounce, low complaint, and strong inbox placement.
+- `contradictory_signals_escalate` covers a high reputation score contradicted by high bounce and poor inbox placement, which must escalate and emit no recommendation.
+- Fixtures contain only synthetic deliverability metadata and no recipients, message bodies, credentials, or private account state.
+- The skill emits read-only verdict evidence only. It does not send, throttle, mutate, or mint authority.

--- a/skills/deliverability-judge/fixtures/sealed-healthy-signals-continue.json
+++ b/skills/deliverability-judge/fixtures/sealed-healthy-signals-continue.json
@@ -1,0 +1,34 @@
+{
+  "evidence": {
+    "postmaster_report": {
+      "sealed": true,
+      "source": "postmaster.example.com/domain/example.com",
+      "timestamp": "2026-06-26T00:00:00Z",
+      "reputation_score": 93
+    },
+    "bounce_metrics": {
+      "sealed": true,
+      "source": "esp.example.com/metrics/bounce/2026-06-26",
+      "timestamp": "2026-06-26T00:01:00Z",
+      "bounce_pct": 0.6
+    },
+    "complaint_metrics": {
+      "sealed": true,
+      "source": "esp.example.com/metrics/complaint/2026-06-26",
+      "timestamp": "2026-06-26T00:02:00Z",
+      "complaint_pct": 0.03
+    },
+    "placement_probe": {
+      "sealed": true,
+      "source": "seedlist.example.com/probe/abc123",
+      "timestamp": "2026-06-26T00:03:00Z",
+      "inbox_placement_pct": 96
+    }
+  },
+  "policy": {
+    "min_reputation_score": 80,
+    "max_bounce_pct": 2,
+    "max_complaint_pct": 0.1,
+    "min_inbox_placement_pct": 90
+  }
+}

--- a/skills/deliverability-judge/run.mjs
+++ b/skills/deliverability-judge/run.mjs
@@ -1,0 +1,262 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const SCHEMA = "deliverability.judge.evidence.v1";
+const VERSION = "0.1.0";
+const HARNESS_CASES = ["sealed_healthy_signals_continue", "contradictory_signals_escalate"];
+
+const inputs = readInputs();
+const policy = normalizePolicy(inputs.policy);
+const judgment = judgeDeliverability(inputs.evidence, policy);
+const evidence = buildEvidence(inputs.evidence, policy, judgment);
+const report = renderReport(evidence);
+
+writeArtifacts(inputs.output_dir, evidence, report);
+
+process.stdout.write(`${JSON.stringify({
+  verdict: judgment.verdict,
+  recommendation: judgment.recommendation,
+  escalation_record: judgment.escalation_record,
+  evidence_json: evidence,
+  report_md: report,
+}, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function normalizePolicy(raw = {}) {
+  return {
+    min_reputation_score: numberOr(raw.min_reputation_score, 80),
+    max_bounce_pct: numberOr(raw.max_bounce_pct, 2),
+    max_complaint_pct: numberOr(raw.max_complaint_pct, 0.1),
+    min_inbox_placement_pct: numberOr(raw.min_inbox_placement_pct, 90),
+  };
+}
+
+function judgeDeliverability(rawEvidence, policy) {
+  const evidence = objectOr(rawEvidence);
+  const signals = {
+    postmaster_report: signal(evidence.postmaster_report, "reputation_score"),
+    bounce_metrics: signal(evidence.bounce_metrics, "bounce_pct"),
+    complaint_metrics: signal(evidence.complaint_metrics, "complaint_pct"),
+    placement_probe: signal(evidence.placement_probe, "inbox_placement_pct"),
+  };
+
+  const blockers = [];
+  for (const [name, item] of Object.entries(signals)) {
+    if (!item.present) blockers.push(`${name} is required`);
+    if (item.present && !item.sealed) blockers.push(`${name} is not sealed`);
+    if (item.present && !item.source) blockers.push(`${name}.source is required`);
+    if (item.present && !item.timestamp) blockers.push(`${name}.timestamp is required`);
+    if (item.present && item.value === null) blockers.push(`${name}.${item.valueName} is required`);
+  }
+
+  const reputation = signals.postmaster_report.value;
+  const bounce = signals.bounce_metrics.value;
+  const complaint = signals.complaint_metrics.value;
+  const placement = signals.placement_probe.value;
+
+  if (reputation !== null && reputation < policy.min_reputation_score) {
+    blockers.push(`reputation_score ${reputation} below ${policy.min_reputation_score}`);
+  }
+  if (bounce !== null && bounce > policy.max_bounce_pct) {
+    blockers.push(`bounce_pct ${bounce} exceeds ${policy.max_bounce_pct}`);
+  }
+  if (complaint !== null && complaint > policy.max_complaint_pct) {
+    blockers.push(`complaint_pct ${complaint} exceeds ${policy.max_complaint_pct}`);
+  }
+  if (placement !== null && placement < policy.min_inbox_placement_pct) {
+    blockers.push(`inbox_placement_pct ${placement} below ${policy.min_inbox_placement_pct}`);
+  }
+
+  const contradictions = [];
+  if (reputation !== null && reputation >= policy.min_reputation_score && bounce !== null && bounce > policy.max_bounce_pct) {
+    contradictions.push("high reputation conflicts with high bounce rate");
+  }
+  if (reputation !== null && reputation >= policy.min_reputation_score && complaint !== null && complaint > policy.max_complaint_pct) {
+    contradictions.push("high reputation conflicts with high complaint rate");
+  }
+  if (reputation !== null && reputation >= policy.min_reputation_score && placement !== null && placement < policy.min_inbox_placement_pct) {
+    contradictions.push("high reputation conflicts with weak placement probe");
+  }
+
+  const allClear = blockers.length === 0 && contradictions.length === 0;
+  if (allClear) {
+    const evidenceHash = hashStable({ signals: simplifySignals(signals), policy });
+    return {
+      verdict: {
+        state: "healthy",
+        confidence_window: "high",
+        reason: "all sealed deliverability signals are within policy and non-contradictory",
+      },
+      recommendation: {
+        action: "continue",
+        signal_bindings: Object.entries(signals).map(([name, item]) => ({
+          signal: name,
+          source: item.source,
+          timestamp: item.timestamp,
+          value: item.value,
+        })),
+        evidence_hash: evidenceHash,
+      },
+      escalation_record: null,
+      blockers,
+      contradictions,
+      signals,
+    };
+  }
+
+  const reasonParts = [...blockers, ...contradictions];
+  return {
+    verdict: {
+      state: "escalate",
+      confidence_window: contradictions.length > 0 ? "conflicted" : "insufficient",
+      reason: reasonParts.join("; "),
+    },
+    recommendation: null,
+    escalation_record: {
+      reason: reasonParts.join("; "),
+      signals: simplifySignals(signals),
+    },
+    blockers,
+    contradictions,
+    signals,
+  };
+}
+
+function signal(raw, valueName) {
+  const item = objectOr(raw);
+  const present = raw && typeof raw === "object" && !Array.isArray(raw);
+  return {
+    present,
+    sealed: item.sealed === true,
+    source: stringOr(item.source),
+    timestamp: stringOr(item.timestamp),
+    valueName,
+    value: numberOrNull(item[valueName]),
+  };
+}
+
+function simplifySignals(signals) {
+  const simplified = {};
+  for (const [name, item] of Object.entries(signals)) {
+    simplified[name] = {
+      sealed: item.sealed,
+      source: item.source,
+      timestamp: item.timestamp,
+      [item.valueName]: item.value,
+    };
+  }
+  return simplified;
+}
+
+function buildEvidence(rawEvidence, policy, judgment) {
+  const signals = simplifySignals(judgment.signals);
+  const signalLines = Object.entries(signals).map(([name, item]) => {
+    const valueName = Object.keys(item).find((key) => key.endsWith("_score") || key.endsWith("_pct"));
+    return `${name} sealed=${item.sealed} source=${item.source} timestamp=${item.timestamp} ${valueName}=${item[valueName]}`;
+  });
+
+  return {
+    schema: SCHEMA,
+    skill: {
+      name: "deliverability-judge",
+      version: VERSION,
+    },
+    observations: [
+      `verdict=${judgment.verdict.state}`,
+      `confidence_window=${judgment.verdict.confidence_window}`,
+      ...signalLines,
+      `recommendation_action=${judgment.recommendation?.action ?? "none"}`,
+      `evidence_hash=${judgment.recommendation?.evidence_hash ?? "none"}`,
+      `refused_reason=${judgment.escalation_record?.reason ?? "none"}`,
+      `harness cases=${HARNESS_CASES.join(", ")}`,
+      "receipt id=pending post-publish dogfood receipt",
+    ],
+    policy,
+    signals,
+    verdict: judgment.verdict,
+    recommendation: judgment.recommendation,
+    escalation_record: judgment.escalation_record,
+    dogfood: {
+      package: "deliverability-judge",
+      input: "evidence{postmaster_report,bounce_metrics,complaint_metrics,placement_probe} + policy",
+      command: "runx skill <owner>/deliverability-judge@0.1.0 --json",
+      receipt_ref: null,
+      verify_verdict: null,
+      harness_cases: HARNESS_CASES.map((name) => ({ name, expected_status: "sealed" })),
+    },
+    effect_boundary: "read-only verdict; live throttle is a separate governed run dispatched by naming",
+  };
+}
+
+function renderReport(evidence) {
+  return [
+    "# Deliverability Judge Report",
+    "",
+    `- Package: deliverability-judge@${VERSION}`,
+    `- Verdict: ${evidence.verdict.state}`,
+    `- Confidence window: ${evidence.verdict.confidence_window}`,
+    `- Reason: ${evidence.verdict.reason}`,
+    `- Recommendation action: ${evidence.recommendation?.action ?? "none"}`,
+    `- Evidence hash: ${evidence.recommendation?.evidence_hash ?? "none"}`,
+    `- Postmaster source: ${evidence.signals.postmaster_report.source}`,
+    `- Bounce source: ${evidence.signals.bounce_metrics.source}`,
+    `- Complaint source: ${evidence.signals.complaint_metrics.source}`,
+    `- Placement source: ${evidence.signals.placement_probe.source}`,
+    `- Refusal reason: ${evidence.escalation_record?.reason ?? "none"}`,
+    `- Harness cases: ${HARNESS_CASES.join(" and ")}`,
+    "- Effect boundary: read-only recommendation only; no send, throttle, mutation, state, or authority mint.",
+    "",
+  ].join("\n");
+}
+
+function writeArtifacts(outputDir, evidence, report) {
+  if (typeof outputDir !== "string" || outputDir.length === 0) return;
+  const root = process.cwd();
+  const resolved = path.resolve(root, outputDir);
+  ensureInside(root, resolved, "output_dir");
+  fs.mkdirSync(resolved, { recursive: true });
+  fs.writeFileSync(path.join(resolved, "evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`);
+  fs.writeFileSync(path.join(resolved, "report.md"), report);
+}
+
+function hashStable(value) {
+  return `sha256:${crypto.createHash("sha256").update(stableJson(value)).digest("hex")}`;
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function numberOr(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function numberOrNull(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function objectOr(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function stringOr(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function ensureInside(root, candidate, label) {
+  const relative = path.relative(root, candidate);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} must stay inside the skill directory`);
+  }
+}


### PR DESCRIPTION
Adds deliverability-judge@0.1.0, a read-only SHAPE-A skill that fuses sealed postmaster, bounce, complaint, and placement-probe signals into a deliverability verdict.

Evidence:
- Source: https://github.com/Li-AmG/deliverability-judge-skill/tree/2bcfb80a60cce377dabe33dce7dde43ebb71c3a6
- GitHub Actions evidence run: https://github.com/Li-AmG/deliverability-judge-skill/actions/runs/28213393923
- Hosted harness: passed
- Dogfood receipt: runx:receipt:sha256:a75c794f20bcb01bd508db9f72d6604b5c499bb85065ea031fbbad979ac78632

Notes:
- The skill emits only a read-only verdict/recommendation packet.
- It never sends email, throttles live traffic, mutates lists, changes DNS, holds state, or mints authority.
- Windows local harness hits receipt store os error 87 on this machine; Linux GitHub Actions harness passed with runx-cli 0.6.13.