### PR TITLE
chore(deps): bump langchain core to 1.2.1

### DIFF
--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -28,7 +28,7 @@
     }
   },
   "dependencies": {
-    "@langchain/core": "^1.2.0",
+    "@langchain/core": "^1.2.1",
     "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
   packages/langchain:
     dependencies:
       '@langchain/core':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -385,8 +385,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@langchain/core@1.2.0':
-    resolution: {integrity: sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==}
+  '@langchain/core@1.2.1':
+    resolution: {integrity: sha512-NNG/cC5FGuHDOAP56h0ddp8Rfk8p+othWzEK5RV9JIG6RvnF5vGa5r0AEGtKfQieed7s1kC42GuIzVOBvMBL/g==}
     engines: {node: '>=20'}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -995,7 +995,7 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@langchain/core@1.2.0':
+  '@langchain/core@1.2.1':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0


### PR DESCRIPTION
Clear the remaining JS dependency drift after the toolchain refresh.\n\nLocal validation:\n- pnpm install --frozen-lockfile\n- pnpm typecheck\n- RUNX_RUST_CLI_BIN=/Users/kam/dev/runx/runx/oss/crates/target/debug/runx RUNX_KERNEL_EVAL_BIN=/Users/kam/dev/runx/runx/oss/crates/target/debug/runx pnpm test:fast