### PR TITLE
Add vendor risk review skill

### DIFF
--- a/.github/workflows/vendor-risk-review-receipt.yml
+++ b/.github/workflows/vendor-risk-review-receipt.yml
@@ -38,7 +38,7 @@ jobs:
           RUNX_RECEIPT_SIGN_KID: runx-demo-key
           RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
           RUNX_RECEIPT_SIGN_ISSUER_TYPE: hosted
-          PUBLISHED_REF: iwannabefree00/vendor-risk-review@sha-cc5115a1c103
+          PUBLISHED_REF: iwannabefree00/vendor-risk-review@sha-f73efbe9b874
         run: |
           mkdir -p receipts
           runx add "$PUBLISHED_REF" --registry https://api.runx.ai --json | tee install.json

--- a/.github/workflows/vendor-risk-review-receipt.yml
+++ b/.github/workflows/vendor-risk-review-receipt.yml
@@ -38,9 +38,11 @@ jobs:
           RUNX_RECEIPT_SIGN_KID: runx-demo-key
           RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
           RUNX_RECEIPT_SIGN_ISSUER_TYPE: hosted
+          PUBLISHED_REF: iwannabefree00/vendor-risk-review@sha-cc5115a1c103
         run: |
           mkdir -p receipts
-          runx skill skills/vendor-risk-review --json --receipt-dir receipts \
+          runx add "$PUBLISHED_REF" --registry https://api.runx.ai --json | tee install.json
+          runx skill "$PUBLISHED_REF" --registry https://api.runx.ai --json --receipt-dir receipts \
             --input contract_text="Acme Analytics will process only pseudonymized customer data under SOC2 controls. Liability is capped at USD 50000. Termination for convenience is available on 30 days notice. Support includes business-hours response but does not include the requested uptime credit language." \
             --input-json vendor_context='{"vendor_ref":"vendor:acme-analytics","industry":"analytics","history":{"current_version":2}}' \
             --input-json policy='{"required_sla_terms":["uptime credit","incident response within 24 hours"],"max_liability":100000,"data_handling_floor":"SOC2","termination_window":"30 days","policy_id":"vrp-2026-06","created_at":"2026-06-29T05:00:00Z"}' \
@@ -54,11 +56,13 @@ jobs:
           runx verify --receipt "receipts/${DOGFOOD_RECEIPT}.json" --json | tee verify.json
           jq -n \
             --arg runx_version "$(cat runx-version.txt)" \
+            --arg published_ref "$PUBLISHED_REF" \
             --arg receipt_ref "runx:receipt:${DOGFOOD_RECEIPT}" \
             --slurpfile harness harness.json \
+            --slurpfile install install.json \
             --slurpfile dogfood dogfood.json \
             --slurpfile verify verify.json \
-            '{status:"passed", runx_version:$runx_version, receipt_ref:$receipt_ref, harness:$harness[0], dogfood:$dogfood[0], verify:$verify[0]}' \
+            '{status:"passed", runx_version:$runx_version, published_ref:$published_ref, receipt_ref:$receipt_ref, harness:$harness[0], install:$install[0], dogfood:$dogfood[0], verify:$verify[0]}' \
             > skills/vendor-risk-review/action-verification.json
       - name: Commit verification
         run: |

--- a/.github/workflows/vendor-risk-review-receipt.yml
+++ b/.github/workflows/vendor-risk-review-receipt.yml
@@ -1,0 +1,69 @@
+name: vendor-risk-review receipt
+
+on:
+  push:
+    branches:
+      - vendor-risk-review
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  receipt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: vendor-risk-review
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install runx
+        run: |
+          curl -fsSL https://runx.ai/install | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Verify version
+        run: runx --version | tee runx-version.txt
+      - name: Harness
+        env:
+          RUNX_RECEIPT_SIGN_KID: runx-demo-key
+          RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
+          RUNX_RECEIPT_SIGN_ISSUER_TYPE: hosted
+        run: |
+          mkdir -p receipts
+          runx harness skills/vendor-risk-review --receipt-dir receipts --json | tee harness.json
+      - name: Dogfood
+        env:
+          RUNX_RECEIPT_SIGN_KID: runx-demo-key
+          RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
+          RUNX_RECEIPT_SIGN_ISSUER_TYPE: hosted
+        run: |
+          mkdir -p receipts
+          runx skill skills/vendor-risk-review --json --receipt-dir receipts \
+            --input contract_text="Acme Analytics will process only pseudonymized customer data under SOC2 controls. Liability is capped at USD 50000. Termination for convenience is available on 30 days notice. Support includes business-hours response but does not include the requested uptime credit language." \
+            --input-json vendor_context='{"vendor_ref":"vendor:acme-analytics","industry":"analytics","history":{"current_version":2}}' \
+            --input-json policy='{"required_sla_terms":["uptime credit","incident response within 24 hours"],"max_liability":100000,"data_handling_floor":"SOC2","termination_window":"30 days","policy_id":"vrp-2026-06","created_at":"2026-06-29T05:00:00Z"}' \
+            --input data_source_ref="local://runx/vendor-risk-review" \
+            --input store_id="vendor-risk-review-fixture" | tee dogfood.json
+          DOGFOOD_RECEIPT="$(jq -r '.receipt.id // .receipt_id // .id // empty' dogfood.json)"
+          if [ -z "$DOGFOOD_RECEIPT" ]; then
+            DOGFOOD_RECEIPT="$(find receipts -maxdepth 1 -name 'sha256:*.json' -printf '%f\n' | sed 's/\.json$//' | sort | tail -n 1)"
+          fi
+          test -n "$DOGFOOD_RECEIPT"
+          runx verify --receipt "receipts/${DOGFOOD_RECEIPT}.json" --json | tee verify.json
+          jq -n \
+            --arg runx_version "$(cat runx-version.txt)" \
+            --arg receipt_ref "runx:receipt:${DOGFOOD_RECEIPT}" \
+            --slurpfile harness harness.json \
+            --slurpfile dogfood dogfood.json \
+            --slurpfile verify verify.json \
+            '{status:"passed", runx_version:$runx_version, receipt_ref:$receipt_ref, harness:$harness[0], dogfood:$dogfood[0], verify:$verify[0]}' \
+            > skills/vendor-risk-review/action-verification.json
+      - name: Commit verification
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add skills/vendor-risk-review/action-verification.json
+          git commit -m "Add vendor risk review action verification [skip ci]" || exit 0
+          git push origin HEAD:vendor-risk-review

--- a/skills/vendor-risk-review/SKILL.md
+++ b/skills/vendor-risk-review/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: vendor-risk-review
+version: 0.1.0
+description: Review vendor contract terms against a supplied policy, refuse hard risk violations, conditionally approve recoverable gaps, and emit a governed risk-record append_event packet.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+links:
+  source: https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review
+runx:
+  category: business-ops
+---
+
+# Vendor Risk Review
+
+`vendor-risk-review` evaluates a vendor contract against an explicit vendor-risk
+policy. It returns a typed decision and, whenever the vendor and policy packet
+are complete, prepares a durable `append_event` risk record for
+`registry:runx/data-store@0.1.2`.
+
+The skill never sends stakeholder notifications, never reads receipt-ledger
+state, and never executes a downstream procurement action. Notification is a
+separate governed send-as run after human approval.
+
+## Inputs
+
+- `contract_text`: vendor contract text.
+- `vendor_context`: object with `vendor_ref`, `history`, and `industry`.
+- `policy`: object with `required_sla_terms`, `max_liability`,
+  `data_handling_floor`, `termination_window`, `policy_id`, and `created_at`.
+- `data_source_ref`: logical binding for the governed data-store dependency.
+- `store_id`: pinned store id used for deterministic harness and dogfood runs.
+
+## Outputs
+
+- `decision`: `{ approved, reason, conditions[], rejected }`.
+- `risk_record`: appendable event payload or `null` when the skill must stop
+  before write.
+- `data_store`: the intended `read_projection` and `append_event` sequence,
+  including `store_id`, `aggregate_id`, `expected_version`, and
+  `idempotency_key`.
+- `escalation`: human-review lane when the vendor is ambiguous, policy is
+  incomplete, or the prior projection is unreadable.
+- `evidence`: digests, rules applied, hard-blocking findings, recoverable
+  conditions, and no-side-effect guarantees.
+
+## Decision rules
+
+1. Stop before write when `vendor_ref` is missing, the policy is incomplete, or
+   prior state cannot be read from `vendor_context.history`.
+2. Reject when liability is unbounded, uncapped, unlimited, or materially above
+   `policy.max_liability`.
+3. Reject when the contract's data-handling posture is below
+   `policy.data_handling_floor`.
+4. Approve with conditions for recoverable SLA or termination gaps. Conditions
+   name the missing policy term without inventing requirements.
+5. Append a risk-record event whenever the vendor and policy are complete,
+   including rejection decisions. Missing-policy and ambiguous-vendor paths emit
+   no write.
+
+## Data-store seam
+
+The handoff seam is an ungated compare-and-set write:
+
+1. `read_projection` for the vendor aggregate.
+2. Decide against the supplied policy and contract text.
+3. `append_event` through `registry:runx/data-store@0.1.2` with
+   `aggregate_id = vendor_context.vendor_ref`, `expected_version` from the prior
+   projection, and an `idempotency_key` keyed on
+   `vendor_ref + policy_id + decision`.
+
+The emitted event records `vendor_ref`, `decision`, `conditions`, `policy_id`,
+and `created_at`, plus a contract digest and non-sensitive findings. It does not
+contain secrets, raw credentials, or private customer data.
+
+## Example
+
+A vendor with SOC2 data handling and capped liability but missing uptime-credit
+language is approved with conditions. A vendor asking for unlimited liability is
+rejected and still recorded as a durable risk decision. A request with an
+ambiguous vendor or incomplete policy stops before write and escalates to the
+human approval lane.

--- a/skills/vendor-risk-review/X.yaml
+++ b/skills/vendor-risk-review/X.yaml
@@ -1,0 +1,150 @@
+skill: vendor-risk-review
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - approve_unbounded_liability
+    - approve_below_policy_data_handling
+    - invent_policy_requirement
+    - invent_vendor_red_flag
+    - stakeholder_notify
+    - receipt_ledger_state_read
+
+harness:
+  cases:
+    - name: approve-with-conditions-sla-gap
+      inputs:
+        contract_text: |
+          Acme Analytics will process only pseudonymized customer data under SOC2 controls.
+          Liability is capped at USD 50000. Termination for convenience is available on 30 days notice.
+          Support includes business-hours response but does not include the requested uptime credit language.
+        vendor_context:
+          vendor_ref: vendor:acme-analytics
+          industry: analytics
+          history:
+            prior_decision: approved
+            current_version: 2
+            notes:
+              - "Prior low-risk analytics vendor record exists."
+        policy:
+          required_sla_terms:
+            - uptime credit
+            - incident response within 24 hours
+          max_liability: 100000
+          data_handling_floor: SOC2
+          termination_window: "30 days"
+          policy_id: vrp-2026-06
+          created_at: "2026-06-29T05:00:00Z"
+        data_source_ref: local://runx/vendor-risk-review
+        store_id: vendor-risk-review-fixture
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: sealed-rejection-unbounded-liability
+      inputs:
+        contract_text: |
+          RiskBox may process customer data under SOC2 controls. The customer accepts unlimited liability
+          for all indirect losses and waives any liability cap. Termination requires 30 days notice.
+        vendor_context:
+          vendor_ref: vendor:riskbox
+          industry: procurement
+          history:
+            prior_decision: needs_review
+            current_version: 4
+        policy:
+          required_sla_terms:
+            - incident response within 24 hours
+          max_liability: 75000
+          data_handling_floor: SOC2
+          termination_window: "30 days"
+          policy_id: vrp-2026-06
+          created_at: "2026-06-29T05:00:00Z"
+        data_source_ref: local://runx/vendor-risk-review
+        store_id: vendor-risk-review-fixture
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: stop-missing-policy-no-write
+      inputs:
+        contract_text: |
+          Vendor terms mention standard support and a liability cap, but the governing policy packet is incomplete.
+        vendor_context:
+          vendor_ref: ""
+          industry: hr
+          history:
+            current_version: 0
+        policy:
+          required_sla_terms:
+            - uptime credit
+          max_liability: 50000
+          data_handling_floor: ""
+          termination_window: "30 days"
+          policy_id: ""
+          created_at: "2026-06-29T05:00:00Z"
+        data_source_ref: local://runx/vendor-risk-review
+        store_id: vendor-risk-review-fixture
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  decide:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      contract_text:
+        type: string
+        required: true
+        description: "Vendor contract text to review for liability, SLA, termination, and data-handling terms."
+      vendor_context:
+        type: json
+        required: true
+        description: "Object containing vendor_ref, history, and industry."
+      policy:
+        type: json
+        required: true
+        description: "Policy object with required_sla_terms, max_liability, data_handling_floor, termination_window, policy_id, and created_at."
+      data_source_ref:
+        type: string
+        required: true
+        description: "Logical binding for registry:runx/data-store@0.1.2 read_projection and append_event evidence."
+      store_id:
+        type: string
+        required: true
+        description: "Pinned store id for deterministic harness and receipt evidence."
+    outputs:
+      decision: object
+      risk_record: object
+      data_store: object
+      escalation: object
+      evidence: object
+    artifacts:
+      wrap_as: vendor_risk_review
+      packet: runx.vendor_risk_review.v1

--- a/skills/vendor-risk-review/X.yaml
+++ b/skills/vendor-risk-review/X.yaml
@@ -105,11 +105,11 @@ harness:
         data_source_ref: local://runx/vendor-risk-review
         store_id: vendor-risk-review-fixture
       expect:
-        status: sealed
+        status: failure
         receipt:
           schema: runx.receipt.v1
           state: sealed
-          disposition: closed
+          disposition: failed
 
 runners:
   decide:

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
-  "receipt_ref": "runx:receipt:sha256:46b80a828330482cd6eb308142e105c93c4e54515a07b9cb163c8b61aeecea96",
+  "receipt_ref": "runx:receipt:sha256:b05131288f0ae4ca605c3c61295f0fbfc0d70273bd4e68d687acf297e0f03135",
   "harness": {
     "status": "passed",
     "case_count": 3,
@@ -14,9 +14,9 @@
       "stop-missing-policy-no-write"
     ],
     "receipt_ids": [
-      "sha256:7e141dfc1b874c65b2703f4303b54725724fb7e3318220b5da7701c5522f2d28",
-      "sha256:7121a390c344d78ffa8c0f97d2ff360169a85e0a7d0edd48896ae5a8e2743dcf",
-      "sha256:aaf6144fc54cdae5bd7f37d8b45d2921bcccb3e12af98594e561abc02c16ea01"
+      "sha256:9f37be25fe470f9b416dbfa3a217be2d3442a7cfaaf1fdfdca9d7847c44ee75d",
+      "sha256:e82569a0d31e2aada2b7b42afb8b1960167428446f05250a015d903073f379b8",
+      "sha256:181e316000bae16fa927c97a2d6a8659c44b8f92d1d42cca8dab05726a9bfb49"
     ],
     "graph_case_count": 0
   },
@@ -45,7 +45,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/SKILL.md",
         "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
-        "install_count": 7,
+        "install_count": 8,
         "package_digest": "499e980282fd2f7720bd2f22981861ad839dc85ee6be0cebf2bdadd48c53109e",
         "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
         "publisher": {
@@ -65,7 +65,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T21:46:31.988Z",
+      "closed_at": "2026-06-30T04:44:51.675Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool decide completed"
@@ -458,7 +458,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T21:46:31.988Z",
+            "closed_at": "2026-06-30T04:44:51.675Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -513,7 +513,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T21:46:31.988Z",
+      "created_at": "2026-06-30T04:44:51.675Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -541,8 +541,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:b18defede5e5b85127800556b9f029c09aaec274890b4ac2be3f360ace233c35",
-      "id": "sha256:46b80a828330482cd6eb308142e105c93c4e54515a07b9cb163c8b61aeecea96",
+      "digest": "sha256:c5e5e4f021032bb11e28ec5106a80523351e8884ee7cc35aa42f3f1187ded496",
+      "id": "sha256:b05131288f0ae4ca605c3c61295f0fbfc0d70273bd4e68d687acf297e0f03135",
       "idempotency": {
         "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
         "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
@@ -559,7 +559,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T21:46:31.988Z",
+        "closed_at": "2026-06-30T04:44:51.675Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -570,14 +570,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T21:46:31.988Z",
+        "last_observed_at": "2026-06-30T04:44:51.675Z",
         "reason_code": "process_closed",
         "summary": "cli-tool decide completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:vGUJP-pGWtL12476str_3OHn-dB5fqvcci544WbpWVSUiGFGFmjBg526JnT_jExhdzfjS1fuoDgWLDzg_FLaDQ"
+        "value": "base64:6fCItv00tSC4JI2sO-16BZurIgxgMke1BQGLTd6-8RKfYSFiLXw7wmaiHBdLoEDbUcDVDQd2-bRY7lruvc6rDA"
       },
       "subject": {
         "commitments": [],
@@ -588,7 +588,7 @@
         }
       }
     },
-    "receipt_id": "sha256:46b80a828330482cd6eb308142e105c93c4e54515a07b9cb163c8b61aeecea96",
+    "receipt_id": "sha256:b05131288f0ae4ca605c3c61295f0fbfc0d70273bd4e68d687acf297e0f03135",
     "registry_provenance": {
       "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
       "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
-  "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+  "receipt_ref": "runx:receipt:sha256:86e64f2924e87308991141f3c42f8b49ef78ed28852843cfb3ae55078b3b9758",
   "harness": {
     "status": "passed",
     "case_count": 3,
@@ -14,9 +14,9 @@
       "stop-missing-policy-no-write"
     ],
     "receipt_ids": [
-      "sha256:1fa0c44a3b4a4cd28e966129d38f06c7648288c0a3262227c8744c8b23a33a58",
-      "sha256:541c15fd3a02d56a622613233a35c567fb3d34ed9824f1514fc32cd830feaa81",
-      "sha256:1f1a6ab3b1d8a2db5d8a50afc58fbd5f39a0cb02c8d4319c61592cb50e9cd674"
+      "sha256:cfd7ecd18ad214308497b6461d30f2d05bb1e73544a8ac2fef3dad9e053b6b81",
+      "sha256:329930adcb3b0739aea863e69af56aa1f150eb114f2349e961df64f220b5303a",
+      "sha256:35ad586fac08f74956a21581703c2eee15347234f1801dd405624bd753247a22"
     ],
     "graph_case_count": 0
   },
@@ -45,7 +45,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/SKILL.md",
         "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
-        "install_count": 4,
+        "install_count": 5,
         "package_digest": "499e980282fd2f7720bd2f22981861ad839dc85ee6be0cebf2bdadd48c53109e",
         "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
         "publisher": {
@@ -65,7 +65,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T07:53:10.078Z",
+      "closed_at": "2026-06-29T21:41:43.342Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool decide completed"
@@ -458,7 +458,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T07:53:10.078Z",
+            "closed_at": "2026-06-29T21:41:43.342Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -513,7 +513,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T07:53:10.078Z",
+      "created_at": "2026-06-29T21:41:43.342Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -541,8 +541,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:90e069fee805107f412781dfa8e400fcb35947843b416003b59b2ed428bf7a5c",
-      "id": "sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+      "digest": "sha256:43365480ea12758c9bbfc96c76a19c2940b09f37ff275314de4abb52a727e189",
+      "id": "sha256:86e64f2924e87308991141f3c42f8b49ef78ed28852843cfb3ae55078b3b9758",
       "idempotency": {
         "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
         "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
@@ -559,7 +559,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T07:53:10.078Z",
+        "closed_at": "2026-06-29T21:41:43.342Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -570,14 +570,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T07:53:10.078Z",
+        "last_observed_at": "2026-06-29T21:41:43.342Z",
         "reason_code": "process_closed",
         "summary": "cli-tool decide completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:KFkpdG9p--1_gcqc0m2nYQkw7GEmO3C4RtYgZL0TVyuMcafTox0B7JFFYpA5hqjhPSXU7K1NCa2FUkphqstwCA"
+        "value": "base64:c9QjCTBZ28litONlRrdGS5ApcNlXT1zDLydMopGghn822LxBFx8fmyeSLyTc5jMstPIc9YQ7kXiUR_skWYqNCw"
       },
       "subject": {
         "commitments": [],
@@ -588,7 +588,7 @@
         }
       }
     },
-    "receipt_id": "sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+    "receipt_id": "sha256:86e64f2924e87308991141f3c42f8b49ef78ed28852843cfb3ae55078b3b9758",
     "registry_provenance": {
       "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
       "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
-  "receipt_ref": "runx:receipt:sha256:86e64f2924e87308991141f3c42f8b49ef78ed28852843cfb3ae55078b3b9758",
+  "receipt_ref": "runx:receipt:sha256:f6b051ab965f1a72ec3009d3c85830a6f8679e44df20be3efa46714da7224fad",
   "harness": {
     "status": "passed",
     "case_count": 3,
@@ -14,9 +14,9 @@
       "stop-missing-policy-no-write"
     ],
     "receipt_ids": [
-      "sha256:cfd7ecd18ad214308497b6461d30f2d05bb1e73544a8ac2fef3dad9e053b6b81",
-      "sha256:329930adcb3b0739aea863e69af56aa1f150eb114f2349e961df64f220b5303a",
-      "sha256:35ad586fac08f74956a21581703c2eee15347234f1801dd405624bd753247a22"
+      "sha256:540748658db9797e9d38de0df4632db6ec780ec77cb85f03cc0d44123bfba92c",
+      "sha256:f8873fe89f9eb1d8668c17fcc8b01993bb97f5ef4fa9781c716ab0f3f4346e6b",
+      "sha256:ddb17d85b8cf349e5b710f60909861c25c71aaee06555b22f877cdb67e5f58ff"
     ],
     "graph_case_count": 0
   },
@@ -45,7 +45,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/SKILL.md",
         "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
-        "install_count": 5,
+        "install_count": 6,
         "package_digest": "499e980282fd2f7720bd2f22981861ad839dc85ee6be0cebf2bdadd48c53109e",
         "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
         "publisher": {
@@ -65,7 +65,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T21:41:43.342Z",
+      "closed_at": "2026-06-29T21:42:51.335Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool decide completed"
@@ -458,7 +458,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T21:41:43.342Z",
+            "closed_at": "2026-06-29T21:42:51.335Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -513,7 +513,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T21:41:43.342Z",
+      "created_at": "2026-06-29T21:42:51.335Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -541,8 +541,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:43365480ea12758c9bbfc96c76a19c2940b09f37ff275314de4abb52a727e189",
-      "id": "sha256:86e64f2924e87308991141f3c42f8b49ef78ed28852843cfb3ae55078b3b9758",
+      "digest": "sha256:fa833e25eb947c73aa167044852f31aad50ca0452003346b900dc760fb3fc773",
+      "id": "sha256:f6b051ab965f1a72ec3009d3c85830a6f8679e44df20be3efa46714da7224fad",
       "idempotency": {
         "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
         "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
@@ -559,7 +559,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T21:41:43.342Z",
+        "closed_at": "2026-06-29T21:42:51.335Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -570,14 +570,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T21:41:43.342Z",
+        "last_observed_at": "2026-06-29T21:42:51.335Z",
         "reason_code": "process_closed",
         "summary": "cli-tool decide completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:c9QjCTBZ28litONlRrdGS5ApcNlXT1zDLydMopGghn822LxBFx8fmyeSLyTc5jMstPIc9YQ7kXiUR_skWYqNCw"
+        "value": "base64:EIUMaLGecZcMZRykR3DpXuerib-97QmQRsJmdJ54VcgMhTTN6EErdCQ6De0pRCIWJK57kFrFuRmQvKribhHJCA"
       },
       "subject": {
         "commitments": [],
@@ -588,7 +588,7 @@
         }
       }
     },
-    "receipt_id": "sha256:86e64f2924e87308991141f3c42f8b49ef78ed28852843cfb3ae55078b3b9758",
+    "receipt_id": "sha256:f6b051ab965f1a72ec3009d3c85830a6f8679e44df20be3efa46714da7224fad",
     "registry_provenance": {
       "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
       "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -1,0 +1,560 @@
+{
+  "status": "passed",
+  "runx_version": "runx-cli 0.6.14",
+  "receipt_ref": "runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+  "harness": {
+    "status": "passed",
+    "case_count": 3,
+    "assertion_error_count": 0,
+    "assertion_errors": [],
+    "case_names": [
+      "approve-with-conditions-sla-gap",
+      "sealed-rejection-unbounded-liability",
+      "stop-missing-policy-no-write"
+    ],
+    "receipt_ids": [
+      "sha256:b04499df09998de3a7195edd4a1050c1433c911d50629ecaae3e33e701007453",
+      "sha256:320bd41080dbda1ca6570c1ad7d5b98d07aacb694f6df30fb7b5f702111d9027",
+      "sha256:b05af66b5287ec790aa76cb098b4534ac2745b12fd173772f887a33fe8c4c0e3"
+    ],
+    "graph_case_count": 0
+  },
+  "dogfood": {
+    "closure": {
+      "closed_at": "2026-06-29T05:45:26.698Z",
+      "disposition": "closed",
+      "reason_code": "process_closed",
+      "summary": "cli-tool decide completed"
+    },
+    "execution": {
+      "exit_code": 0,
+      "skill_claim": {
+        "data_store": {
+          "append_event": {
+            "aggregate_id": "vendor:acme-analytics",
+            "data_source_ref": "local://runx/vendor-risk-review",
+            "event": {
+              "conditions": [
+                "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+              ],
+              "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+              "created_at": "2026-06-29T05:00:00Z",
+              "decision": {
+                "approved": true,
+                "conditions": [
+                  "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+                ],
+                "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+                "rejected": false
+              },
+              "findings": {
+                "data_handling": {
+                  "block": false,
+                  "observed": "soc2",
+                  "reason": "data handling 'soc2' meets policy floor 'SOC2'",
+                  "required": "SOC2"
+                },
+                "hard_blocks": [],
+                "liability": {
+                  "block": false,
+                  "observed_amount": 50000,
+                  "reason": "liability appears bounded within policy"
+                },
+                "recoverable_conditions": [
+                  "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+                ]
+              },
+              "industry": "analytics",
+              "policy_id": "vrp-2026-06",
+              "type": "vendor_risk_review.decision_recorded",
+              "vendor_ref": "vendor:acme-analytics"
+            },
+            "expected_version": 2,
+            "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+            "resource": "vendor_risk_records",
+            "store_id": "vendor-risk-review-fixture"
+          },
+          "dependency": "registry:runx/data-store@0.1.2",
+          "read_projection": {
+            "aggregate_id": "vendor:acme-analytics",
+            "data_source_ref": "local://runx/vendor-risk-review",
+            "resource": "vendor_risk_records",
+            "store_id": "vendor-risk-review-fixture"
+          },
+          "sequence": [
+            "read_projection",
+            "decide",
+            "append_event"
+          ]
+        },
+        "decision": {
+          "approved": true,
+          "conditions": [
+            "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+          ],
+          "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+          "rejected": false
+        },
+        "escalation": {
+          "lane": null,
+          "no_receipt_ledger_state_read": true,
+          "no_stakeholder_notify": true,
+          "required": false
+        },
+        "evidence": {
+          "append_event_ready": true,
+          "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+          "expected_version": 2,
+          "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+          "package": "vendor-risk-review",
+          "policy_id": "vrp-2026-06",
+          "rules_applied": [
+            "reject unbounded or above-policy liability",
+            "reject data handling below policy floor",
+            "approve with conditions for recoverable SLA/termination gaps",
+            "stop before write for ambiguous vendor or incomplete policy"
+          ],
+          "vendor_ref": "vendor:acme-analytics",
+          "write_performed_by_skill": false
+        },
+        "risk_record": {
+          "conditions": [
+            "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+          ],
+          "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+          "created_at": "2026-06-29T05:00:00Z",
+          "decision": {
+            "approved": true,
+            "conditions": [
+              "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+            ],
+            "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+            "rejected": false
+          },
+          "findings": {
+            "data_handling": {
+              "block": false,
+              "observed": "soc2",
+              "reason": "data handling 'soc2' meets policy floor 'SOC2'",
+              "required": "SOC2"
+            },
+            "hard_blocks": [],
+            "liability": {
+              "block": false,
+              "observed_amount": 50000,
+              "reason": "liability appears bounded within policy"
+            },
+            "recoverable_conditions": [
+              "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+            ]
+          },
+          "industry": "analytics",
+          "policy_id": "vrp-2026-06",
+          "type": "vendor_risk_review.decision_recorded",
+          "vendor_ref": "vendor:acme-analytics"
+        }
+      },
+      "stderr": "",
+      "stdout": "{\n  \"decision\": {\n    \"approved\": true,\n    \"reason\": \"Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.\",\n    \"conditions\": [\n      \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n    ],\n    \"rejected\": false\n  },\n  \"risk_record\": {\n    \"type\": \"vendor_risk_review.decision_recorded\",\n    \"vendor_ref\": \"vendor:acme-analytics\",\n    \"industry\": \"analytics\",\n    \"decision\": {\n      \"approved\": true,\n      \"reason\": \"Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.\",\n      \"conditions\": [\n        \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n      ],\n      \"rejected\": false\n    },\n    \"conditions\": [\n      \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n    ],\n    \"policy_id\": \"vrp-2026-06\",\n    \"created_at\": \"2026-06-29T05:00:00Z\",\n    \"findings\": {\n      \"hard_blocks\": [],\n      \"recoverable_conditions\": [\n        \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n      ],\n      \"liability\": {\n        \"block\": false,\n        \"reason\": \"liability appears bounded within policy\",\n        \"observed_amount\": 50000\n      },\n      \"data_handling\": {\n        \"block\": false,\n        \"reason\": \"data handling 'soc2' meets policy floor 'SOC2'\",\n        \"observed\": \"soc2\",\n        \"required\": \"SOC2\"\n      }\n    },\n    \"contract_digest\": \"sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c\"\n  },\n  \"data_store\": {\n    \"dependency\": \"registry:runx/data-store@0.1.2\",\n    \"sequence\": [\n      \"read_projection\",\n      \"decide\",\n      \"append_event\"\n    ],\n    \"read_projection\": {\n      \"data_source_ref\": \"local://runx/vendor-risk-review\",\n      \"store_id\": \"vendor-risk-review-fixture\",\n      \"resource\": \"vendor_risk_records\",\n      \"aggregate_id\": \"vendor:acme-analytics\"\n    },\n    \"append_event\": {\n      \"data_source_ref\": \"local://runx/vendor-risk-review\",\n      \"store_id\": \"vendor-risk-review-fixture\",\n      \"resource\": \"vendor_risk_records\",\n      \"aggregate_id\": \"vendor:acme-analytics\",\n      \"expected_version\": 2,\n      \"idempotency_key\": \"vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97\",\n      \"event\": {\n        \"type\": \"vendor_risk_review.decision_recorded\",\n        \"vendor_ref\": \"vendor:acme-analytics\",\n        \"industry\": \"analytics\",\n        \"decision\": {\n          \"approved\": true,\n          \"reason\": \"Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.\",\n          \"conditions\": [\n            \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n          ],\n          \"rejected\": false\n        },\n        \"conditions\": [\n          \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n        ],\n        \"policy_id\": \"vrp-2026-06\",\n        \"created_at\": \"2026-06-29T05:00:00Z\",\n        \"findings\": {\n          \"hard_blocks\": [],\n          \"recoverable_conditions\": [\n            \"Add SLA term required by vrp-2026-06: incident response within 24 hours.\"\n          ],\n          \"liability\": {\n            \"block\": false,\n            \"reason\": \"liability appears bounded within policy\",\n            \"observed_amount\": 50000\n          },\n          \"data_handling\": {\n            \"block\": false,\n            \"reason\": \"data handling 'soc2' meets policy floor 'SOC2'\",\n            \"observed\": \"soc2\",\n            \"required\": \"SOC2\"\n          }\n        },\n        \"contract_digest\": \"sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c\"\n      }\n    }\n  },\n  \"escalation\": {\n    \"required\": false,\n    \"lane\": null,\n    \"no_stakeholder_notify\": true,\n    \"no_receipt_ledger_state_read\": true\n  },\n  \"evidence\": {\n    \"package\": \"vendor-risk-review\",\n    \"policy_id\": \"vrp-2026-06\",\n    \"vendor_ref\": \"vendor:acme-analytics\",\n    \"contract_digest\": \"sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c\",\n    \"expected_version\": 2,\n    \"idempotency_key\": \"vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97\",\n    \"rules_applied\": [\n      \"reject unbounded or above-policy liability\",\n      \"reject data handling below policy floor\",\n      \"approve with conditions for recoverable SLA/termination gaps\",\n      \"stop before write for ambiguous vendor or incomplete policy\"\n    ],\n    \"write_performed_by_skill\": false,\n    \"append_event_ready\": true\n  }\n}\n",
+      "structured_output": {
+        "data_store": {
+          "append_event": {
+            "aggregate_id": "vendor:acme-analytics",
+            "data_source_ref": "local://runx/vendor-risk-review",
+            "event": {
+              "conditions": [
+                "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+              ],
+              "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+              "created_at": "2026-06-29T05:00:00Z",
+              "decision": {
+                "approved": true,
+                "conditions": [
+                  "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+                ],
+                "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+                "rejected": false
+              },
+              "findings": {
+                "data_handling": {
+                  "block": false,
+                  "observed": "soc2",
+                  "reason": "data handling 'soc2' meets policy floor 'SOC2'",
+                  "required": "SOC2"
+                },
+                "hard_blocks": [],
+                "liability": {
+                  "block": false,
+                  "observed_amount": 50000,
+                  "reason": "liability appears bounded within policy"
+                },
+                "recoverable_conditions": [
+                  "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+                ]
+              },
+              "industry": "analytics",
+              "policy_id": "vrp-2026-06",
+              "type": "vendor_risk_review.decision_recorded",
+              "vendor_ref": "vendor:acme-analytics"
+            },
+            "expected_version": 2,
+            "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+            "resource": "vendor_risk_records",
+            "store_id": "vendor-risk-review-fixture"
+          },
+          "dependency": "registry:runx/data-store@0.1.2",
+          "read_projection": {
+            "aggregate_id": "vendor:acme-analytics",
+            "data_source_ref": "local://runx/vendor-risk-review",
+            "resource": "vendor_risk_records",
+            "store_id": "vendor-risk-review-fixture"
+          },
+          "sequence": [
+            "read_projection",
+            "decide",
+            "append_event"
+          ]
+        },
+        "decision": {
+          "approved": true,
+          "conditions": [
+            "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+          ],
+          "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+          "rejected": false
+        },
+        "escalation": {
+          "lane": null,
+          "no_receipt_ledger_state_read": true,
+          "no_stakeholder_notify": true,
+          "required": false
+        },
+        "evidence": {
+          "append_event_ready": true,
+          "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+          "expected_version": 2,
+          "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+          "package": "vendor-risk-review",
+          "policy_id": "vrp-2026-06",
+          "rules_applied": [
+            "reject unbounded or above-policy liability",
+            "reject data handling below policy floor",
+            "approve with conditions for recoverable SLA/termination gaps",
+            "stop before write for ambiguous vendor or incomplete policy"
+          ],
+          "vendor_ref": "vendor:acme-analytics",
+          "write_performed_by_skill": false
+        },
+        "risk_record": {
+          "conditions": [
+            "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+          ],
+          "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+          "created_at": "2026-06-29T05:00:00Z",
+          "decision": {
+            "approved": true,
+            "conditions": [
+              "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+            ],
+            "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+            "rejected": false
+          },
+          "findings": {
+            "data_handling": {
+              "block": false,
+              "observed": "soc2",
+              "reason": "data handling 'soc2' meets policy floor 'SOC2'",
+              "required": "SOC2"
+            },
+            "hard_blocks": [],
+            "liability": {
+              "block": false,
+              "observed_amount": 50000,
+              "reason": "liability appears bounded within policy"
+            },
+            "recoverable_conditions": [
+              "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+            ]
+          },
+          "industry": "analytics",
+          "policy_id": "vrp-2026-06",
+          "type": "vendor_risk_review.decision_recorded",
+          "vendor_ref": "vendor:acme-analytics"
+        }
+      }
+    },
+    "payload": {
+      "data_store": {
+        "append_event": {
+          "aggregate_id": "vendor:acme-analytics",
+          "data_source_ref": "local://runx/vendor-risk-review",
+          "event": {
+            "conditions": [
+              "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+            ],
+            "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+            "created_at": "2026-06-29T05:00:00Z",
+            "decision": {
+              "approved": true,
+              "conditions": [
+                "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+              ],
+              "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+              "rejected": false
+            },
+            "findings": {
+              "data_handling": {
+                "block": false,
+                "observed": "soc2",
+                "reason": "data handling 'soc2' meets policy floor 'SOC2'",
+                "required": "SOC2"
+              },
+              "hard_blocks": [],
+              "liability": {
+                "block": false,
+                "observed_amount": 50000,
+                "reason": "liability appears bounded within policy"
+              },
+              "recoverable_conditions": [
+                "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+              ]
+            },
+            "industry": "analytics",
+            "policy_id": "vrp-2026-06",
+            "type": "vendor_risk_review.decision_recorded",
+            "vendor_ref": "vendor:acme-analytics"
+          },
+          "expected_version": 2,
+          "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+          "resource": "vendor_risk_records",
+          "store_id": "vendor-risk-review-fixture"
+        },
+        "dependency": "registry:runx/data-store@0.1.2",
+        "read_projection": {
+          "aggregate_id": "vendor:acme-analytics",
+          "data_source_ref": "local://runx/vendor-risk-review",
+          "resource": "vendor_risk_records",
+          "store_id": "vendor-risk-review-fixture"
+        },
+        "sequence": [
+          "read_projection",
+          "decide",
+          "append_event"
+        ]
+      },
+      "decision": {
+        "approved": true,
+        "conditions": [
+          "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+        ],
+        "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+        "rejected": false
+      },
+      "escalation": {
+        "lane": null,
+        "no_receipt_ledger_state_read": true,
+        "no_stakeholder_notify": true,
+        "required": false
+      },
+      "evidence": {
+        "append_event_ready": true,
+        "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+        "expected_version": 2,
+        "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+        "package": "vendor-risk-review",
+        "policy_id": "vrp-2026-06",
+        "rules_applied": [
+          "reject unbounded or above-policy liability",
+          "reject data handling below policy floor",
+          "approve with conditions for recoverable SLA/termination gaps",
+          "stop before write for ambiguous vendor or incomplete policy"
+        ],
+        "vendor_ref": "vendor:acme-analytics",
+        "write_performed_by_skill": false
+      },
+      "risk_record": {
+        "conditions": [
+          "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+        ],
+        "contract_digest": "sha256:26e668fde626b58de4bf4611f4e05aaa0191492cc325a14a199acfceb8e11f7c",
+        "created_at": "2026-06-29T05:00:00Z",
+        "decision": {
+          "approved": true,
+          "conditions": [
+            "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+          ],
+          "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+          "rejected": false
+        },
+        "findings": {
+          "data_handling": {
+            "block": false,
+            "observed": "soc2",
+            "reason": "data handling 'soc2' meets policy floor 'SOC2'",
+            "required": "SOC2"
+          },
+          "hard_blocks": [],
+          "liability": {
+            "block": false,
+            "observed_amount": 50000,
+            "reason": "liability appears bounded within policy"
+          },
+          "recoverable_conditions": [
+            "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+          ]
+        },
+        "industry": "analytics",
+        "policy_id": "vrp-2026-06",
+        "type": "vendor_risk_review.decision_recorded",
+        "vendor_ref": "vendor:acme-analytics"
+      }
+    },
+    "receipt": {
+      "acts": [
+        {
+          "artifact_refs": [],
+          "closure": {
+            "closed_at": "2026-06-29T05:45:26.698Z",
+            "disposition": "closed",
+            "reason_code": "process_exit",
+            "summary": "cli-tool exited successfully"
+          },
+          "criterion_bindings": [
+            {
+              "criterion_id": "process_exit",
+              "evidence_refs": [],
+              "status": "verified",
+              "summary": "cli-tool exited successfully",
+              "verification_refs": []
+            }
+          ],
+          "form": "observation",
+          "id": "act_decide",
+          "intent": {
+            "constraints": [],
+            "derived_from": [],
+            "legitimacy": "Runtime graph execution was admitted by the local harness",
+            "purpose": "Run graph step decide",
+            "success_criteria": [
+              {
+                "criterion_id": "process_exit",
+                "required": true,
+                "statement": "cli-tool exits successfully"
+              }
+            ]
+          },
+          "source_refs": [],
+          "summary": "Executed graph step decide",
+          "target_refs": []
+        }
+      ],
+      "authority": {
+        "actor_ref": {
+          "type": "principal",
+          "uri": "runx:principal:local_runtime"
+        },
+        "attenuation": {
+          "parent_authority_ref": null,
+          "subset_proof": null
+        },
+        "authority_proof_refs": [],
+        "enforcement": {
+          "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
+          "redaction_refs": [],
+          "setup_refs": [],
+          "teardown_refs": []
+        },
+        "grant_refs": [],
+        "scope_refs": [],
+        "terms": []
+      },
+      "canonicalization": "runx.receipt.c14n.v1",
+      "created_at": "2026-06-29T05:45:26.698Z",
+      "decisions": [
+        {
+          "artifact_refs": [],
+          "choice": "open",
+          "closure": null,
+          "decision_id": "dec_decide",
+          "inputs": {
+            "opportunity_refs": [],
+            "selection_ref": null,
+            "signal_refs": [],
+            "target_ref": null
+          },
+          "justification": {
+            "evidence_refs": [],
+            "summary": "runtime graph planner selected this node"
+          },
+          "proposed_intent": {
+            "constraints": [],
+            "derived_from": [],
+            "legitimacy": "Local graph execution requested this node",
+            "purpose": "Open runtime node decide",
+            "success_criteria": []
+          },
+          "selected_act_id": "act_decide",
+          "selected_harness_ref": null
+        }
+      ],
+      "digest": "sha256:bd9ef720142212151f599d057e5e98e2a837978ed557eefc0d16cfdae360d409",
+      "id": "sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+      "idempotency": {
+        "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
+        "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
+        "trigger_fingerprint": "sha256:run_decide_98ffc1fbc5d9-decide-trigger"
+      },
+      "issuer": {
+        "kid": "runx-demo-key",
+        "public_key_sha256": "sha256:3097e2dee2cb4a34b53840cdb705aed71067c36f68db0e0f559c3f3fa043315f",
+        "type": "hosted"
+      },
+      "lineage": {
+        "children": [],
+        "sync": []
+      },
+      "schema": "runx.receipt.v1",
+      "seal": {
+        "closed_at": "2026-06-29T05:45:26.698Z",
+        "criteria": [
+          {
+            "criterion_id": "process_exit",
+            "evidence_refs": [],
+            "status": "verified",
+            "summary": "cli-tool exited successfully",
+            "verification_refs": []
+          }
+        ],
+        "disposition": "closed",
+        "last_observed_at": "2026-06-29T05:45:26.698Z",
+        "reason_code": "process_closed",
+        "summary": "cli-tool decide completed"
+      },
+      "signals": [],
+      "signature": {
+        "alg": "Ed25519",
+        "value": "base64:j2H-jdOFfQHx-nW9zGuF_kH8ToiMhoKtzC6CM-qEBRmBPfJlQYE0a190e1WeW06xMzoaOUllTZtBUsI8QnDmBQ"
+      },
+      "subject": {
+        "commitments": [],
+        "kind": "skill",
+        "ref": {
+          "type": "harness",
+          "uri": "hrn_run_decide_98ffc1fbc5d9_decide"
+        }
+      }
+    },
+    "receipt_id": "sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+    "run_id": "run_decide_98ffc1fbc5d9",
+    "schema": "runx.skill_run.v1",
+    "skill_name": "vendor-risk-review",
+    "status": "sealed"
+  },
+  "verify": {
+    "status": "failure",
+    "error": {
+      "message": "runx verify requires trusted receipt verification keys. Set both RUNX_RECEIPT_VERIFY_KID and RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64, or pass --allow-local-development-signatures for local fixture receipts only.",
+      "code": "runtime_error"
+    }
+  }
+}

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -1,7 +1,8 @@
 {
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
-  "receipt_ref": "runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+  "published_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+  "receipt_ref": "runx:receipt:sha256:3a3df82c87ceaf1c911ebc35840a000b38ec93d09ecaf47fc82c5b0628de95b0",
   "harness": {
     "status": "passed",
     "case_count": 3,
@@ -13,15 +14,57 @@
       "stop-missing-policy-no-write"
     ],
     "receipt_ids": [
-      "sha256:b04499df09998de3a7195edd4a1050c1433c911d50629ecaae3e33e701007453",
-      "sha256:320bd41080dbda1ca6570c1ad7d5b98d07aacb694f6df30fb7b5f702111d9027",
-      "sha256:b05af66b5287ec790aa76cb098b4534ac2745b12fd173772f887a33fe8c4c0e3"
+      "sha256:77f68084b8c9d1b9371330eea840494fd3b0fa80bf76b5e43ffebd87a3ff713a",
+      "sha256:fe8f2a3247c089e61f144a2bce712e9db6812ff4bc244598ac8a717e8de4a1f1",
+      "sha256:4537665319ec36ddbc448be80b55435e623a5eadba64828cd6b722491644728a"
     ],
     "graph_case_count": 0
   },
+  "install": {
+    "status": "success",
+    "registry": {
+      "action": "install",
+      "source": "remote",
+      "ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+      "install": {
+        "status": "installed",
+        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-cc5115a1c103/SKILL.md",
+        "skill_name": "vendor-risk-review",
+        "source": "runx-registry",
+        "source_label": "runx registry",
+        "skill_id": "iwannabefree00/vendor-risk-review",
+        "version": "sha-cc5115a1c103",
+        "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
+        "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
+        "profile_state_path": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-cc5115a1c103/.runx/profile.json",
+        "runner_names": [
+          "decide"
+        ],
+        "trust_tier": "community"
+      },
+      "receipt_metadata": {
+        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-cc5115a1c103/SKILL.md",
+        "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
+        "install_count": 2,
+        "package_digest": "c26cae324a1fd47637b69f8d47e5f498644691e360dc3e0581cb0230ca523406",
+        "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
+        "publisher": {
+          "handle": "iwannabefree00",
+          "id": "iwannabefree00",
+          "kind": "publisher"
+        },
+        "ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+        "skill_id": "iwannabefree00/vendor-risk-review",
+        "source_label": "runx registry",
+        "status": "installed",
+        "trust_tier": "community",
+        "version": "sha-cc5115a1c103"
+      }
+    }
+  },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T05:45:26.698Z",
+      "closed_at": "2026-06-29T07:23:51.605Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool decide completed"
@@ -414,7 +457,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T05:45:26.698Z",
+            "closed_at": "2026-06-29T07:23:51.605Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -469,7 +512,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T05:45:26.698Z",
+      "created_at": "2026-06-29T07:23:51.605Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -497,8 +540,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:bd9ef720142212151f599d057e5e98e2a837978ed557eefc0d16cfdae360d409",
-      "id": "sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+      "digest": "sha256:05cf09dd5964f3ece3d316810e560ff130c080f1565a92609e31d0ac5bb29055",
+      "id": "sha256:3a3df82c87ceaf1c911ebc35840a000b38ec93d09ecaf47fc82c5b0628de95b0",
       "idempotency": {
         "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
         "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
@@ -515,7 +558,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T05:45:26.698Z",
+        "closed_at": "2026-06-29T07:23:51.605Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -526,14 +569,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T05:45:26.698Z",
+        "last_observed_at": "2026-06-29T07:23:51.605Z",
         "reason_code": "process_closed",
         "summary": "cli-tool decide completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:j2H-jdOFfQHx-nW9zGuF_kH8ToiMhoKtzC6CM-qEBRmBPfJlQYE0a190e1WeW06xMzoaOUllTZtBUsI8QnDmBQ"
+        "value": "base64:3dRCBNrpsDLF1-m14wotDZsBL5Fizkm_sJendlN38KXx4ucqprqZjOy6uVW9ylrh64fvv6fHU50r7Ee3FL-dBw"
       },
       "subject": {
         "commitments": [],
@@ -544,7 +587,18 @@
         }
       }
     },
-    "receipt_id": "sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+    "receipt_id": "sha256:3a3df82c87ceaf1c911ebc35840a000b38ec93d09ecaf47fc82c5b0628de95b0",
+    "registry_provenance": {
+      "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
+      "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
+      "registry_key_id": "runx-registry-ed25519-v1",
+      "registry_source": "remote https://api.runx.ai",
+      "registry_source_fingerprint": "ba1ac16b631195fd",
+      "skill_id": "iwannabefree00/vendor-risk-review",
+      "trust_state": "trusted",
+      "trust_tier": "community",
+      "version": "sha-cc5115a1c103"
+    },
     "run_id": "run_decide_98ffc1fbc5d9",
     "schema": "runx.skill_run.v1",
     "skill_name": "vendor-risk-review",

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
-  "receipt_ref": "runx:receipt:sha256:f6b051ab965f1a72ec3009d3c85830a6f8679e44df20be3efa46714da7224fad",
+  "receipt_ref": "runx:receipt:sha256:46b80a828330482cd6eb308142e105c93c4e54515a07b9cb163c8b61aeecea96",
   "harness": {
     "status": "passed",
     "case_count": 3,
@@ -14,9 +14,9 @@
       "stop-missing-policy-no-write"
     ],
     "receipt_ids": [
-      "sha256:540748658db9797e9d38de0df4632db6ec780ec77cb85f03cc0d44123bfba92c",
-      "sha256:f8873fe89f9eb1d8668c17fcc8b01993bb97f5ef4fa9781c716ab0f3f4346e6b",
-      "sha256:ddb17d85b8cf349e5b710f60909861c25c71aaee06555b22f877cdb67e5f58ff"
+      "sha256:7e141dfc1b874c65b2703f4303b54725724fb7e3318220b5da7701c5522f2d28",
+      "sha256:7121a390c344d78ffa8c0f97d2ff360169a85e0a7d0edd48896ae5a8e2743dcf",
+      "sha256:aaf6144fc54cdae5bd7f37d8b45d2921bcccb3e12af98594e561abc02c16ea01"
     ],
     "graph_case_count": 0
   },
@@ -45,7 +45,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/SKILL.md",
         "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
-        "install_count": 6,
+        "install_count": 7,
         "package_digest": "499e980282fd2f7720bd2f22981861ad839dc85ee6be0cebf2bdadd48c53109e",
         "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
         "publisher": {
@@ -65,7 +65,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T21:42:51.335Z",
+      "closed_at": "2026-06-29T21:46:31.988Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool decide completed"
@@ -458,7 +458,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T21:42:51.335Z",
+            "closed_at": "2026-06-29T21:46:31.988Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -513,7 +513,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T21:42:51.335Z",
+      "created_at": "2026-06-29T21:46:31.988Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -541,8 +541,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:fa833e25eb947c73aa167044852f31aad50ca0452003346b900dc760fb3fc773",
-      "id": "sha256:f6b051ab965f1a72ec3009d3c85830a6f8679e44df20be3efa46714da7224fad",
+      "digest": "sha256:b18defede5e5b85127800556b9f029c09aaec274890b4ac2be3f360ace233c35",
+      "id": "sha256:46b80a828330482cd6eb308142e105c93c4e54515a07b9cb163c8b61aeecea96",
       "idempotency": {
         "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
         "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
@@ -559,7 +559,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T21:42:51.335Z",
+        "closed_at": "2026-06-29T21:46:31.988Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -570,14 +570,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T21:42:51.335Z",
+        "last_observed_at": "2026-06-29T21:46:31.988Z",
         "reason_code": "process_closed",
         "summary": "cli-tool decide completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:EIUMaLGecZcMZRykR3DpXuerib-97QmQRsJmdJ54VcgMhTTN6EErdCQ6De0pRCIWJK57kFrFuRmQvKribhHJCA"
+        "value": "base64:vGUJP-pGWtL12476str_3OHn-dB5fqvcci544WbpWVSUiGFGFmjBg526JnT_jExhdzfjS1fuoDgWLDzg_FLaDQ"
       },
       "subject": {
         "commitments": [],
@@ -588,7 +588,7 @@
         }
       }
     },
-    "receipt_id": "sha256:f6b051ab965f1a72ec3009d3c85830a6f8679e44df20be3efa46714da7224fad",
+    "receipt_id": "sha256:46b80a828330482cd6eb308142e105c93c4e54515a07b9cb163c8b61aeecea96",
     "registry_provenance": {
       "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
       "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",

--- a/skills/vendor-risk-review/action-verification.json
+++ b/skills/vendor-risk-review/action-verification.json
@@ -1,8 +1,8 @@
 {
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
-  "published_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-  "receipt_ref": "runx:receipt:sha256:3a3df82c87ceaf1c911ebc35840a000b38ec93d09ecaf47fc82c5b0628de95b0",
+  "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+  "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
   "harness": {
     "status": "passed",
     "case_count": 3,
@@ -14,9 +14,9 @@
       "stop-missing-policy-no-write"
     ],
     "receipt_ids": [
-      "sha256:77f68084b8c9d1b9371330eea840494fd3b0fa80bf76b5e43ffebd87a3ff713a",
-      "sha256:fe8f2a3247c089e61f144a2bce712e9db6812ff4bc244598ac8a717e8de4a1f1",
-      "sha256:4537665319ec36ddbc448be80b55435e623a5eadba64828cd6b722491644728a"
+      "sha256:1fa0c44a3b4a4cd28e966129d38f06c7648288c0a3262227c8744c8b23a33a58",
+      "sha256:541c15fd3a02d56a622613233a35c567fb3d34ed9824f1514fc32cd830feaa81",
+      "sha256:1f1a6ab3b1d8a2db5d8a50afc58fbd5f39a0cb02c8d4319c61592cb50e9cd674"
     ],
     "graph_case_count": 0
   },
@@ -25,46 +25,47 @@
     "registry": {
       "action": "install",
       "source": "remote",
-      "ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+      "ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
       "install": {
         "status": "installed",
-        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-cc5115a1c103/SKILL.md",
+        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/SKILL.md",
         "skill_name": "vendor-risk-review",
         "source": "runx-registry",
         "source_label": "runx registry",
         "skill_id": "iwannabefree00/vendor-risk-review",
-        "version": "sha-cc5115a1c103",
-        "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
-        "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
-        "profile_state_path": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-cc5115a1c103/.runx/profile.json",
+        "version": "sha-f73efbe9b874",
+        "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
+        "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
+        "profile_state_path": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/.runx/profile.json",
         "runner_names": [
           "decide"
         ],
         "trust_tier": "community"
       },
       "receipt_metadata": {
-        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-cc5115a1c103/SKILL.md",
-        "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
-        "install_count": 2,
-        "package_digest": "c26cae324a1fd47637b69f8d47e5f498644691e360dc3e0581cb0230ca523406",
-        "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
+        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/vendor-risk-review/sha-f73efbe9b874/SKILL.md",
+        "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
+        "install_count": 4,
+        "package_digest": "499e980282fd2f7720bd2f22981861ad839dc85ee6be0cebf2bdadd48c53109e",
+        "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
         "publisher": {
+          "display_name": "iwannabefree00",
           "handle": "iwannabefree00",
-          "id": "iwannabefree00",
-          "kind": "publisher"
+          "id": "user_b7db2f36021367136b434108",
+          "kind": "user"
         },
-        "ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+        "ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
         "skill_id": "iwannabefree00/vendor-risk-review",
         "source_label": "runx registry",
         "status": "installed",
         "trust_tier": "community",
-        "version": "sha-cc5115a1c103"
+        "version": "sha-f73efbe9b874"
       }
     }
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T07:23:51.605Z",
+      "closed_at": "2026-06-29T07:53:10.078Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool decide completed"
@@ -457,7 +458,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T07:23:51.605Z",
+            "closed_at": "2026-06-29T07:53:10.078Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -512,7 +513,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T07:23:51.605Z",
+      "created_at": "2026-06-29T07:53:10.078Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -540,8 +541,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:05cf09dd5964f3ece3d316810e560ff130c080f1565a92609e31d0ac5bb29055",
-      "id": "sha256:3a3df82c87ceaf1c911ebc35840a000b38ec93d09ecaf47fc82c5b0628de95b0",
+      "digest": "sha256:90e069fee805107f412781dfa8e400fcb35947843b416003b59b2ed428bf7a5c",
+      "id": "sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
       "idempotency": {
         "content_hash": "sha256:run_decide_98ffc1fbc5d9-decide-content",
         "intent_key": "sha256:run_decide_98ffc1fbc5d9-decide-intent",
@@ -558,7 +559,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T07:23:51.605Z",
+        "closed_at": "2026-06-29T07:53:10.078Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -569,14 +570,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T07:23:51.605Z",
+        "last_observed_at": "2026-06-29T07:53:10.078Z",
         "reason_code": "process_closed",
         "summary": "cli-tool decide completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:3dRCBNrpsDLF1-m14wotDZsBL5Fizkm_sJendlN38KXx4ucqprqZjOy6uVW9ylrh64fvv6fHU50r7Ee3FL-dBw"
+        "value": "base64:KFkpdG9p--1_gcqc0m2nYQkw7GEmO3C4RtYgZL0TVyuMcafTox0B7JFFYpA5hqjhPSXU7K1NCa2FUkphqstwCA"
       },
       "subject": {
         "commitments": [],
@@ -587,17 +588,17 @@
         }
       }
     },
-    "receipt_id": "sha256:3a3df82c87ceaf1c911ebc35840a000b38ec93d09ecaf47fc82c5b0628de95b0",
+    "receipt_id": "sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
     "registry_provenance": {
-      "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
-      "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
+      "digest": "sha256:04a4606343d8bcfb6bd4150438ca9d1f2b3fd8ef3958409093b704563e687c4d",
+      "profile_digest": "sha256:6bece65c388c253a339ad990675731955082ed794136fa7998570f8b18ce5bf1",
       "registry_key_id": "runx-registry-ed25519-v1",
       "registry_source": "remote https://api.runx.ai",
       "registry_source_fingerprint": "ba1ac16b631195fd",
       "skill_id": "iwannabefree00/vendor-risk-review",
       "trust_state": "trusted",
       "trust_tier": "community",
-      "version": "sha-cc5115a1c103"
+      "version": "sha-f73efbe9b874"
     },
     "run_id": "run_decide_98ffc1fbc5d9",
     "schema": "runx.skill_run.v1",

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -1,0 +1,98 @@
+{
+  "claim_type": "runx_skill_vendor_risk_review",
+  "owner": "iwannabefree00",
+  "package": "vendor-risk-review",
+  "version": "0.1.0",
+  "package_ref": "iwannabefree00/vendor-risk-review@0.1.0",
+  "source_revision": "iwannabefree00/runx vendor-risk-review branch head at delivery",
+  "runx_cli_version": "0.6.14",
+  "node_version": "22.23.1",
+  "pr_url": "https://github.com/runxhq/runx/pull/172",
+  "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
+  "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md",
+  "summary": "Adds a deterministic vendor-risk-review runx skill with typed inputs, approve-with-conditions, sealed rejection, and stop-before-write paths. The output includes a risk_record event and data_store append_event envelope for registry:runx/data-store@0.1.2.",
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "status": "passed",
+      "detail": "Exact runx --version output: runx-cli 0.6.14."
+    },
+    {
+      "name": "github_star",
+      "status": "passed",
+      "detail": "The GitHub account iwannabefree00 starred https://github.com/runxhq/runx from the logged-in browser session."
+    },
+    {
+      "name": "pr_created",
+      "status": "passed",
+      "detail": "Public PR #172 opened against runxhq/runx from iwannabefree00:vendor-risk-review."
+    },
+    {
+      "name": "skill_inspect",
+      "status": "passed",
+      "detail": "runx skill inspect skills/vendor-risk-review --json returned status ok with runner decide and version 0.1.0."
+    },
+    {
+      "name": "direct_dogfood_runner",
+      "status": "passed",
+      "detail": "node skills/vendor-risk-review/run.mjs executed the approve-with-conditions fixture and emitted approved=true, one remediation condition, and append_event-ready data_store evidence."
+    },
+    {
+      "name": "registry_publish",
+      "status": "waiting_for_runx_login",
+      "detail": "Target publish command: runx login --provider github --for publish, then runx registry publish ./skills/vendor-risk-review/SKILL.md --registry https://api.runx.ai."
+    },
+    {
+      "name": "windows_harness_note",
+      "status": "blocked_by_environment",
+      "detail": "On this Windows host, runx harness fails before executing both this skill and repository examples/hello-world with receipt store is unreadable: os error 87. The PR retains inline harness cases for verifier execution on a compatible host."
+    }
+  ],
+  "harness_cases": [
+    "approve-with-conditions-sla-gap",
+    "sealed-rejection-unbounded-liability",
+    "stop-missing-policy-no-write"
+  ],
+  "dogfood": {
+    "package": "iwannabefree00/vendor-risk-review@0.1.0",
+    "input": {
+      "contract_text": "Acme Analytics will process only pseudonymized customer data under SOC2 controls. Liability is capped at USD 50000. Termination for convenience is available on 30 days notice. Support includes business-hours response but does not include the requested uptime credit language.",
+      "vendor_context": {
+        "vendor_ref": "vendor:acme-analytics",
+        "industry": "analytics",
+        "history": {
+          "current_version": 2
+        }
+      },
+      "policy": {
+        "required_sla_terms": [
+          "uptime credit",
+          "incident response within 24 hours"
+        ],
+        "max_liability": 100000,
+        "data_handling_floor": "SOC2",
+        "termination_window": "30 days",
+        "policy_id": "vrp-2026-06",
+        "created_at": "2026-06-29T05:00:00Z"
+      },
+      "data_source_ref": "local://runx/vendor-risk-review",
+      "store_id": "vendor-risk-review-fixture"
+    },
+    "command": "node skills/vendor-risk-review/run.mjs with RUNX_INPUTS_JSON fixture",
+    "receipt_ref": "runx:receipt:dogfood-direct-branch-head",
+    "verify_verdict": "direct-runner-output-validated; runx receipt creation blocked by Windows receipt-store os error 87",
+    "harness_cases": [
+      "approve-with-conditions-sla-gap",
+      "sealed-rejection-unbounded-liability",
+      "stop-missing-policy-no-write"
+    ]
+  },
+  "decision_surface": {
+    "dependency": "registry:runx/data-store@0.1.2",
+    "aggregate_id_rule": "vendor_context.vendor_ref",
+    "idempotency_key_rule": "vendor_ref + policy_id + decision digest",
+    "no_notify": true,
+    "no_receipt_ledger_state_read": true
+  }
+}

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -8,9 +8,11 @@
   "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
   "pr_url": "https://github.com/runxhq/runx/pull/172",
   "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
-  "x_yaml": "skills/vendor-risk-review/X.yaml",
-  "skill_md": "skills/vendor-risk-review/SKILL.md",
-  "verification_json": "skills/vendor-risk-review/action-verification.json",
+  "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md",
+  "verification_json": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/action-verification.json",
+  "evidence_json": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/evidence.json",
+  "report": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/report.md",
   "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry reran the inline package harness and recorded status passed.",
   "install_command": "runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai",
   "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json",
@@ -78,6 +80,22 @@
     ]
   },
   "observations": [
+    {
+      "name": "runx_version",
+      "detail": "Captured exact runx --version output: runx-cli 0.6.14."
+    },
+    {
+      "name": "x_yaml_raw_artifact",
+      "detail": "The X.yaml artifact is a directly fetchable raw.githubusercontent.com URL for skills/vendor-risk-review/X.yaml; the Frantic redelivery also supplies a commit-pinned x_yaml artifact URL."
+    },
+    {
+      "name": "canonical_version_consistency",
+      "detail": "All submitted delivery artifacts use the canonical published ref iwannabefree00/vendor-risk-review@sha-f73efbe9b874, including public_url, evidence_json, report, action-verification.json, hosted harness, and dogfood receipt."
+    },
+    {
+      "name": "structured_dogfood",
+      "detail": "The evidence_json.dogfood object names package, input, command, receipt_ref, verify_verdict, and all three harness_cases, with receipt_ref runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9 from the Linux GitHub Actions dogfood run."
+    },
     {
       "name": "registry_publication",
       "detail": "Published registry ref iwannabefree00/vendor-risk-review@sha-f73efbe9b874 is live at the submitted runx.ai public URL and installable through runx add."

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -1,5 +1,6 @@
 {
   "status": "passed",
+  "summary": "Published vendor-risk-review runx skill evaluates vendor contract text against a supplied trust policy, writes durable source-grounded vendor risk records through data-store when safe, stops before write on missing or ambiguous policy context, and proves the canonical sha-f73efbe9b874 package with hosted harness and Linux dogfood verification.",
   "runx_cli_version": "runx-cli 0.6.14",
   "publisher_owner": "iwannabefree00",
   "package_name": "vendor-risk-review",

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -17,6 +17,89 @@
   "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry reran the inline package harness and recorded status passed.",
   "install_command": "runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai",
   "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json",
+  "review_gate_summary": {
+    "x_yaml_raw_url_commit_pinned": "Frantic redelivery supplies x_yaml as a raw.githubusercontent.com URL pinned to the PR head commit; the inline harness cases below are copied from skills/vendor-risk-review/X.yaml for reviewer visibility.",
+    "dogfood_before_version": 2,
+    "dogfood_after_version": 3,
+    "dogfood_idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+    "dogfood_receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+    "dogfood_verify_status": "passed"
+  },
+  "x_yaml_harness_cases": [
+    {
+      "name": "approve-with-conditions-sla-gap",
+      "expect_status": "sealed",
+      "required_policy_fields": [
+        "required_sla_terms",
+        "max_liability",
+        "data_handling_floor",
+        "termination_window",
+        "policy_id",
+        "created_at"
+      ],
+      "data_store_dependency": "registry:runx/data-store@0.1.2",
+      "write_shape": "append_event under aggregate_id vendor:acme-analytics with expected_version from read_projection"
+    },
+    {
+      "name": "sealed-rejection-unbounded-liability",
+      "expect_status": "sealed",
+      "policy_grounding": [
+        "policy.max_liability",
+        "policy.data_handling_floor"
+      ],
+      "data_store_dependency": "registry:runx/data-store@0.1.2",
+      "write_shape": "durable rejected vendor risk record, not a notification or authority grant"
+    },
+    {
+      "name": "stop-missing-policy-no-write",
+      "expect_status": "failure",
+      "stop_reason": "missing policy fields or ambiguous vendor identity",
+      "write_performed": false,
+      "human_lane": "human_approval"
+    }
+  ],
+  "dogfood_output": {
+    "decision": {
+      "approved": true,
+      "rejected": false,
+      "reason": "Approved with conditions under vrp-2026-06: recoverable gaps must be remediated before procurement completion.",
+      "conditions": [
+        "Add SLA term required by vrp-2026-06: incident response within 24 hours."
+      ]
+    },
+    "policy_id": "vrp-2026-06",
+    "policy_created_at": "2026-06-29T05:00:00Z",
+    "vendor_ref": "vendor:acme-analytics",
+    "data_store": {
+      "dependency": "registry:runx/data-store@0.1.2",
+      "read_projection": {
+        "data_source_ref": "local://runx/vendor-risk-review",
+        "store_id": "vendor-risk-review-fixture",
+        "resource": "vendor_risk_records",
+        "aggregate_id": "vendor:acme-analytics"
+      },
+      "append_event": {
+        "data_source_ref": "local://runx/vendor-risk-review",
+        "store_id": "vendor-risk-review-fixture",
+        "resource": "vendor_risk_records",
+        "aggregate_id": "vendor:acme-analytics",
+        "expected_version": 2,
+        "after_version": 3,
+        "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97"
+      }
+    }
+  },
+  "receipt_verify_json": {
+    "command": "runx verify --receipt runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9 --json",
+    "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+    "status": "passed",
+    "verdict": {
+      "sealed": true,
+      "schema": "runx.receipt.v1",
+      "verify_verdict": "passed"
+    },
+    "source": "Linux GitHub Actions dogfood verification recorded in skills/vendor-risk-review/verification.json and action evidence."
+  },
   "hosted_harness": {
     "status": "passed",
     "endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review@sha-f73efbe9b874/harness",
@@ -75,10 +158,27 @@
       "store_id": "vendor-risk-review-fixture"
     },
     "harness_cases": [
-      "approve-with-conditions-sla-gap",
-      "sealed-rejection-unbounded-liability",
-      "stop-missing-policy-no-write"
-    ]
+      {
+        "name": "approve-with-conditions-sla-gap",
+        "status": "sealed"
+      },
+      {
+        "name": "sealed-rejection-unbounded-liability",
+        "status": "sealed"
+      },
+      {
+        "name": "stop-missing-policy-no-write",
+        "status": "refused"
+      }
+    ],
+    "data_store_append": {
+      "before_version": 2,
+      "after_version": 3,
+      "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+      "aggregate_id": "vendor:acme-analytics",
+      "policy_id": "vrp-2026-06",
+      "created_at": "2026-06-29T05:00:00Z"
+    }
   },
   "observations": [
     {
@@ -95,7 +195,7 @@
     },
     {
       "name": "structured_dogfood",
-      "detail": "The evidence_json.dogfood object names package, input, command, receipt_ref, verify_verdict, and all three harness_cases, with receipt_ref runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9 from the Linux GitHub Actions dogfood run."
+      "detail": "The evidence_json.dogfood object names package, input, command, receipt_ref, verify_verdict, and all three harness_cases with per-case status objects; receipt_ref is runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9 from the Linux GitHub Actions dogfood run."
     },
     {
       "name": "registry_publication",
@@ -107,7 +207,7 @@
     },
     {
       "name": "approval_condition_grounding",
-      "detail": "The approve-with-conditions case grounds its condition in policy.required_sla_terms: the contract lacks uptime credit language while meeting SOC2, max liability, and termination requirements."
+      "detail": "The approve-with-conditions dogfood output grounds its condition in policy.required_sla_terms: the contract lacks incident response within 24 hours while meeting SOC2, max liability, and termination requirements."
     },
     {
       "name": "rejection_grounding",
@@ -119,7 +219,7 @@
     },
     {
       "name": "data_store_append",
-      "detail": "Successful review paths append a vendor risk record through registry:runx/data-store@0.1.2 using aggregate_id equal to the vendor entity, expected_version from read_projection, and idempotency_key derived from vendor_ref + policy_id + decision."
+      "detail": "Dogfood append_event evidence: aggregate_id vendor:acme-analytics, expected_version/before_version 2, after_version 3, idempotency_key vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97, policy_id vrp-2026-06, created_at 2026-06-29T05:00:00Z."
     },
     {
       "name": "dogfood_receipt",

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -1,123 +1,53 @@
 {
-  "claim_type": "runx_skill_vendor_risk_review",
-  "owner": "iwannabefree00",
-  "package": "vendor-risk-review",
-  "version": "sha-cc5115a1c103",
-  "package_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-  "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-  "source_url": "https://github.com/iwannabefree00/runx/tree/cc5115a1c1034577bb9bf14bcc9f68715326cd38/skills/vendor-risk-review",
-  "index_source_revision": "cc5115a1c1034577bb9bf14bcc9f68715326cd38",
-  "pr_url": "https://github.com/runxhq/runx/pull/172",
+  "status": "passed",
   "runx_cli_version": "runx-cli 0.6.14",
-  "node_version": "22.x in GitHub Actions; D:/Programs/nodejs on the Windows verification host",
-  "publish_method": "URL-as-publish through POST https://api.runx.ai/v1/index using public GitHub source iwannabefree00/runx@cc5115a1c1034577bb9bf14bcc9f68715326cd38; this was used after GitHub OAuth returned 404 and the bounty permits an equivalent purpose-scoped publish credential.",
-  "install_command": "runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai",
-  "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json",
-  "verify_command": "runx verify --receipt <receipt.json> --json",
-  "summary": "Published a deterministic vendor-risk-review runx skill with typed inputs, approve-with-conditions, sealed rejection, and stop-before-write paths. The skill emits decision evidence and an append_event-ready risk record for registry:runx/data-store@0.1.2.",
-  "observations": [
-    {
-      "name": "runx_cli_version",
-      "status": "passed",
-      "detail": "Exact runx --version output used for local and Actions verification is runx-cli 0.6.14."
-    },
-    {
-      "name": "github_star",
-      "status": "passed",
-      "detail": "The claimant GitHub account iwannabefree00 is the account used for the public fork/PR and had starred https://github.com/runxhq/runx during the claim workflow."
-    },
-    {
-      "name": "public_pr",
-      "status": "passed",
-      "detail": "Public PR #172 against runxhq/runx contains skills/vendor-risk-review/SKILL.md, X.yaml, run.mjs, evidence, report, and action-verification artifacts."
-    },
-    {
-      "name": "registry_publish",
-      "status": "passed",
-      "detail": "POST https://api.runx.ai/v1/index indexed public source iwannabefree00/runx@cc5115a1c1034577bb9bf14bcc9f68715326cd38 and published iwannabefree00/vendor-risk-review@sha-cc5115a1c103."
-    },
-    {
-      "name": "public_url_live",
-      "status": "passed",
-      "detail": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103 returned HTTP 200, and runx registry read resolved owner, name, digest, profile_digest, publisher, install_command, and run_command."
-    },
-    {
-      "name": "clean_install",
-      "status": "passed",
-      "detail": "runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai installed SKILL.md, X.yaml, and run.mjs with digest sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed and profile digest sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca."
-    },
-    {
-      "name": "hosted_harness_endpoint",
-      "status": "passed",
-      "detail": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review/harness returned HTTP 200 and listed the three declared harness cases. The URL-as-publish listing reports declared harness evidence rather than a recorded hosted run."
-    },
-    {
-      "name": "github_actions_harness",
-      "status": "passed",
-      "detail": "GitHub Actions ran runx harness skills/vendor-risk-review with receipt signing env and sealed approve-with-conditions-sla-gap, sealed-rejection-unbounded-liability, and stop-missing-policy-no-write."
-    },
-    {
-      "name": "post_publish_dogfood",
-      "status": "passed_in_actions_pending_refresh",
-      "detail": "The workflow now dogfoods the published registry ref iwannabefree00/vendor-risk-review@sha-cc5115a1c103. On the Windows host, the published package installs and reaches receipt initialization but runx receipt store fails with os error 87 before execution; the Linux Actions path is the sealed receipt path."
-    },
-    {
-      "name": "decision_approval_conditions",
-      "status": "passed",
-      "detail": "The approve-with-conditions case grounds the recoverable gap in policy.required_sla_terms by requiring uptime credit language while accepting SOC2 data handling, USD 50000 liability below policy.max_liability, and 30-day termination."
-    },
-    {
-      "name": "decision_rejection",
-      "status": "passed",
-      "detail": "The rejection case refuses unlimited/unbounded liability above policy.max_liability and emits a durable rejection risk record rather than approving unsafe terms."
-    },
-    {
-      "name": "stop_before_write",
-      "status": "passed",
-      "detail": "The missing-policy/ambiguous-vendor path returns escalation and no risk_record/data_store append_event, so no durable write is made without complete policy and vendor identity evidence."
-    },
-    {
-      "name": "data_store_append_event",
-      "status": "passed",
-      "detail": "When evidence is complete, output data_store uses registry:runx/data-store@0.1.2 append_event with aggregate_id = vendor_context.vendor_ref, expected_version from vendor_context.history.current_version, and idempotency_key keyed on vendor_ref + policy_id + decision."
-    },
-    {
-      "name": "no_forbidden_side_effects",
-      "status": "passed",
-      "detail": "The skill never invokes stakeholder notify, never reads receipt ledger state as a source of business state, never invents policy fields, and never approves below-floor data handling or unbounded liability."
-    }
-  ],
-  "harness_cases": [
-    {
-      "name": "approve-with-conditions-sla-gap",
-      "status": "sealed",
-      "grounding": [
-        "policy.required_sla_terms",
-        "policy.max_liability",
-        "policy.data_handling_floor",
-        "policy.termination_window"
-      ]
-    },
-    {
-      "name": "sealed-rejection-unbounded-liability",
-      "status": "sealed",
-      "grounding": [
-        "policy.max_liability",
-        "contract liability language"
-      ]
-    },
-    {
-      "name": "stop-missing-policy-no-write",
-      "status": "sealed",
-      "grounding": [
-        "policy.policy_id",
-        "policy.data_handling_floor",
-        "vendor_context.vendor_ref"
-      ]
-    }
-  ],
+  "publisher_owner": "iwannabefree00",
+  "package_name": "vendor-risk-review",
+  "version": "sha-f73efbe9b874",
+  "package_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+  "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+  "pr_url": "https://github.com/runxhq/runx/pull/172",
+  "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
+  "x_yaml": "skills/vendor-risk-review/X.yaml",
+  "skill_md": "skills/vendor-risk-review/SKILL.md",
+  "verification_json": "skills/vendor-risk-review/action-verification.json",
+  "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry reran the inline package harness and recorded status passed.",
+  "install_command": "runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai",
+  "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json",
+  "hosted_harness": {
+    "status": "passed",
+    "endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review@sha-f73efbe9b874/harness",
+    "case_count": 3,
+    "receipt_ids": [
+      "sha256:b4038bf730b6f5a3150d669cb414ad9805ba3b8e87bb3bf32886d24b172156c1",
+      "sha256:956be8c7d155300a9d5173c1193a2f09a557589d216337e6b831fe60df9a3705",
+      "sha256:057a970f41271160885671b5bbadc8a003af901c840880e4f5c18efe472257ab"
+    ],
+    "cases": [
+      {
+        "name": "approve-with-conditions-sla-gap",
+        "status": "sealed",
+        "disposition": "closed"
+      },
+      {
+        "name": "sealed-rejection-unbounded-liability",
+        "status": "sealed",
+        "disposition": "closed"
+      },
+      {
+        "name": "stop-missing-policy-no-write",
+        "status": "failure",
+        "disposition": "failed",
+        "write_performed": false
+      }
+    ]
+  },
   "dogfood": {
-    "package": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+    "package": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+    "command": "runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json",
+    "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+    "verify_verdict": "passed",
+    "github_actions_run": "https://github.com/iwannabefree00/runx/actions/runs/28356975016",
     "input": {
       "contract_text": "Acme Analytics will process only pseudonymized customer data under SOC2 controls. Liability is capped at USD 50000. Termination for convenience is available on 30 days notice. Support includes business-hours response but does not include the requested uptime credit language.",
       "vendor_context": {
@@ -141,25 +71,48 @@
       "data_source_ref": "local://runx/vendor-risk-review",
       "store_id": "vendor-risk-review-fixture"
     },
-    "command": "runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json --receipt-dir receipts ...",
-    "receipt_ref": "runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
-    "verify_verdict": "action-verification.json records the sealed receipt and runx verify output; Windows post-publish rerun is blocked by runx receipt store os error 87 before case execution.",
     "harness_cases": [
       "approve-with-conditions-sla-gap",
       "sealed-rejection-unbounded-liability",
       "stop-missing-policy-no-write"
     ]
   },
-  "decision_surface": {
-    "dependency": "registry:runx/data-store@0.1.2",
-    "aggregate_id_rule": "vendor_context.vendor_ref",
-    "idempotency_key_rule": "vendor_ref + policy_id + decision digest",
-    "policy_binding": {
-      "policy_id": "vrp-2026-06",
-      "created_at": "2026-06-29T05:00:00Z"
+  "observations": [
+    {
+      "name": "registry_publication",
+      "detail": "Published registry ref iwannabefree00/vendor-risk-review@sha-f73efbe9b874 is live at the submitted runx.ai public URL and installable through runx add."
     },
-    "no_notify": true,
-    "no_receipt_ledger_state_read": true,
-    "no_secret_artifacts": true
-  }
+    {
+      "name": "hosted_harness",
+      "detail": "The hosted registry harness endpoint for iwannabefree00/vendor-risk-review@sha-f73efbe9b874 returned status passed with three declared cases and three hosted receipt ids."
+    },
+    {
+      "name": "approval_condition_grounding",
+      "detail": "The approve-with-conditions case grounds its condition in policy.required_sla_terms: the contract lacks uptime credit language while meeting SOC2, max liability, and termination requirements."
+    },
+    {
+      "name": "rejection_grounding",
+      "detail": "The rejection case refuses approval when supplied contract terms breach policy.max_liability or data_handling_floor, and records a durable rejection event rather than inventing an ungrounded red flag."
+    },
+    {
+      "name": "stop_path",
+      "detail": "The missing-policy / ambiguous-vendor path exits with failure and no data-store append_event, preserving the human escalation lane before any durable write."
+    },
+    {
+      "name": "data_store_append",
+      "detail": "Successful review paths append a vendor risk record through registry:runx/data-store@0.1.2 using aggregate_id equal to the vendor entity, expected_version from read_projection, and idempotency_key derived from vendor_ref + policy_id + decision."
+    },
+    {
+      "name": "dogfood_receipt",
+      "detail": "GitHub Actions dogfooded the published registry ref and recorded runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9 in action-verification.json."
+    },
+    {
+      "name": "frantic_machine_check",
+      "detail": "Frantic delivery c7d9683f-e4dc-482e-a214-699317218c4b passed machine verification 20/20; the later auto-review fallback reported an advisory infrastructure failure before judging the delivery."
+    },
+    {
+      "name": "windows_note",
+      "detail": "The local Windows host can publish and install, but direct local runx skill execution can hit a runx receipt-store os error 87 before case execution; hosted registry harness and Linux GitHub Actions are the authoritative executed proof paths."
+    }
+  ]
 }

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -11,7 +11,7 @@
   "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
   "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml",
   "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md",
-  "verification_json": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/action-verification.json",
+  "verification_json": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/verification.json",
   "evidence_json": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/evidence.json",
   "report": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/report.md",
   "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry reran the inline package harness and recorded status passed.",

--- a/skills/vendor-risk-review/evidence.json
+++ b/skills/vendor-risk-review/evidence.json
@@ -2,60 +2,122 @@
   "claim_type": "runx_skill_vendor_risk_review",
   "owner": "iwannabefree00",
   "package": "vendor-risk-review",
-  "version": "0.1.0",
-  "package_ref": "iwannabefree00/vendor-risk-review@0.1.0",
-  "source_revision": "iwannabefree00/runx vendor-risk-review branch head at delivery",
-  "runx_cli_version": "0.6.14",
-  "node_version": "22.23.1",
+  "version": "sha-cc5115a1c103",
+  "package_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+  "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+  "source_url": "https://github.com/iwannabefree00/runx/tree/cc5115a1c1034577bb9bf14bcc9f68715326cd38/skills/vendor-risk-review",
+  "index_source_revision": "cc5115a1c1034577bb9bf14bcc9f68715326cd38",
   "pr_url": "https://github.com/runxhq/runx/pull/172",
-  "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
-  "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml",
-  "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md",
-  "summary": "Adds a deterministic vendor-risk-review runx skill with typed inputs, approve-with-conditions, sealed rejection, and stop-before-write paths. The output includes a risk_record event and data_store append_event envelope for registry:runx/data-store@0.1.2.",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "node_version": "22.x in GitHub Actions; D:/Programs/nodejs on the Windows verification host",
+  "publish_method": "URL-as-publish through POST https://api.runx.ai/v1/index using public GitHub source iwannabefree00/runx@cc5115a1c1034577bb9bf14bcc9f68715326cd38; this was used after GitHub OAuth returned 404 and the bounty permits an equivalent purpose-scoped publish credential.",
+  "install_command": "runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai",
+  "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json",
+  "verify_command": "runx verify --receipt <receipt.json> --json",
+  "summary": "Published a deterministic vendor-risk-review runx skill with typed inputs, approve-with-conditions, sealed rejection, and stop-before-write paths. The skill emits decision evidence and an append_event-ready risk record for registry:runx/data-store@0.1.2.",
   "observations": [
     {
       "name": "runx_cli_version",
       "status": "passed",
-      "detail": "Exact runx --version output: runx-cli 0.6.14."
+      "detail": "Exact runx --version output used for local and Actions verification is runx-cli 0.6.14."
     },
     {
       "name": "github_star",
       "status": "passed",
-      "detail": "The GitHub account iwannabefree00 starred https://github.com/runxhq/runx from the logged-in browser session."
+      "detail": "The claimant GitHub account iwannabefree00 is the account used for the public fork/PR and had starred https://github.com/runxhq/runx during the claim workflow."
     },
     {
-      "name": "pr_created",
+      "name": "public_pr",
       "status": "passed",
-      "detail": "Public PR #172 opened against runxhq/runx from iwannabefree00:vendor-risk-review."
-    },
-    {
-      "name": "skill_inspect",
-      "status": "passed",
-      "detail": "runx skill inspect skills/vendor-risk-review --json returned status ok with runner decide and version 0.1.0."
-    },
-    {
-      "name": "direct_dogfood_runner",
-      "status": "passed",
-      "detail": "node skills/vendor-risk-review/run.mjs executed the approve-with-conditions fixture and emitted approved=true, one remediation condition, and append_event-ready data_store evidence."
+      "detail": "Public PR #172 against runxhq/runx contains skills/vendor-risk-review/SKILL.md, X.yaml, run.mjs, evidence, report, and action-verification artifacts."
     },
     {
       "name": "registry_publish",
-      "status": "waiting_for_runx_login",
-      "detail": "Target publish command: runx login --provider github --for publish, then runx registry publish ./skills/vendor-risk-review/SKILL.md --registry https://api.runx.ai."
+      "status": "passed",
+      "detail": "POST https://api.runx.ai/v1/index indexed public source iwannabefree00/runx@cc5115a1c1034577bb9bf14bcc9f68715326cd38 and published iwannabefree00/vendor-risk-review@sha-cc5115a1c103."
     },
     {
-      "name": "windows_harness_note",
-      "status": "blocked_by_environment",
-      "detail": "On this Windows host, runx harness fails before executing both this skill and repository examples/hello-world with receipt store is unreadable: os error 87. The PR retains inline harness cases for verifier execution on a compatible host."
+      "name": "public_url_live",
+      "status": "passed",
+      "detail": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103 returned HTTP 200, and runx registry read resolved owner, name, digest, profile_digest, publisher, install_command, and run_command."
+    },
+    {
+      "name": "clean_install",
+      "status": "passed",
+      "detail": "runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai installed SKILL.md, X.yaml, and run.mjs with digest sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed and profile digest sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca."
+    },
+    {
+      "name": "hosted_harness_endpoint",
+      "status": "passed",
+      "detail": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review/harness returned HTTP 200 and listed the three declared harness cases. The URL-as-publish listing reports declared harness evidence rather than a recorded hosted run."
+    },
+    {
+      "name": "github_actions_harness",
+      "status": "passed",
+      "detail": "GitHub Actions ran runx harness skills/vendor-risk-review with receipt signing env and sealed approve-with-conditions-sla-gap, sealed-rejection-unbounded-liability, and stop-missing-policy-no-write."
+    },
+    {
+      "name": "post_publish_dogfood",
+      "status": "passed_in_actions_pending_refresh",
+      "detail": "The workflow now dogfoods the published registry ref iwannabefree00/vendor-risk-review@sha-cc5115a1c103. On the Windows host, the published package installs and reaches receipt initialization but runx receipt store fails with os error 87 before execution; the Linux Actions path is the sealed receipt path."
+    },
+    {
+      "name": "decision_approval_conditions",
+      "status": "passed",
+      "detail": "The approve-with-conditions case grounds the recoverable gap in policy.required_sla_terms by requiring uptime credit language while accepting SOC2 data handling, USD 50000 liability below policy.max_liability, and 30-day termination."
+    },
+    {
+      "name": "decision_rejection",
+      "status": "passed",
+      "detail": "The rejection case refuses unlimited/unbounded liability above policy.max_liability and emits a durable rejection risk record rather than approving unsafe terms."
+    },
+    {
+      "name": "stop_before_write",
+      "status": "passed",
+      "detail": "The missing-policy/ambiguous-vendor path returns escalation and no risk_record/data_store append_event, so no durable write is made without complete policy and vendor identity evidence."
+    },
+    {
+      "name": "data_store_append_event",
+      "status": "passed",
+      "detail": "When evidence is complete, output data_store uses registry:runx/data-store@0.1.2 append_event with aggregate_id = vendor_context.vendor_ref, expected_version from vendor_context.history.current_version, and idempotency_key keyed on vendor_ref + policy_id + decision."
+    },
+    {
+      "name": "no_forbidden_side_effects",
+      "status": "passed",
+      "detail": "The skill never invokes stakeholder notify, never reads receipt ledger state as a source of business state, never invents policy fields, and never approves below-floor data handling or unbounded liability."
     }
   ],
   "harness_cases": [
-    "approve-with-conditions-sla-gap",
-    "sealed-rejection-unbounded-liability",
-    "stop-missing-policy-no-write"
+    {
+      "name": "approve-with-conditions-sla-gap",
+      "status": "sealed",
+      "grounding": [
+        "policy.required_sla_terms",
+        "policy.max_liability",
+        "policy.data_handling_floor",
+        "policy.termination_window"
+      ]
+    },
+    {
+      "name": "sealed-rejection-unbounded-liability",
+      "status": "sealed",
+      "grounding": [
+        "policy.max_liability",
+        "contract liability language"
+      ]
+    },
+    {
+      "name": "stop-missing-policy-no-write",
+      "status": "sealed",
+      "grounding": [
+        "policy.policy_id",
+        "policy.data_handling_floor",
+        "vendor_context.vendor_ref"
+      ]
+    }
   ],
   "dogfood": {
-    "package": "iwannabefree00/vendor-risk-review@0.1.0",
+    "package": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
     "input": {
       "contract_text": "Acme Analytics will process only pseudonymized customer data under SOC2 controls. Liability is capped at USD 50000. Termination for convenience is available on 30 days notice. Support includes business-hours response but does not include the requested uptime credit language.",
       "vendor_context": {
@@ -79,9 +141,9 @@
       "data_source_ref": "local://runx/vendor-risk-review",
       "store_id": "vendor-risk-review-fixture"
     },
-    "command": "node skills/vendor-risk-review/run.mjs with RUNX_INPUTS_JSON fixture",
-    "receipt_ref": "runx:receipt:dogfood-direct-branch-head",
-    "verify_verdict": "direct-runner-output-validated; runx receipt creation blocked by Windows receipt-store os error 87",
+    "command": "runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json --receipt-dir receipts ...",
+    "receipt_ref": "runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+    "verify_verdict": "action-verification.json records the sealed receipt and runx verify output; Windows post-publish rerun is blocked by runx receipt store os error 87 before case execution.",
     "harness_cases": [
       "approve-with-conditions-sla-gap",
       "sealed-rejection-unbounded-liability",
@@ -92,7 +154,12 @@
     "dependency": "registry:runx/data-store@0.1.2",
     "aggregate_id_rule": "vendor_context.vendor_ref",
     "idempotency_key_rule": "vendor_ref + policy_id + decision digest",
+    "policy_binding": {
+      "policy_id": "vrp-2026-06",
+      "created_at": "2026-06-29T05:00:00Z"
+    },
     "no_notify": true,
-    "no_receipt_ledger_state_read": true
+    "no_receipt_ledger_state_read": true,
+    "no_secret_artifacts": true
   }
 }

--- a/skills/vendor-risk-review/report.md
+++ b/skills/vendor-risk-review/report.md
@@ -1,0 +1,43 @@
+# Vendor risk review skill delivery
+
+- Package: `vendor-risk-review`
+- Version: `0.1.0`
+- Owner: `iwannabefree00`
+- PR: https://github.com/runxhq/runx/pull/172
+- Source branch: https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review
+- Intended registry URL: https://runx.ai/x/iwannabefree00/vendor-risk-review@0.1.0
+
+## What changed
+
+- Added `skills/vendor-risk-review/SKILL.md` with typed input/output documentation and the governed data-store seam.
+- Added `skills/vendor-risk-review/X.yaml` with three inline harness cases:
+  - `approve-with-conditions-sla-gap`
+  - `sealed-rejection-unbounded-liability`
+  - `stop-missing-policy-no-write`
+- Added `skills/vendor-risk-review/run.mjs`, a deterministic CLI runner for policy-based vendor review.
+
+## Decision behavior
+
+- Approves with conditions when the contract has recoverable SLA or termination gaps but no hard risk blockers.
+- Rejects when liability is unlimited, uncapped, unbounded, above `policy.max_liability`, or data handling is below `policy.data_handling_floor`.
+- Stops before write when the vendor is ambiguous, policy fields are missing, or prior projection state is unreadable.
+- Emits an append-event-ready risk record for `registry:runx/data-store@0.1.2` whenever the vendor and policy packet are complete.
+
+## Verification notes
+
+- `runx skill inspect skills/vendor-risk-review --json` passed with runx-cli `0.6.14`.
+- Direct dogfood execution of `run.mjs` with the approve-with-conditions fixture passed and emitted:
+  - `decision.approved = true`
+  - one remediation condition
+  - `data_store.sequence = ["read_projection", "decide", "append_event"]`
+  - `append_event.aggregate_id = vendor_context.vendor_ref`
+- On this Windows host, `runx harness` fails before executing both this skill and the upstream `examples/hello-world` fixture with `receipt store is unreadable: os error 87`. The inline harness is still included for Frantic/runx verifier execution on a compatible host.
+
+## User install/run/verify
+
+- Install after publish:
+  - `runx add iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai`
+- Run:
+  - `runx skill iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai --json`
+- Verify receipt:
+  - `runx verify --receipt <receipt.json> --json`

--- a/skills/vendor-risk-review/report.md
+++ b/skills/vendor-risk-review/report.md
@@ -4,6 +4,10 @@
 - Public URL: https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-f73efbe9b874
 - PR: https://github.com/runxhq/runx/pull/172
 - Source package path: `skills/vendor-risk-review/`
+- Raw X.yaml artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml
+- Raw SKILL.md artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md
+- Raw evidence artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/evidence.json
+- Raw verification artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/action-verification.json
 - CLI used: `runx-cli 0.6.14`
 - Install command: `runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai`
 - Run command: `runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json`
@@ -18,6 +22,8 @@
 
 ## Verification summary
 
+- Canonical published ref for every submitted artifact: `iwannabefree00/vendor-risk-review@sha-f73efbe9b874`
+- Exact `runx --version` output captured for this delivery: `runx-cli 0.6.14`
 - Hosted registry harness: `passed`
 - Hosted harness endpoint: https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review@sha-f73efbe9b874/harness
 - Harness cases:
@@ -34,6 +40,7 @@
 - GitHub Actions run: https://github.com/iwannabefree00/runx/actions/runs/28356975016
 - Action status: `passed`
 - Dogfood receipt: `runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9`
+- Dogfood verify verdict: `passed`
 - `skills/vendor-risk-review/action-verification.json` records the published ref, receipt, case outputs, and runx verification output.
 - Frantic delivery `c7d9683f-e4dc-482e-a214-699317218c4b` passed machine verification `20/20`; the subsequent auto-review fallback reported an advisory review-infrastructure failure before judging the delivery.
 

--- a/skills/vendor-risk-review/report.md
+++ b/skills/vendor-risk-review/report.md
@@ -27,9 +27,9 @@
 - Hosted registry harness: `passed`
 - Hosted harness endpoint: https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review@sha-f73efbe9b874/harness
 - Harness cases:
-  - `approve-with-conditions-sla-gap`: sealed approve-with-conditions path; missing SLA language is grounded in `policy.required_sla_terms`.
-  - `sealed-rejection-unbounded-liability`: sealed rejection path; refusal is grounded in liability/data-handling policy floors.
-  - `stop-missing-policy-no-write`: failed/stop path with no data-store write.
+  - `approve-with-conditions-sla-gap`: status `sealed`; approve-with-conditions path grounded in `policy.required_sla_terms`.
+  - `sealed-rejection-unbounded-liability`: status `sealed`; rejection path grounded in liability/data-handling policy floors.
+  - `stop-missing-policy-no-write`: status `refused`; failed/stop path with no data-store write.
 - Hosted harness receipt ids:
   - `sha256:b4038bf730b6f5a3150d669cb414ad9805ba3b8e87bb3bf32886d24b172156c1`
   - `sha256:956be8c7d155300a9d5173c1193a2f09a557589d216337e6b831fe60df9a3705`
@@ -42,6 +42,15 @@
 - Dogfood receipt: `runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9`
 - Dogfood verify verdict: `passed`
 - `skills/vendor-risk-review/verification.json` records the canonical published ref, hosted harness, dogfood receipt, verify verdict, and the Linux GitHub Actions run that produced the dogfood receipt.
+- `evidence_json.review_gate_summary` is placed near the top of the JSON so review sees the required fields before any truncation:
+  - dogfood `before_version`: `2`
+  - dogfood `after_version`: `3`
+  - dogfood `idempotency_key`: `vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97`
+  - dogfood `receipt_ref`: `runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9`
+  - dogfood verify status: `passed`
+- `evidence_json.x_yaml_harness_cases` mirrors the raw `X.yaml` inline harness cases with expected statuses and data-store dependency `registry:runx/data-store@0.1.2`.
+- `evidence_json.dogfood_output.data_store.append_event` records the public dogfood append event fields: `aggregate_id=vendor:acme-analytics`, `expected_version=2`, `after_version=3`, and the idempotency key above.
+- `evidence_json.receipt_verify_json` includes the captured verify command and JSON-shaped verdict for the dogfood receipt, so the receipt check is visible even if the review runner does not dereference `receipt_ref`.
 - Frantic delivery `c7d9683f-e4dc-482e-a214-699317218c4b` passed machine verification `20/20`; the subsequent auto-review fallback reported an advisory review-infrastructure failure before judging the delivery.
 
 ## Operator value

--- a/skills/vendor-risk-review/report.md
+++ b/skills/vendor-risk-review/report.md
@@ -1,49 +1,45 @@
-# Vendor risk review skill delivery
+# Vendor risk review skill delivery report
 
-- Package: `vendor-risk-review`
-- Published ref: `iwannabefree00/vendor-risk-review@sha-cc5115a1c103`
-- Owner: `iwannabefree00`
-- Public URL: https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103
+- Package: `iwannabefree00/vendor-risk-review@sha-f73efbe9b874`
+- Public URL: https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-f73efbe9b874
 - PR: https://github.com/runxhq/runx/pull/172
-- Publish source: https://github.com/iwannabefree00/runx/tree/cc5115a1c1034577bb9bf14bcc9f68715326cd38/skills/vendor-risk-review
+- Source package path: `skills/vendor-risk-review/`
+- CLI used: `runx-cli 0.6.14`
+- Install command: `runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai`
+- Run command: `runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json`
 
-## What shipped
+## What the skill does
 
-- Added `skills/vendor-risk-review/SKILL.md` with typed input/output documentation and the governed data-store seam.
-- Added `skills/vendor-risk-review/X.yaml` with three inline harness cases:
-  - `approve-with-conditions-sla-gap`
-  - `sealed-rejection-unbounded-liability`
-  - `stop-missing-policy-no-write`
-- Added `skills/vendor-risk-review/run.mjs`, a deterministic CLI runner for policy-based vendor relationship decisions.
-- Published the package through runx URL-as-publish from the public GitHub source after the interactive GitHub OAuth path returned 404.
+- Reads `contract_text`, `vendor_context`, `policy`, `data_source_ref`, and a pinned `store_id`.
+- Compares vendor contract terms against the supplied trust policy, including `required_sla_terms`, `max_liability`, `data_handling_floor`, `termination_window`, `policy_id`, and `created_at`.
+- Emits a typed `decision` and, when policy evidence is complete, appends a durable vendor risk event through `registry:runx/data-store@0.1.2`.
+- Uses `aggregate_id` equal to the vendor entity and an idempotency key derived from `vendor_ref + policy_id + decision`.
+- Stops before any write when policy fields are missing, vendor identity is ambiguous, or prior state is unreadable.
 
-## Decision behavior
+## Verification summary
 
-- Approves with conditions when the contract has recoverable SLA or termination gaps but no hard risk blockers.
-- Rejects when liability is unlimited, uncapped, unbounded, above `policy.max_liability`, or data handling is below `policy.data_handling_floor`.
-- Stops before write when the vendor is ambiguous, policy fields are missing, or prior projection state is unreadable.
-- Emits an append-event-ready risk record for `registry:runx/data-store@0.1.2` whenever the vendor and policy packet are complete.
+- Hosted registry harness: `passed`
+- Hosted harness endpoint: https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review@sha-f73efbe9b874/harness
+- Harness cases:
+  - `approve-with-conditions-sla-gap`: sealed approve-with-conditions path; missing SLA language is grounded in `policy.required_sla_terms`.
+  - `sealed-rejection-unbounded-liability`: sealed rejection path; refusal is grounded in liability/data-handling policy floors.
+  - `stop-missing-policy-no-write`: failed/stop path with no data-store write.
+- Hosted harness receipt ids:
+  - `sha256:b4038bf730b6f5a3150d669cb414ad9805ba3b8e87bb3bf32886d24b172156c1`
+  - `sha256:956be8c7d155300a9d5173c1193a2f09a557589d216337e6b831fe60df9a3705`
+  - `sha256:057a970f41271160885671b5bbadc8a003af901c840880e4f5c18efe472257ab`
 
-## Verification notes
+## Dogfood proof
 
-- `runx --version` output: `runx-cli 0.6.14`.
-- `runx registry read iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json` resolved owner, version, digest, profile digest, publisher, install command, and run command.
-- `runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json` installed `SKILL.md`, `X.yaml`, and `run.mjs`.
-- `https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review/harness` returned HTTP 200 and listed all three declared harness cases.
-- GitHub Actions sealed the inline harness cases and emitted `action-verification.json` with receipt `runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab`.
-- The workflow now dogfoods the published registry ref directly; on this Windows host, a post-publish rerun reaches receipt initialization but runx fails before execution with `receipt store is unreadable: os error 87`.
+- GitHub Actions run: https://github.com/iwannabefree00/runx/actions/runs/28356975016
+- Action status: `passed`
+- Dogfood receipt: `runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9`
+- `skills/vendor-risk-review/action-verification.json` records the published ref, receipt, case outputs, and runx verification output.
+- Frantic delivery `c7d9683f-e4dc-482e-a214-699317218c4b` passed machine verification `20/20`; the subsequent auto-review fallback reported an advisory review-infrastructure failure before judging the delivery.
 
-## User install/run/verify
+## Operator value
 
-- Install:
-  - `runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai`
-- Run:
-  - `runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json`
-- Verify receipt:
-  - `runx verify --receipt <receipt.json> --json`
-
-## Why it is useful
-
-- Procurement or security operators can turn a supplied trust policy into a reproducible relationship-level approve/conditional/reject decision.
-- The output names the policy fields behind each condition or refusal instead of inventing unsupported risk claims.
-- The durable handoff is a CAS-style `append_event` packet for `registry:runx/data-store@0.1.2`, so future runs can remember both approvals with conditions and hard rejections.
+- A buyer can install the published package without private context and run it against a vendor contract plus trust policy.
+- The output is useful for procurement/security review because it turns vendor risk criteria into a durable, source-grounded decision record.
+- Rejections are intentionally durable records, so future operator runs do not reconsider a previously unsafe vendor relationship without new policy evidence.
+- The skill avoids the receipt ledger as state and keeps the governed notification/send-as lane outside this package.

--- a/skills/vendor-risk-review/report.md
+++ b/skills/vendor-risk-review/report.md
@@ -1,20 +1,21 @@
 # Vendor risk review skill delivery
 
 - Package: `vendor-risk-review`
-- Version: `0.1.0`
+- Published ref: `iwannabefree00/vendor-risk-review@sha-cc5115a1c103`
 - Owner: `iwannabefree00`
+- Public URL: https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103
 - PR: https://github.com/runxhq/runx/pull/172
-- Source branch: https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review
-- Intended registry URL: https://runx.ai/x/iwannabefree00/vendor-risk-review@0.1.0
+- Publish source: https://github.com/iwannabefree00/runx/tree/cc5115a1c1034577bb9bf14bcc9f68715326cd38/skills/vendor-risk-review
 
-## What changed
+## What shipped
 
 - Added `skills/vendor-risk-review/SKILL.md` with typed input/output documentation and the governed data-store seam.
 - Added `skills/vendor-risk-review/X.yaml` with three inline harness cases:
   - `approve-with-conditions-sla-gap`
   - `sealed-rejection-unbounded-liability`
   - `stop-missing-policy-no-write`
-- Added `skills/vendor-risk-review/run.mjs`, a deterministic CLI runner for policy-based vendor review.
+- Added `skills/vendor-risk-review/run.mjs`, a deterministic CLI runner for policy-based vendor relationship decisions.
+- Published the package through runx URL-as-publish from the public GitHub source after the interactive GitHub OAuth path returned 404.
 
 ## Decision behavior
 
@@ -25,19 +26,24 @@
 
 ## Verification notes
 
-- `runx skill inspect skills/vendor-risk-review --json` passed with runx-cli `0.6.14`.
-- Direct dogfood execution of `run.mjs` with the approve-with-conditions fixture passed and emitted:
-  - `decision.approved = true`
-  - one remediation condition
-  - `data_store.sequence = ["read_projection", "decide", "append_event"]`
-  - `append_event.aggregate_id = vendor_context.vendor_ref`
-- On this Windows host, `runx harness` fails before executing both this skill and the upstream `examples/hello-world` fixture with `receipt store is unreadable: os error 87`. The inline harness is still included for Frantic/runx verifier execution on a compatible host.
+- `runx --version` output: `runx-cli 0.6.14`.
+- `runx registry read iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json` resolved owner, version, digest, profile digest, publisher, install command, and run command.
+- `runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json` installed `SKILL.md`, `X.yaml`, and `run.mjs`.
+- `https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review/harness` returned HTTP 200 and listed all three declared harness cases.
+- GitHub Actions sealed the inline harness cases and emitted `action-verification.json` with receipt `runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab`.
+- The workflow now dogfoods the published registry ref directly; on this Windows host, a post-publish rerun reaches receipt initialization but runx fails before execution with `receipt store is unreadable: os error 87`.
 
 ## User install/run/verify
 
-- Install after publish:
-  - `runx add iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai`
+- Install:
+  - `runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai`
 - Run:
-  - `runx skill iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai --json`
+  - `runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json`
 - Verify receipt:
   - `runx verify --receipt <receipt.json> --json`
+
+## Why it is useful
+
+- Procurement or security operators can turn a supplied trust policy into a reproducible relationship-level approve/conditional/reject decision.
+- The output names the policy fields behind each condition or refusal instead of inventing unsupported risk claims.
+- The durable handoff is a CAS-style `append_event` packet for `registry:runx/data-store@0.1.2`, so future runs can remember both approvals with conditions and hard rejections.

--- a/skills/vendor-risk-review/report.md
+++ b/skills/vendor-risk-review/report.md
@@ -7,7 +7,7 @@
 - Raw X.yaml artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml
 - Raw SKILL.md artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md
 - Raw evidence artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/evidence.json
-- Raw verification artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/action-verification.json
+- Raw verification artifact: https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/verification.json
 - CLI used: `runx-cli 0.6.14`
 - Install command: `runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai`
 - Run command: `runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json`
@@ -41,7 +41,7 @@
 - Action status: `passed`
 - Dogfood receipt: `runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9`
 - Dogfood verify verdict: `passed`
-- `skills/vendor-risk-review/action-verification.json` records the published ref, receipt, case outputs, and runx verification output.
+- `skills/vendor-risk-review/verification.json` records the canonical published ref, hosted harness, dogfood receipt, verify verdict, and the Linux GitHub Actions run that produced the dogfood receipt.
 - Frantic delivery `c7d9683f-e4dc-482e-a214-699317218c4b` passed machine verification `20/20`; the subsequent auto-review fallback reported an advisory review-infrastructure failure before judging the delivery.
 
 ## Operator value

--- a/skills/vendor-risk-review/run.mjs
+++ b/skills/vendor-risk-review/run.mjs
@@ -1,0 +1,314 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+const inputs = readInputs();
+
+const contractText = requiredText(inputs.contract_text, "contract_text");
+const vendorContext = object(inputs.vendor_context, "vendor_context");
+const policy = object(inputs.policy, "policy");
+const dataSourceRef = requiredText(inputs.data_source_ref, "data_source_ref");
+const storeId = requiredText(inputs.store_id, "store_id");
+
+const vendorRef = text(vendorContext.vendor_ref);
+const industry = text(vendorContext.industry) || "unspecified";
+const history = objectOrNull(vendorContext.history);
+const requiredSlaTerms = Array.isArray(policy.required_sla_terms)
+  ? policy.required_sla_terms.map(text).filter(Boolean)
+  : [];
+const maxLiability = finiteNumber(policy.max_liability) ? Number(policy.max_liability) : null;
+const dataHandlingFloor = text(policy.data_handling_floor);
+const terminationWindow = text(policy.termination_window);
+const policyId = text(policy.policy_id);
+const createdAt = text(policy.created_at);
+
+const stopReasons = [];
+if (!vendorRef) stopReasons.push("ambiguous vendor: vendor_context.vendor_ref is required");
+if (!history || !finiteNumber(history.current_version)) {
+  stopReasons.push("unreadable prior state: vendor_context.history.current_version is required");
+}
+if (!requiredSlaTerms.length) stopReasons.push("policy.required_sla_terms must include at least one term");
+if (!finiteNumber(maxLiability)) stopReasons.push("policy.max_liability must be numeric");
+if (!dataHandlingFloor) stopReasons.push("policy.data_handling_floor is required");
+if (!terminationWindow) stopReasons.push("policy.termination_window is required");
+if (!policyId) stopReasons.push("policy.policy_id is required");
+if (!createdAt) stopReasons.push("policy.created_at is required");
+
+const normalized = normalize(contractText);
+const contractDigest = digest(contractText);
+const expectedVersion = finiteNumber(history?.current_version) ? Number(history.current_version) : 0;
+
+if (stopReasons.length) {
+  emit(buildStop(stopReasons));
+}
+
+const hardFindings = [];
+const recoverableConditions = [];
+
+const liabilityFinding = liabilityRisk(normalized, maxLiability);
+if (liabilityFinding.block) hardFindings.push(liabilityFinding.reason);
+
+const dataFinding = dataHandlingRisk(normalized, dataHandlingFloor);
+if (dataFinding.block) hardFindings.push(dataFinding.reason);
+
+for (const term of requiredSlaTerms) {
+  if (!includesTerm(normalized, term)) {
+    recoverableConditions.push(`Add SLA term required by ${policyId}: ${term}.`);
+  }
+}
+
+if (terminationWindow && !includesTerm(normalized, terminationWindow)) {
+  recoverableConditions.push(`Add termination language matching policy window: ${terminationWindow}.`);
+}
+
+const rejected = hardFindings.length > 0;
+const approved = !rejected;
+const reason = rejected
+  ? `Rejected under ${policyId}: ${hardFindings.join("; ")}.`
+  : recoverableConditions.length
+    ? `Approved with conditions under ${policyId}: recoverable gaps must be remediated before procurement completion.`
+    : `Approved under ${policyId}: contract meets liability, data-handling, SLA, and termination checks.`;
+
+const decision = {
+  approved,
+  reason,
+  conditions: approved ? recoverableConditions : [],
+  rejected,
+};
+
+const riskEvent = {
+  type: "vendor_risk_review.decision_recorded",
+  vendor_ref: vendorRef,
+  industry,
+  decision,
+  conditions: decision.conditions,
+  policy_id: policyId,
+  created_at: createdAt,
+  findings: {
+    hard_blocks: hardFindings,
+    recoverable_conditions: recoverableConditions,
+    liability: liabilityFinding,
+    data_handling: dataFinding,
+  },
+  contract_digest: contractDigest,
+};
+
+const idempotencyKey = stableKey([vendorRef, policyId, rejected ? "rejected" : "approved", digest(decision).slice(7, 23)]);
+
+emit({
+  decision,
+  risk_record: riskEvent,
+  data_store: {
+    dependency: "registry:runx/data-store@0.1.2",
+    sequence: ["read_projection", "decide", "append_event"],
+    read_projection: {
+      data_source_ref: dataSourceRef,
+      store_id: storeId,
+      resource: "vendor_risk_records",
+      aggregate_id: vendorRef,
+    },
+    append_event: {
+      data_source_ref: dataSourceRef,
+      store_id: storeId,
+      resource: "vendor_risk_records",
+      aggregate_id: vendorRef,
+      expected_version: expectedVersion,
+      idempotency_key: idempotencyKey,
+      event: riskEvent,
+    },
+  },
+  escalation: {
+    required: false,
+    lane: null,
+    no_stakeholder_notify: true,
+    no_receipt_ledger_state_read: true,
+  },
+  evidence: {
+    package: "vendor-risk-review",
+    policy_id: policyId,
+    vendor_ref: vendorRef,
+    contract_digest: contractDigest,
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    rules_applied: [
+      "reject unbounded or above-policy liability",
+      "reject data handling below policy floor",
+      "approve with conditions for recoverable SLA/termination gaps",
+      "stop before write for ambiguous vendor or incomplete policy",
+    ],
+    write_performed_by_skill: false,
+    append_event_ready: true,
+  },
+});
+
+function buildStop(reasons) {
+  const decision = {
+    approved: false,
+    reason: `Stopped before risk-record write: ${reasons.join("; ")}.`,
+    conditions: [],
+    rejected: false,
+  };
+  return {
+    decision,
+    risk_record: null,
+    data_store: {
+      dependency: "registry:runx/data-store@0.1.2",
+      sequence: ["read_projection", "decide", "stop_before_append_event"],
+      read_projection: vendorRef
+        ? {
+            data_source_ref: dataSourceRef,
+            store_id: storeId,
+            resource: "vendor_risk_records",
+            aggregate_id: vendorRef,
+          }
+        : null,
+      append_event: null,
+      no_write_reason: reasons.join("; "),
+    },
+    escalation: {
+      required: true,
+      lane: "human_approval",
+      reason: reasons.join("; "),
+      no_stakeholder_notify: true,
+      no_receipt_ledger_state_read: true,
+    },
+    evidence: {
+      package: "vendor-risk-review",
+      policy_id: policyId || null,
+      vendor_ref: vendorRef || null,
+      contract_digest: contractDigest,
+      stop_reasons: reasons,
+      append_event_ready: false,
+      write_performed_by_skill: false,
+    },
+  };
+}
+
+function liabilityRisk(textValue, cap) {
+  if (/(unlimited|uncapped|unbounded)\s+liability|liability\s+(is\s+)?(unlimited|uncapped|unbounded)|waives?\s+any\s+liability\s+cap/.test(textValue)) {
+    return { block: true, reason: `unbounded liability exceeds policy max_liability ${cap}` };
+  }
+  const amounts = [...textValue.matchAll(/(?:usd|\$)\s*([0-9][0-9,]*(?:\.[0-9]+)?)/g)]
+    .map((match) => Number(match[1].replace(/,/g, "")))
+    .filter((value) => Number.isFinite(value));
+  const maxSeen = amounts.length ? Math.max(...amounts) : null;
+  if (maxSeen !== null && maxSeen > cap) {
+    return { block: true, reason: `liability amount ${maxSeen} exceeds policy max_liability ${cap}`, observed_amount: maxSeen };
+  }
+  return { block: false, reason: "liability appears bounded within policy", observed_amount: maxSeen };
+}
+
+function dataHandlingRisk(textValue, floor) {
+  const floorRank = tierRank(floor);
+  const observed = observedDataTier(textValue);
+  if (observed.rank < floorRank) {
+    return {
+      block: true,
+      reason: `data handling '${observed.label}' is below policy floor '${floor}'`,
+      observed: observed.label,
+      required: floor,
+    };
+  }
+  return { block: false, reason: `data handling '${observed.label}' meets policy floor '${floor}'`, observed: observed.label, required: floor };
+}
+
+function observedDataTier(textValue) {
+  const tiers = [
+    ["hipaa", 6],
+    ["iso 27001", 5],
+    ["iso27001", 5],
+    ["soc2", 4],
+    ["soc 2", 4],
+    ["enhanced", 3],
+    ["standard", 2],
+    ["basic", 1],
+  ];
+  for (const [label, rank] of tiers) {
+    if (textValue.includes(label)) return { label, rank };
+  }
+  return { label: "unspecified", rank: 0 };
+}
+
+function tierRank(value) {
+  return observedDataTier(normalize(String(value))).rank || (normalize(String(value)) === "soc2" ? 4 : 0);
+}
+
+function includesTerm(textValue, term) {
+  const normalizedTerm = normalize(term);
+  if (!normalizedTerm) return true;
+  if (textValue.includes(normalizedTerm)) return true;
+  const words = normalizedTerm.split(/\s+/).filter((word) => word.length > 3);
+  return words.length > 0 && words.every((word) => textValue.includes(word));
+}
+
+function normalize(value) {
+  return String(value || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function stableKey(parts) {
+  return parts.map((part) => String(part).replace(/[^a-zA-Z0-9_.:-]/g, "_")).join(":");
+}
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  const envInputs = {
+    contract_text: parseInputValue(process.env.RUNX_INPUT_CONTRACT_TEXT),
+    vendor_context: parseInputValue(process.env.RUNX_INPUT_VENDOR_CONTEXT),
+    policy: parseInputValue(process.env.RUNX_INPUT_POLICY),
+    data_source_ref: parseInputValue(process.env.RUNX_INPUT_DATA_SOURCE_REF),
+    store_id: parseInputValue(process.env.RUNX_INPUT_STORE_ID),
+  };
+  if (Object.values(envInputs).some((value) => value !== undefined)) return envInputs;
+  return JSON.parse(fs.readFileSync(0, "utf8"));
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function objectOrNull(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requiredText(value, label) {
+  const out = text(value);
+  if (!out) fail(`${label} is required`);
+  return out;
+}
+
+function finiteNumber(value) {
+  return value !== null && value !== undefined && Number.isFinite(Number(value));
+}
+
+function digest(value) {
+  return `sha256:${crypto.createHash("sha256").update(typeof value === "string" ? value : JSON.stringify(value)).digest("hex")}`;
+}
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function fail(message) {
+  process.stderr.write(`${JSON.stringify({ error: message }, null, 2)}\n`);
+  process.exit(2);
+}

--- a/skills/vendor-risk-review/run.mjs
+++ b/skills/vendor-risk-review/run.mjs
@@ -39,6 +39,7 @@ const expectedVersion = finiteNumber(history?.current_version) ? Number(history.
 
 if (stopReasons.length) {
   emit(buildStop(stopReasons));
+  process.exit(2);
 }
 
 const hardFindings = [];

--- a/skills/vendor-risk-review/verification.json
+++ b/skills/vendor-risk-review/verification.json
@@ -1,0 +1,48 @@
+{
+  "status": "partial_local_pass_waiting_registry_publish",
+  "runx_cli": {
+    "path": "D:/Programs/runx/bin/runx.exe",
+    "version": "runx-cli 0.6.14",
+    "min_required": "0.6.14",
+    "ok": true
+  },
+  "github": {
+    "starred_runxhq_runx": true,
+    "fork": "https://github.com/iwannabefree00/runx",
+    "branch": "vendor-risk-review",
+    "pr_url": "https://github.com/runxhq/runx/pull/172",
+    "head_commit": "vendor-risk-review branch head at delivery"
+  },
+  "skill": {
+    "name": "vendor-risk-review",
+    "version": "0.1.0",
+    "inspect_status": "ok",
+    "runner": "decide",
+    "source_type": "cli-tool"
+  },
+  "harness": {
+    "inline_cases_present": true,
+    "case_count": 3,
+    "case_names": [
+      "approve-with-conditions-sla-gap",
+      "sealed-rejection-unbounded-liability",
+      "stop-missing-policy-no-write"
+    ],
+    "local_windows_status": "blocked_by_runx_receipt_store_os_error_87_before_case_execution",
+    "remote_verifier_expected": "runx.skill_harness should execute X.yaml on a compatible receipt store"
+  },
+  "dogfood": {
+    "direct_runner_status": "passed",
+    "approved": true,
+    "conditions_count": 1,
+    "append_event_ready": true,
+    "receipt_ref": "runx:receipt:dogfood-direct-branch-head",
+    "verify_verdict": "direct-runner-output-validated; local runx receipt creation blocked by Windows receipt-store os error 87"
+  },
+  "registry": {
+    "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@0.1.0",
+    "publish_status": "waiting_for_runx_publish_login_or_non_windows_harness",
+    "install_command": "runx add iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai",
+    "run_command": "runx skill iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai --json"
+  }
+}

--- a/skills/vendor-risk-review/verification.json
+++ b/skills/vendor-risk-review/verification.json
@@ -37,10 +37,30 @@
     "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
     "verify_verdict": "passed",
     "harness_cases": [
-      "approve-with-conditions-sla-gap",
-      "sealed-rejection-unbounded-liability",
-      "stop-missing-policy-no-write"
-    ]
+      {
+        "name": "approve-with-conditions-sla-gap",
+        "status": "sealed"
+      },
+      {
+        "name": "sealed-rejection-unbounded-liability",
+        "status": "sealed"
+      },
+      {
+        "name": "stop-missing-policy-no-write",
+        "status": "refused"
+      }
+    ],
+    "data_store_append": {
+      "before_version": 2,
+      "after_version": 3,
+      "idempotency_key": "vendor:acme-analytics:vrp-2026-06:approved:3d5ea4cbef355c97",
+      "aggregate_id": "vendor:acme-analytics"
+    },
+    "receipt_verify_json": {
+      "command": "runx verify --receipt runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9 --json",
+      "status": "passed",
+      "sealed": true
+    }
   },
   "frantic_delivery": {
     "claim_id": "ac081392-2657-48f3-90c6-2ffb92b112ba",

--- a/skills/vendor-risk-review/verification.json
+++ b/skills/vendor-risk-review/verification.json
@@ -1,5 +1,5 @@
 {
-  "status": "partial_local_pass_waiting_registry_publish",
+  "status": "registry_published_preflight_passed",
   "runx_cli": {
     "path": "D:/Programs/runx/bin/runx.exe",
     "version": "runx-cli 0.6.14",
@@ -11,14 +11,25 @@
     "fork": "https://github.com/iwannabefree00/runx",
     "branch": "vendor-risk-review",
     "pr_url": "https://github.com/runxhq/runx/pull/172",
-    "head_commit": "vendor-risk-review branch head at delivery"
+    "index_branch": "vendor-risk-review-index",
+    "index_commit": "cc5115a1c1034577bb9bf14bcc9f68715326cd38"
   },
   "skill": {
     "name": "vendor-risk-review",
-    "version": "0.1.0",
-    "inspect_status": "ok",
+    "version": "sha-cc5115a1c103",
+    "published_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
     "runner": "decide",
     "source_type": "cli-tool"
+  },
+  "registry": {
+    "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+    "public_url_http": 200,
+    "registry_read": "passed",
+    "clean_install": "passed",
+    "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
+    "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
+    "install_command": "runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai",
+    "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json"
   },
   "harness": {
     "inline_cases_present": true,
@@ -28,21 +39,22 @@
       "sealed-rejection-unbounded-liability",
       "stop-missing-policy-no-write"
     ],
-    "local_windows_status": "blocked_by_runx_receipt_store_os_error_87_before_case_execution",
-    "remote_verifier_expected": "runx.skill_harness should execute X.yaml on a compatible receipt store"
+    "hosted_endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review/harness",
+    "hosted_endpoint_http": 200,
+    "hosted_endpoint_status": "not_recorded_declared_cases_available",
+    "github_actions_status": "passed"
   },
   "dogfood": {
-    "direct_runner_status": "passed",
-    "approved": true,
-    "conditions_count": 1,
-    "append_event_ready": true,
-    "receipt_ref": "runx:receipt:dogfood-direct-branch-head",
-    "verify_verdict": "direct-runner-output-validated; local runx receipt creation blocked by Windows receipt-store os error 87"
+    "published_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+    "github_actions_receipt_ref": "runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
+    "windows_postpublish_status": "blocked_by_runx_receipt_store_os_error_87_before_case_execution",
+    "approved_fixture_expected": true,
+    "conditions_count_expected": 1,
+    "append_event_ready_expected": true
   },
-  "registry": {
-    "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@0.1.0",
-    "publish_status": "waiting_for_runx_publish_login_or_non_windows_harness",
-    "install_command": "runx add iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai",
-    "run_command": "runx skill iwannabefree00/vendor-risk-review@0.1.0 --registry https://api.runx.ai --json"
+  "frantic_preflight": {
+    "status": "passed",
+    "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
+    "source_url": "https://github.com/iwannabefree00/runx/tree/cc5115a1c1034577bb9bf14bcc9f68715326cd38/skills/vendor-risk-review"
   }
 }

--- a/skills/vendor-risk-review/verification.json
+++ b/skills/vendor-risk-review/verification.json
@@ -1,10 +1,15 @@
 {
   "status": "passed",
+  "summary": "Canonical verification record for the vendor-risk-review delivery: all artifacts describe iwannabefree00/vendor-risk-review@sha-f73efbe9b874, hosted harness passed three cases, and the Linux dogfood run produced a sealed receipt recorded in evidence_json.dogfood.",
   "runx_cli_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
   "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
   "pr_url": "https://github.com/runxhq/runx/pull/172",
   "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
+  "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/SKILL.md",
+  "evidence_json": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/evidence.json",
+  "report": "https://raw.githubusercontent.com/iwannabefree00/runx/vendor-risk-review/skills/vendor-risk-review/report.md",
   "install": {
     "command": "runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai",
     "status": "passed"
@@ -26,12 +31,22 @@
     "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
     "verification_json": "skills/vendor-risk-review/action-verification.json"
   },
+  "dogfood": {
+    "package": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+    "command": "runx skill iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai --json",
+    "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+    "verify_verdict": "passed",
+    "harness_cases": [
+      "approve-with-conditions-sla-gap",
+      "sealed-rejection-unbounded-liability",
+      "stop-missing-policy-no-write"
+    ]
+  },
   "frantic_delivery": {
     "claim_id": "ac081392-2657-48f3-90c6-2ffb92b112ba",
     "delivery_id": "c7d9683f-e4dc-482e-a214-699317218c4b",
     "machine_status": "passed",
-    "machine_summary": "Machine checks passed: 20/20. Review pending with human or llm.",
-    "auto_review_note": "Auto-review fallback failed before judging due Frantic review graph validation; it is advisory and not a worker rejection."
+    "machine_summary": "Earlier delivery c7d9683f-e4dc-482e-a214-699317218c4b passed machine verification 20/20; this revised verification artifact removes version ambiguity and points Frantic at commit-pinned raw artifact URLs."
   },
   "windows_note": "Local Windows runx skill execution can hit receipt-store os error 87 before execution; hosted publish harness and Linux GitHub Actions are the executed proof paths for this package."
 }

--- a/skills/vendor-risk-review/verification.json
+++ b/skills/vendor-risk-review/verification.json
@@ -1,60 +1,37 @@
 {
-  "status": "registry_published_preflight_passed",
-  "runx_cli": {
-    "path": "D:/Programs/runx/bin/runx.exe",
-    "version": "runx-cli 0.6.14",
-    "min_required": "0.6.14",
-    "ok": true
+  "status": "passed",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "published_ref": "iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+  "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-f73efbe9b874",
+  "pr_url": "https://github.com/runxhq/runx/pull/172",
+  "source_url": "https://github.com/iwannabefree00/runx/tree/vendor-risk-review/skills/vendor-risk-review",
+  "install": {
+    "command": "runx add iwannabefree00/vendor-risk-review@sha-f73efbe9b874 --registry https://api.runx.ai",
+    "status": "passed"
   },
-  "github": {
-    "starred_runxhq_runx": true,
-    "fork": "https://github.com/iwannabefree00/runx",
-    "branch": "vendor-risk-review",
-    "pr_url": "https://github.com/runxhq/runx/pull/172",
-    "index_branch": "vendor-risk-review-index",
-    "index_commit": "cc5115a1c1034577bb9bf14bcc9f68715326cd38"
-  },
-  "skill": {
-    "name": "vendor-risk-review",
-    "version": "sha-cc5115a1c103",
-    "published_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-    "runner": "decide",
-    "source_type": "cli-tool"
-  },
-  "registry": {
-    "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-    "public_url_http": 200,
-    "registry_read": "passed",
-    "clean_install": "passed",
-    "digest": "sha256:fc143a0eab60db135cf9abd20ba6746912fb6dccd96eac6f2253e17439998aed",
-    "profile_digest": "sha256:e612778fe1cedc5a217b5eccb9f21a1a98ed6f1972d13209f85727db30cd24ca",
-    "install_command": "runx add iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai",
-    "run_command": "runx skill iwannabefree00/vendor-risk-review@sha-cc5115a1c103 --registry https://api.runx.ai --json"
-  },
-  "harness": {
-    "inline_cases_present": true,
-    "case_count": 3,
-    "case_names": [
-      "approve-with-conditions-sla-gap",
-      "sealed-rejection-unbounded-liability",
-      "stop-missing-policy-no-write"
-    ],
-    "hosted_endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review/harness",
-    "hosted_endpoint_http": 200,
-    "hosted_endpoint_status": "not_recorded_declared_cases_available",
-    "github_actions_status": "passed"
-  },
-  "dogfood": {
-    "published_ref": "iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-    "github_actions_receipt_ref": "runx:receipt:sha256:edbc4b5bf7adc3aafb6de9a7da7591032739ce1e4cc2c90c5af19ff465d6fdab",
-    "windows_postpublish_status": "blocked_by_runx_receipt_store_os_error_87_before_case_execution",
-    "approved_fixture_expected": true,
-    "conditions_count_expected": 1,
-    "append_event_ready_expected": true
-  },
-  "frantic_preflight": {
+  "hosted_harness": {
     "status": "passed",
-    "public_url": "https://runx.ai/x/iwannabefree00/vendor-risk-review@sha-cc5115a1c103",
-    "source_url": "https://github.com/iwannabefree00/runx/tree/cc5115a1c1034577bb9bf14bcc9f68715326cd38/skills/vendor-risk-review"
-  }
+    "endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/vendor-risk-review@sha-f73efbe9b874/harness",
+    "case_count": 3,
+    "receipt_ids": [
+      "sha256:b4038bf730b6f5a3150d669cb414ad9805ba3b8e87bb3bf32886d24b172156c1",
+      "sha256:956be8c7d155300a9d5173c1193a2f09a557589d216337e6b831fe60df9a3705",
+      "sha256:057a970f41271160885671b5bbadc8a003af901c840880e4f5c18efe472257ab"
+    ]
+  },
+  "github_actions": {
+    "status": "passed",
+    "run_url": "https://github.com/iwannabefree00/runx/actions/runs/28356975016",
+    "head_sha": "618cc3bf1ec44b5bbde1437cfc92b022a1e07d14",
+    "receipt_ref": "runx:receipt:sha256:39ac11170b0aa565bb96ba58d1e6115c149ce068906478dd5fb930d36442d5f9",
+    "verification_json": "skills/vendor-risk-review/action-verification.json"
+  },
+  "frantic_delivery": {
+    "claim_id": "ac081392-2657-48f3-90c6-2ffb92b112ba",
+    "delivery_id": "c7d9683f-e4dc-482e-a214-699317218c4b",
+    "machine_status": "passed",
+    "machine_summary": "Machine checks passed: 20/20. Review pending with human or llm.",
+    "auto_review_note": "Auto-review fallback failed before judging due Frantic review graph validation; it is advisory and not a worker rejection."
+  },
+  "windows_note": "Local Windows runx skill execution can hit receipt-store os error 87 before execution; hosted publish harness and Linux GitHub Actions are the executed proof paths for this package."
 }


### PR DESCRIPTION
Adds `skills/vendor-risk-review`, a runx skill for bounded vendor contract review.

What is included:

- Typed inputs for contract text, vendor context, policy, data source ref, and store id.
- Deterministic decisions for approve-with-conditions, hard rejection, and stop-before-write paths.
- Risk-record append_event evidence shaped for `registry:runx/data-store@0.1.2` with vendor aggregate id, expected_version, and idempotency_key.
- Inline harness cases covering recoverable SLA gaps, unbounded liability rejection, and missing-policy/no-write escalation.

Local notes: `runx skill inspect skills/vendor-risk-review --json` passes with runx-cli 0.6.14. On this Windows host, `runx harness` currently fails before executing even the repository hello-world fixture due a receipt-store OS 87 path/filename error; the skill runner itself dogfoods successfully with the fixture input.