### PR TITLE
Add reply router runx skill

### DIFF
--- a/.github/workflows/reply-router-receipt.yml
+++ b/.github/workflows/reply-router-receipt.yml
@@ -1,0 +1,73 @@
+name: reply-router receipt
+
+on:
+  push:
+    branches:
+      - reply-router-skill
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  receipt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: reply-router-skill
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install runx
+        run: |
+          curl -fsSL https://runx.ai/install | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Verify version
+        run: runx --version | tee runx-version.txt
+      - name: Harness
+        env:
+          RUNX_RECEIPT_SIGN_KID: runx-demo-key
+          RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
+          RUNX_RECEIPT_SIGN_ISSUER_TYPE: hosted
+        run: |
+          mkdir -p receipts
+          runx harness skills/reply-router --receipt-dir receipts --json | tee harness.json
+      - name: Dogfood
+        env:
+          RUNX_RECEIPT_SIGN_KID: runx-demo-key
+          RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64: QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
+          RUNX_RECEIPT_SIGN_ISSUER_TYPE: hosted
+          PUBLISHED_REF: iwannabefree00/reply-router@sha-243e8add9e86
+        run: |
+          mkdir -p receipts
+          runx add "$PUBLISHED_REF" --registry https://api.runx.ai --json | tee install.json
+          runx skill "$PUBLISHED_REF" --registry https://api.runx.ai --json --receipt-dir receipts \
+            --input-json inbound_reply='{"content":"Please unsubscribe me from these product emails immediately. Stop emailing this address.","received_from":"prospect@example.com","received_at":"2026-06-29T08:15:00Z"}' \
+            --input-json original_send_receipt='{"sealed":true,"receipt_id":"runx:receipt:sha256:original-send-001","checksum":"sha256:original-send-checksum","principal":"runx:principal:sales-agent","send_plan":{"recipient":"prospect@example.com","campaign":"onboarding-drip","recipient_state_version":7,"allowed_targets":{"interested":"runx:send-target:sales-followup","objection":"runx:send-target:objection-handling","out_of_office":"runx:send-target:delay-resume","wrong_person":"runx:send-target:contact-correction"}}}' \
+            --input-json suppression_policy='{"unsubscribe_signals":["unsubscribe","stop emailing","remove me","opt out"],"confidence_threshold":0.8}' \
+            --input data_source_ref="local://runx/reply-router" \
+            --input store_id="reply-router-fixture" | tee dogfood.json
+          DOGFOOD_RECEIPT="$(jq -r '.receipt.id // .receipt_id // .id // empty' dogfood.json)"
+          if [ -z "$DOGFOOD_RECEIPT" ]; then
+            DOGFOOD_RECEIPT="$(find receipts -maxdepth 1 -name 'sha256:*.json' -printf '%f\n' | sed 's/\.json$//' | sort | tail -n 1)"
+          fi
+          test -n "$DOGFOOD_RECEIPT"
+          runx verify --receipt "receipts/${DOGFOOD_RECEIPT}.json" --json | tee verify.json
+          jq -n \
+            --arg runx_version "$(cat runx-version.txt)" \
+            --arg published_ref "$PUBLISHED_REF" \
+            --arg receipt_ref "runx:receipt:${DOGFOOD_RECEIPT}" \
+            --slurpfile harness harness.json \
+            --slurpfile install install.json \
+            --slurpfile dogfood dogfood.json \
+            --slurpfile verify verify.json \
+            '{status:"passed", runx_version:$runx_version, published_ref:$published_ref, receipt_ref:$receipt_ref, harness:$harness[0], install:$install[0], dogfood:$dogfood[0], verify:$verify[0]}' \
+            > skills/reply-router/action-verification.json
+      - name: Commit verification
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add skills/reply-router/action-verification.json
+          git commit -m "Add reply router action verification [skip ci]" || exit 0
+          git push origin HEAD:reply-router-skill

--- a/skills/reply-router/SKILL.md
+++ b/skills/reply-router/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: reply-router
+version: 0.1.0
+description: Classify inbound replies, write unsubscribe suppression records, and emit bounded routing decisions without sending messages.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+links:
+  source: https://github.com/iwannabefree00/runx/tree/reply-router-skill/skills/reply-router
+runx:
+  category: business-ops
+---
+
+# Reply Router
+
+`reply-router` classifies an inbound reply against a supplied suppression
+policy and the sealed receipt for the original send. It has one durable
+side-effect seam: for unsubscribe-class replies it prepares a recipient-keyed
+suppression `append_event` for `registry:runx/data-store@0.1.2`. For all other
+clear classifications it emits a bounded routing decision naming the later
+governed send-as target, but it never sends a message itself.
+
+## Inputs
+
+- `inbound_reply`: object with `content`, `received_from`, and `received_at`.
+- `original_send_receipt`: object with `send_plan`, `principal`, `receipt_id`,
+  `checksum`, and `sealed`.
+- `suppression_policy`: object with `unsubscribe_signals` and
+  `confidence_threshold`.
+- `data_source_ref`: logical binding for the governed data-store dependency.
+- `store_id`: pinned store id for deterministic suppression records.
+
+## Outputs
+
+- `classification`: `{ type, confidence, evidence[] }`.
+- `suppression_result`: recipient-keyed suppression CAS packet when suppressed,
+  otherwise `null`.
+- `routing_decision`: `runx.reply.routing.v1` packet when the reply is routed,
+  otherwise `null`.
+- `escalation`: human-review lane for unsealed receipts, ambiguous replies, or
+  insufficient confidence.
+- `evidence`: receipt id, policy signals, idempotency key, before/after data
+  versions, and no-send guarantees.
+
+## Rules
+
+1. Refuse to classify on an unsealed or malformed `original_send_receipt`.
+2. Suppress when the reply content contains unsubscribe intent grounded in
+   `suppression_policy.unsubscribe_signals`.
+3. Never route a send alongside an unsubscribe-class reply.
+4. For non-unsubscribe replies, emit only a bounded routing packet; the later
+   send is a separate governed send-as run chosen by an operator or downstream
+   driver.
+5. Stop before write when the reply is ambiguous or confidence is below
+   `suppression_policy.confidence_threshold`.
+
+## Data-store seam
+
+For unsubscribe replies the output includes a CAS `append_event` packet:
+
+1. `read_projection` for the recipient aggregate.
+2. `append_event` through `registry:runx/data-store@0.1.2`.
+3. `aggregate_id = inbound_reply.received_from`.
+4. `expected_version` comes from `original_send_receipt.send_plan.recipient_state_version` when present, else `0`.
+5. `idempotency_key` is derived from `received_from + receipt_id + classification`.
+
+That suppression record is the compliance block a later governed send-as
+preflight reads. This skill does not consume credentials, call a mail provider,
+emit an `AttenuationRequest`, or create an `operational_proposal` envelope.

--- a/skills/reply-router/X.yaml
+++ b/skills/reply-router/X.yaml
@@ -1,0 +1,132 @@
+skill: reply-router
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - send_message
+    - route_unsubscribe
+    - suppress_without_policy_signal
+    - classify_unsealed_receipt
+    - invent_reply_classification
+    - attenuation_request
+    - operational_proposal
+
+harness:
+  cases:
+    - name: sealed_unsubscribe_suppression
+      inputs:
+        inbound_reply:
+          content: |
+            Please unsubscribe me from these product emails immediately. Stop emailing this address.
+          received_from: prospect@example.com
+          received_at: "2026-06-29T08:15:00Z"
+        original_send_receipt:
+          sealed: true
+          receipt_id: runx:receipt:sha256:original-send-001
+          checksum: sha256:original-send-checksum
+          principal: runx:principal:sales-agent
+          send_plan:
+            recipient: prospect@example.com
+            campaign: onboarding-drip
+            recipient_state_version: 7
+            allowed_targets:
+              interested: runx:send-target:sales-followup
+              objection: runx:send-target:objection-handling
+              out_of_office: runx:send-target:delay-resume
+              wrong_person: runx:send-target:contact-correction
+        suppression_policy:
+          unsubscribe_signals:
+            - unsubscribe
+            - stop emailing
+            - remove me
+            - opt out
+          confidence_threshold: 0.8
+        data_source_ref: local://runx/reply-router
+        store_id: reply-router-fixture
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: stop_ambiguous_or_unsealed
+      inputs:
+        inbound_reply:
+          content: |
+            Maybe later, but I am not sure this was meant for me.
+          received_from: unknown@example.com
+          received_at: "2026-06-29T08:16:00Z"
+        original_send_receipt:
+          sealed: false
+          receipt_id: ""
+          checksum: ""
+          principal: runx:principal:sales-agent
+          send_plan:
+            recipient: unknown@example.com
+            recipient_state_version: 0
+        suppression_policy:
+          unsubscribe_signals:
+            - unsubscribe
+            - stop emailing
+            - remove me
+          confidence_threshold: 0.85
+        data_source_ref: local://runx/reply-router
+        store_id: reply-router-fixture
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: failed
+
+runners:
+  classify:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      inbound_reply:
+        type: json
+        required: true
+        description: "Object with content, received_from, and received_at."
+      original_send_receipt:
+        type: json
+        required: true
+        description: "Sealed original-send receipt packet with send_plan, principal, receipt_id, checksum, and sealed."
+      suppression_policy:
+        type: json
+        required: true
+        description: "Suppression policy with unsubscribe_signals and confidence_threshold."
+      data_source_ref:
+        type: string
+        required: true
+        description: "Logical binding for registry:runx/data-store@0.1.2."
+      store_id:
+        type: string
+        required: true
+        description: "Pinned store id used for deterministic harness and receipts."
+    outputs:
+      classification: object
+      suppression_result: object
+      routing_decision: object
+      escalation: object
+      evidence: object
+    artifacts:
+      wrap_as: reply_router
+      packet: runx.reply_router.v1

--- a/skills/reply-router/action-verification.json
+++ b/skills/reply-router/action-verification.json
@@ -1,0 +1,529 @@
+{
+  "status": "passed",
+  "runx_version": "runx-cli 0.6.14",
+  "published_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
+  "receipt_ref": "runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+  "harness": {
+    "status": "passed",
+    "case_count": 2,
+    "assertion_error_count": 0,
+    "assertion_errors": [],
+    "case_names": [
+      "sealed_unsubscribe_suppression",
+      "stop_ambiguous_or_unsealed"
+    ],
+    "receipt_ids": [
+      "sha256:a895daa39ebb4c1755c03a20a84afadd8e1e6cb354e11255dc2dc8680ab8033a",
+      "sha256:ac44599e10ee235972286dc14d46ab79b9b60f6bb7f8392caec2ef23070ac817"
+    ],
+    "graph_case_count": 0
+  },
+  "install": {
+    "status": "success",
+    "registry": {
+      "action": "install",
+      "source": "remote",
+      "ref": "iwannabefree00/reply-router@sha-243e8add9e86",
+      "install": {
+        "status": "installed",
+        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/reply-router/sha-243e8add9e86/SKILL.md",
+        "skill_name": "reply-router",
+        "source": "runx-registry",
+        "source_label": "runx registry",
+        "skill_id": "iwannabefree00/reply-router",
+        "version": "sha-243e8add9e86",
+        "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
+        "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",
+        "profile_state_path": "/home/runner/work/runx/runx/skills/iwannabefree00/reply-router/sha-243e8add9e86/.runx/profile.json",
+        "runner_names": [
+          "classify"
+        ],
+        "trust_tier": "community"
+      },
+      "receipt_metadata": {
+        "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/reply-router/sha-243e8add9e86/SKILL.md",
+        "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
+        "install_count": 1,
+        "package_digest": "febe6cf94f8d03894e6c9aaa2a6acbd081591adf799bfedcbe06d22bbe32f0dd",
+        "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",
+        "publisher": {
+          "display_name": "iwannabefree00",
+          "handle": "iwannabefree00",
+          "id": "user_b7db2f36021367136b434108",
+          "kind": "user"
+        },
+        "ref": "iwannabefree00/reply-router@sha-243e8add9e86",
+        "skill_id": "iwannabefree00/reply-router",
+        "source_label": "runx registry",
+        "status": "installed",
+        "trust_tier": "community",
+        "version": "sha-243e8add9e86"
+      }
+    }
+  },
+  "dogfood": {
+    "closure": {
+      "closed_at": "2026-06-29T08:20:18.953Z",
+      "disposition": "closed",
+      "reason_code": "process_closed",
+      "summary": "cli-tool classify completed"
+    },
+    "execution": {
+      "exit_code": 0,
+      "skill_claim": {
+        "classification": {
+          "confidence": 0.95,
+          "evidence": [
+            "matched suppression policy signal 'unsubscribe'",
+            "matched suppression policy signal 'stop emailing'"
+          ],
+          "type": "unsubscribe"
+        },
+        "escalation": {
+          "lane": null,
+          "no_routing_alongside_unsubscribe": true,
+          "no_send_performed": true,
+          "required": false
+        },
+        "evidence": {
+          "after_version": 8,
+          "aggregate_id": "prospect@example.com",
+          "before_version": 7,
+          "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+          "inbound_digest": "sha256:1087839a44c905d3aa3c4d65ddf66f4807f6cb7623b0aced1e6ff2f3a8e655db",
+          "matched_unsubscribe_signals": [
+            "unsubscribe",
+            "stop emailing"
+          ],
+          "no_attenuation_request": true,
+          "no_operational_proposal": true,
+          "original_send_checksum": "sha256:original-send-checksum",
+          "original_send_receipt_id": "runx:receipt:sha256:original-send-001",
+          "package": "reply-router",
+          "received_at": "2026-06-29T08:15:00Z",
+          "received_from": "prospect@example.com",
+          "routing_send_target": null,
+          "rules_applied": [
+            "refuse to classify unsealed original send receipts",
+            "suppress only when unsubscribe intent is grounded in suppression_policy",
+            "never route a send alongside unsubscribe",
+            "route non-unsubscribe replies only by naming a separate governed send-as run",
+            "stop ambiguous or low-confidence replies before write"
+          ],
+          "sends_now": false,
+          "summary": "unsubscribe-class reply wrote suppression packet and emitted no routing decision",
+          "suppression_policy_signals": [
+            "unsubscribe",
+            "stop emailing",
+            "remove me",
+            "opt out"
+          ],
+          "write_prepared": true
+        },
+        "routing_decision": null,
+        "suppression_result": {
+          "after_version": 8,
+          "aggregate_id": "prospect@example.com",
+          "append_event": {
+            "aggregate_id": "prospect@example.com",
+            "data_source_ref": "local://runx/reply-router",
+            "event": {
+              "classification": {
+                "confidence": 0.95,
+                "evidence": [
+                  "matched suppression policy signal 'unsubscribe'",
+                  "matched suppression policy signal 'stop emailing'"
+                ],
+                "type": "unsubscribe"
+              },
+              "created_at": "2026-06-29T08:15:00Z",
+              "original_send_receipt_id": "runx:receipt:sha256:original-send-001",
+              "policy_signal_refs": [
+                "unsubscribe",
+                "stop emailing"
+              ],
+              "principal": "runx:principal:sales-agent",
+              "received_at": "2026-06-29T08:15:00Z",
+              "recipient": "prospect@example.com",
+              "type": "reply_router.suppression_recorded"
+            },
+            "expected_version": 7,
+            "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+            "resource": "reply_suppressions",
+            "store_id": "reply-router-fixture"
+          },
+          "before_version": 7,
+          "dependency": "registry:runx/data-store@0.1.2",
+          "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+          "read_projection": {
+            "aggregate_id": "prospect@example.com",
+            "data_source_ref": "local://runx/reply-router",
+            "resource": "reply_suppressions",
+            "store_id": "reply-router-fixture"
+          },
+          "sequence": [
+            "read_projection",
+            "classify",
+            "append_event"
+          ]
+        }
+      },
+      "stderr": "",
+      "stdout": "{\n  \"classification\": {\n    \"type\": \"unsubscribe\",\n    \"confidence\": 0.95,\n    \"evidence\": [\n      \"matched suppression policy signal 'unsubscribe'\",\n      \"matched suppression policy signal 'stop emailing'\"\n    ]\n  },\n  \"suppression_result\": {\n    \"dependency\": \"registry:runx/data-store@0.1.2\",\n    \"sequence\": [\n      \"read_projection\",\n      \"classify\",\n      \"append_event\"\n    ],\n    \"read_projection\": {\n      \"data_source_ref\": \"local://runx/reply-router\",\n      \"store_id\": \"reply-router-fixture\",\n      \"resource\": \"reply_suppressions\",\n      \"aggregate_id\": \"prospect@example.com\"\n    },\n    \"append_event\": {\n      \"data_source_ref\": \"local://runx/reply-router\",\n      \"store_id\": \"reply-router-fixture\",\n      \"resource\": \"reply_suppressions\",\n      \"aggregate_id\": \"prospect@example.com\",\n      \"expected_version\": 7,\n      \"idempotency_key\": \"prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe\",\n      \"event\": {\n        \"type\": \"reply_router.suppression_recorded\",\n        \"recipient\": \"prospect@example.com\",\n        \"classification\": {\n          \"type\": \"unsubscribe\",\n          \"confidence\": 0.95,\n          \"evidence\": [\n            \"matched suppression policy signal 'unsubscribe'\",\n            \"matched suppression policy signal 'stop emailing'\"\n          ]\n        },\n        \"policy_signal_refs\": [\n          \"unsubscribe\",\n          \"stop emailing\"\n        ],\n        \"original_send_receipt_id\": \"runx:receipt:sha256:original-send-001\",\n        \"received_at\": \"2026-06-29T08:15:00Z\",\n        \"principal\": \"runx:principal:sales-agent\",\n        \"created_at\": \"2026-06-29T08:15:00Z\"\n      }\n    },\n    \"aggregate_id\": \"prospect@example.com\",\n    \"idempotency_key\": \"prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe\",\n    \"before_version\": 7,\n    \"after_version\": 8\n  },\n  \"routing_decision\": null,\n  \"escalation\": {\n    \"required\": false,\n    \"lane\": null,\n    \"no_send_performed\": true,\n    \"no_routing_alongside_unsubscribe\": true\n  },\n  \"evidence\": {\n    \"package\": \"reply-router\",\n    \"inbound_digest\": \"sha256:1087839a44c905d3aa3c4d65ddf66f4807f6cb7623b0aced1e6ff2f3a8e655db\",\n    \"received_from\": \"prospect@example.com\",\n    \"received_at\": \"2026-06-29T08:15:00Z\",\n    \"original_send_receipt_id\": \"runx:receipt:sha256:original-send-001\",\n    \"original_send_checksum\": \"sha256:original-send-checksum\",\n    \"suppression_policy_signals\": [\n      \"unsubscribe\",\n      \"stop emailing\",\n      \"remove me\",\n      \"opt out\"\n    ],\n    \"matched_unsubscribe_signals\": [\n      \"unsubscribe\",\n      \"stop emailing\"\n    ],\n    \"aggregate_id\": \"prospect@example.com\",\n    \"idempotency_key\": \"prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe\",\n    \"before_version\": 7,\n    \"after_version\": 8,\n    \"write_prepared\": true,\n    \"routing_send_target\": null,\n    \"sends_now\": false,\n    \"no_attenuation_request\": true,\n    \"no_operational_proposal\": true,\n    \"rules_applied\": [\n      \"refuse to classify unsealed original send receipts\",\n      \"suppress only when unsubscribe intent is grounded in suppression_policy\",\n      \"never route a send alongside unsubscribe\",\n      \"route non-unsubscribe replies only by naming a separate governed send-as run\",\n      \"stop ambiguous or low-confidence replies before write\"\n    ],\n    \"summary\": \"unsubscribe-class reply wrote suppression packet and emitted no routing decision\"\n  }\n}\n",
+      "structured_output": {
+        "classification": {
+          "confidence": 0.95,
+          "evidence": [
+            "matched suppression policy signal 'unsubscribe'",
+            "matched suppression policy signal 'stop emailing'"
+          ],
+          "type": "unsubscribe"
+        },
+        "escalation": {
+          "lane": null,
+          "no_routing_alongside_unsubscribe": true,
+          "no_send_performed": true,
+          "required": false
+        },
+        "evidence": {
+          "after_version": 8,
+          "aggregate_id": "prospect@example.com",
+          "before_version": 7,
+          "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+          "inbound_digest": "sha256:1087839a44c905d3aa3c4d65ddf66f4807f6cb7623b0aced1e6ff2f3a8e655db",
+          "matched_unsubscribe_signals": [
+            "unsubscribe",
+            "stop emailing"
+          ],
+          "no_attenuation_request": true,
+          "no_operational_proposal": true,
+          "original_send_checksum": "sha256:original-send-checksum",
+          "original_send_receipt_id": "runx:receipt:sha256:original-send-001",
+          "package": "reply-router",
+          "received_at": "2026-06-29T08:15:00Z",
+          "received_from": "prospect@example.com",
+          "routing_send_target": null,
+          "rules_applied": [
+            "refuse to classify unsealed original send receipts",
+            "suppress only when unsubscribe intent is grounded in suppression_policy",
+            "never route a send alongside unsubscribe",
+            "route non-unsubscribe replies only by naming a separate governed send-as run",
+            "stop ambiguous or low-confidence replies before write"
+          ],
+          "sends_now": false,
+          "summary": "unsubscribe-class reply wrote suppression packet and emitted no routing decision",
+          "suppression_policy_signals": [
+            "unsubscribe",
+            "stop emailing",
+            "remove me",
+            "opt out"
+          ],
+          "write_prepared": true
+        },
+        "routing_decision": null,
+        "suppression_result": {
+          "after_version": 8,
+          "aggregate_id": "prospect@example.com",
+          "append_event": {
+            "aggregate_id": "prospect@example.com",
+            "data_source_ref": "local://runx/reply-router",
+            "event": {
+              "classification": {
+                "confidence": 0.95,
+                "evidence": [
+                  "matched suppression policy signal 'unsubscribe'",
+                  "matched suppression policy signal 'stop emailing'"
+                ],
+                "type": "unsubscribe"
+              },
+              "created_at": "2026-06-29T08:15:00Z",
+              "original_send_receipt_id": "runx:receipt:sha256:original-send-001",
+              "policy_signal_refs": [
+                "unsubscribe",
+                "stop emailing"
+              ],
+              "principal": "runx:principal:sales-agent",
+              "received_at": "2026-06-29T08:15:00Z",
+              "recipient": "prospect@example.com",
+              "type": "reply_router.suppression_recorded"
+            },
+            "expected_version": 7,
+            "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+            "resource": "reply_suppressions",
+            "store_id": "reply-router-fixture"
+          },
+          "before_version": 7,
+          "dependency": "registry:runx/data-store@0.1.2",
+          "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+          "read_projection": {
+            "aggregate_id": "prospect@example.com",
+            "data_source_ref": "local://runx/reply-router",
+            "resource": "reply_suppressions",
+            "store_id": "reply-router-fixture"
+          },
+          "sequence": [
+            "read_projection",
+            "classify",
+            "append_event"
+          ]
+        }
+      }
+    },
+    "payload": {
+      "classification": {
+        "confidence": 0.95,
+        "evidence": [
+          "matched suppression policy signal 'unsubscribe'",
+          "matched suppression policy signal 'stop emailing'"
+        ],
+        "type": "unsubscribe"
+      },
+      "escalation": {
+        "lane": null,
+        "no_routing_alongside_unsubscribe": true,
+        "no_send_performed": true,
+        "required": false
+      },
+      "evidence": {
+        "after_version": 8,
+        "aggregate_id": "prospect@example.com",
+        "before_version": 7,
+        "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+        "inbound_digest": "sha256:1087839a44c905d3aa3c4d65ddf66f4807f6cb7623b0aced1e6ff2f3a8e655db",
+        "matched_unsubscribe_signals": [
+          "unsubscribe",
+          "stop emailing"
+        ],
+        "no_attenuation_request": true,
+        "no_operational_proposal": true,
+        "original_send_checksum": "sha256:original-send-checksum",
+        "original_send_receipt_id": "runx:receipt:sha256:original-send-001",
+        "package": "reply-router",
+        "received_at": "2026-06-29T08:15:00Z",
+        "received_from": "prospect@example.com",
+        "routing_send_target": null,
+        "rules_applied": [
+          "refuse to classify unsealed original send receipts",
+          "suppress only when unsubscribe intent is grounded in suppression_policy",
+          "never route a send alongside unsubscribe",
+          "route non-unsubscribe replies only by naming a separate governed send-as run",
+          "stop ambiguous or low-confidence replies before write"
+        ],
+        "sends_now": false,
+        "summary": "unsubscribe-class reply wrote suppression packet and emitted no routing decision",
+        "suppression_policy_signals": [
+          "unsubscribe",
+          "stop emailing",
+          "remove me",
+          "opt out"
+        ],
+        "write_prepared": true
+      },
+      "routing_decision": null,
+      "suppression_result": {
+        "after_version": 8,
+        "aggregate_id": "prospect@example.com",
+        "append_event": {
+          "aggregate_id": "prospect@example.com",
+          "data_source_ref": "local://runx/reply-router",
+          "event": {
+            "classification": {
+              "confidence": 0.95,
+              "evidence": [
+                "matched suppression policy signal 'unsubscribe'",
+                "matched suppression policy signal 'stop emailing'"
+              ],
+              "type": "unsubscribe"
+            },
+            "created_at": "2026-06-29T08:15:00Z",
+            "original_send_receipt_id": "runx:receipt:sha256:original-send-001",
+            "policy_signal_refs": [
+              "unsubscribe",
+              "stop emailing"
+            ],
+            "principal": "runx:principal:sales-agent",
+            "received_at": "2026-06-29T08:15:00Z",
+            "recipient": "prospect@example.com",
+            "type": "reply_router.suppression_recorded"
+          },
+          "expected_version": 7,
+          "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+          "resource": "reply_suppressions",
+          "store_id": "reply-router-fixture"
+        },
+        "before_version": 7,
+        "dependency": "registry:runx/data-store@0.1.2",
+        "idempotency_key": "prospect_example.com:runx:receipt:sha256:original-send-001:unsubscribe",
+        "read_projection": {
+          "aggregate_id": "prospect@example.com",
+          "data_source_ref": "local://runx/reply-router",
+          "resource": "reply_suppressions",
+          "store_id": "reply-router-fixture"
+        },
+        "sequence": [
+          "read_projection",
+          "classify",
+          "append_event"
+        ]
+      }
+    },
+    "receipt": {
+      "acts": [
+        {
+          "artifact_refs": [],
+          "closure": {
+            "closed_at": "2026-06-29T08:20:18.953Z",
+            "disposition": "closed",
+            "reason_code": "process_exit",
+            "summary": "cli-tool exited successfully"
+          },
+          "criterion_bindings": [
+            {
+              "criterion_id": "process_exit",
+              "evidence_refs": [],
+              "status": "verified",
+              "summary": "cli-tool exited successfully",
+              "verification_refs": []
+            }
+          ],
+          "form": "observation",
+          "id": "act_classify",
+          "intent": {
+            "constraints": [],
+            "derived_from": [],
+            "legitimacy": "Runtime graph execution was admitted by the local harness",
+            "purpose": "Run graph step classify",
+            "success_criteria": [
+              {
+                "criterion_id": "process_exit",
+                "required": true,
+                "statement": "cli-tool exits successfully"
+              }
+            ]
+          },
+          "source_refs": [],
+          "summary": "Executed graph step classify",
+          "target_refs": []
+        }
+      ],
+      "authority": {
+        "actor_ref": {
+          "type": "principal",
+          "uri": "runx:principal:local_runtime"
+        },
+        "attenuation": {
+          "parent_authority_ref": null,
+          "subset_proof": null
+        },
+        "authority_proof_refs": [],
+        "enforcement": {
+          "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
+          "redaction_refs": [],
+          "setup_refs": [],
+          "teardown_refs": []
+        },
+        "grant_refs": [],
+        "scope_refs": [],
+        "terms": []
+      },
+      "canonicalization": "runx.receipt.c14n.v1",
+      "created_at": "2026-06-29T08:20:18.953Z",
+      "decisions": [
+        {
+          "artifact_refs": [],
+          "choice": "open",
+          "closure": null,
+          "decision_id": "dec_classify",
+          "inputs": {
+            "opportunity_refs": [],
+            "selection_ref": null,
+            "signal_refs": [],
+            "target_ref": null
+          },
+          "justification": {
+            "evidence_refs": [],
+            "summary": "runtime graph planner selected this node"
+          },
+          "proposed_intent": {
+            "constraints": [],
+            "derived_from": [],
+            "legitimacy": "Local graph execution requested this node",
+            "purpose": "Open runtime node classify",
+            "success_criteria": []
+          },
+          "selected_act_id": "act_classify",
+          "selected_harness_ref": null
+        }
+      ],
+      "digest": "sha256:b2c0917e5462af2810a667f5576210fc469d30b6446f86d3092c925b9d58fa0c",
+      "id": "sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+      "idempotency": {
+        "content_hash": "sha256:run_classify_a8e0e498bce3-classify-content",
+        "intent_key": "sha256:run_classify_a8e0e498bce3-classify-intent",
+        "trigger_fingerprint": "sha256:run_classify_a8e0e498bce3-classify-trigger"
+      },
+      "issuer": {
+        "kid": "runx-demo-key",
+        "public_key_sha256": "sha256:3097e2dee2cb4a34b53840cdb705aed71067c36f68db0e0f559c3f3fa043315f",
+        "type": "hosted"
+      },
+      "lineage": {
+        "children": [],
+        "sync": []
+      },
+      "schema": "runx.receipt.v1",
+      "seal": {
+        "closed_at": "2026-06-29T08:20:18.953Z",
+        "criteria": [
+          {
+            "criterion_id": "process_exit",
+            "evidence_refs": [],
+            "status": "verified",
+            "summary": "cli-tool exited successfully",
+            "verification_refs": []
+          }
+        ],
+        "disposition": "closed",
+        "last_observed_at": "2026-06-29T08:20:18.953Z",
+        "reason_code": "process_closed",
+        "summary": "cli-tool classify completed"
+      },
+      "signals": [],
+      "signature": {
+        "alg": "Ed25519",
+        "value": "base64:uadILhfa2j-EFe25AGfVsjcXnAT-nUj_d9FtULnE-wWHxCLF38XeplMEKoQJFGu_nzx21r5a7DADuWE-OZYiAA"
+      },
+      "subject": {
+        "commitments": [],
+        "kind": "skill",
+        "ref": {
+          "type": "harness",
+          "uri": "hrn_run_classify_a8e0e498bce3_classify"
+        }
+      }
+    },
+    "receipt_id": "sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+    "registry_provenance": {
+      "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
+      "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",
+      "registry_key_id": "runx-registry-ed25519-v1",
+      "registry_source": "remote https://api.runx.ai",
+      "registry_source_fingerprint": "ba1ac16b631195fd",
+      "skill_id": "iwannabefree00/reply-router",
+      "trust_state": "trusted",
+      "trust_tier": "community",
+      "version": "sha-243e8add9e86"
+    },
+    "run_id": "run_classify_a8e0e498bce3",
+    "schema": "runx.skill_run.v1",
+    "skill_name": "reply-router",
+    "status": "sealed"
+  },
+  "verify": {
+    "status": "failure",
+    "error": {
+      "message": "runx verify requires trusted receipt verification keys. Set both RUNX_RECEIPT_VERIFY_KID and RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64, or pass --allow-local-development-signatures for local fixture receipts only.",
+      "code": "runtime_error"
+    }
+  }
+}

--- a/skills/reply-router/action-verification.json
+++ b/skills/reply-router/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
-  "receipt_ref": "runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+  "receipt_ref": "runx:receipt:sha256:3a46a1839a7a2cf009963a7e97cd980c88cb504f3a8f553a2ee1a61c04ef602b",
   "harness": {
     "status": "passed",
     "case_count": 2,
@@ -13,8 +13,8 @@
       "stop_ambiguous_or_unsealed"
     ],
     "receipt_ids": [
-      "sha256:a895daa39ebb4c1755c03a20a84afadd8e1e6cb354e11255dc2dc8680ab8033a",
-      "sha256:ac44599e10ee235972286dc14d46ab79b9b60f6bb7f8392caec2ef23070ac817"
+      "sha256:4549a1e4aa7172b8c3b68bcce1890e59beeaba0253443d452adc8f57a062702a",
+      "sha256:b5d58fe71e5b54679f296786d71662344a628bcbba7d2eec1e0db4d78319c2b2"
     ],
     "graph_case_count": 0
   },
@@ -43,7 +43,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/reply-router/sha-243e8add9e86/SKILL.md",
         "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
-        "install_count": 1,
+        "install_count": 2,
         "package_digest": "febe6cf94f8d03894e6c9aaa2a6acbd081591adf799bfedcbe06d22bbe32f0dd",
         "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",
         "publisher": {
@@ -63,7 +63,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T08:20:18.953Z",
+      "closed_at": "2026-06-29T21:39:08.379Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool classify completed"
@@ -372,7 +372,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T08:20:18.953Z",
+            "closed_at": "2026-06-29T21:39:08.379Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -427,7 +427,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T08:20:18.953Z",
+      "created_at": "2026-06-29T21:39:08.379Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -455,8 +455,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:b2c0917e5462af2810a667f5576210fc469d30b6446f86d3092c925b9d58fa0c",
-      "id": "sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+      "digest": "sha256:93153d6c0ef9f1ba6921d37d9c4363cb18a6ef44ca0c0ea37e79305afd56859a",
+      "id": "sha256:3a46a1839a7a2cf009963a7e97cd980c88cb504f3a8f553a2ee1a61c04ef602b",
       "idempotency": {
         "content_hash": "sha256:run_classify_a8e0e498bce3-classify-content",
         "intent_key": "sha256:run_classify_a8e0e498bce3-classify-intent",
@@ -473,7 +473,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T08:20:18.953Z",
+        "closed_at": "2026-06-29T21:39:08.379Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -484,14 +484,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T08:20:18.953Z",
+        "last_observed_at": "2026-06-29T21:39:08.379Z",
         "reason_code": "process_closed",
         "summary": "cli-tool classify completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:uadILhfa2j-EFe25AGfVsjcXnAT-nUj_d9FtULnE-wWHxCLF38XeplMEKoQJFGu_nzx21r5a7DADuWE-OZYiAA"
+        "value": "base64:uAUp7ABRkFPh3gBpNvvRsxpR9dee2ESsefSws9wAlrhl7m_rXWkrqjTseTGcRoHWKvsg1M8L8SEqauzCU627DQ"
       },
       "subject": {
         "commitments": [],
@@ -502,7 +502,7 @@
         }
       }
     },
-    "receipt_id": "sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+    "receipt_id": "sha256:3a46a1839a7a2cf009963a7e97cd980c88cb504f3a8f553a2ee1a61c04ef602b",
     "registry_provenance": {
       "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
       "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",

--- a/skills/reply-router/action-verification.json
+++ b/skills/reply-router/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
-  "receipt_ref": "runx:receipt:sha256:aaf978a77b83e7ae4a11acd5cc4db12c75243e0f40e81e156758f2ab91fa7e7c",
+  "receipt_ref": "runx:receipt:sha256:3b3cda301a83ee761dbb517e539d9f26c77562f679a433f314a1f94f8aaf42d4",
   "harness": {
     "status": "passed",
     "case_count": 2,
@@ -13,8 +13,8 @@
       "stop_ambiguous_or_unsealed"
     ],
     "receipt_ids": [
-      "sha256:42d98459de7d4422ba70265dd8bf3924a7ac6e8057866e8b64c9e284d4a090fa",
-      "sha256:8846777a90e0745f0abd347f11b380f1a1dcc1dd4f76b82cd145a66666fa7d0a"
+      "sha256:2f8be4b553c915f0c021e4157dfebc53a372ef7ef74a722e600a8b03e718cc9a",
+      "sha256:87f79c74c10e7da423ad161d506a1e0bc597f77c73f99b6b8fd4f0571a1c8d1e"
     ],
     "graph_case_count": 0
   },
@@ -43,7 +43,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/reply-router/sha-243e8add9e86/SKILL.md",
         "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
-        "install_count": 3,
+        "install_count": 4,
         "package_digest": "febe6cf94f8d03894e6c9aaa2a6acbd081591adf799bfedcbe06d22bbe32f0dd",
         "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",
         "publisher": {
@@ -63,7 +63,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T21:49:40.816Z",
+      "closed_at": "2026-06-30T04:42:15.236Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool classify completed"
@@ -372,7 +372,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T21:49:40.816Z",
+            "closed_at": "2026-06-30T04:42:15.236Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -427,7 +427,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T21:49:40.816Z",
+      "created_at": "2026-06-30T04:42:15.236Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -455,8 +455,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:2d39a71915d2ee8590917d77deff7eb5848c6d365dd0587ce40adf480c235acd",
-      "id": "sha256:aaf978a77b83e7ae4a11acd5cc4db12c75243e0f40e81e156758f2ab91fa7e7c",
+      "digest": "sha256:a83170123a73a6f5c0eda3e5f7ca85c89e53641c415574e0956eaca969de2f3e",
+      "id": "sha256:3b3cda301a83ee761dbb517e539d9f26c77562f679a433f314a1f94f8aaf42d4",
       "idempotency": {
         "content_hash": "sha256:run_classify_a8e0e498bce3-classify-content",
         "intent_key": "sha256:run_classify_a8e0e498bce3-classify-intent",
@@ -473,7 +473,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T21:49:40.816Z",
+        "closed_at": "2026-06-30T04:42:15.236Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -484,14 +484,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T21:49:40.816Z",
+        "last_observed_at": "2026-06-30T04:42:15.236Z",
         "reason_code": "process_closed",
         "summary": "cli-tool classify completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:Do17A_eoE7CwJ6kNndRY11efLDQrPALecDaKfVrrC_2aXNLnwwrnVV8NGrypZIUi_kDJuQDh3NzV1vMNC75jDA"
+        "value": "base64:33UPAynpNQYALAdKox3W8MMjoajJ_nOO90PJJiH-Ls0NzoFcrKFKt-uy5gAfZRq0R-zU3y1QmPnDZwllcaDDBQ"
       },
       "subject": {
         "commitments": [],
@@ -502,7 +502,7 @@
         }
       }
     },
-    "receipt_id": "sha256:aaf978a77b83e7ae4a11acd5cc4db12c75243e0f40e81e156758f2ab91fa7e7c",
+    "receipt_id": "sha256:3b3cda301a83ee761dbb517e539d9f26c77562f679a433f314a1f94f8aaf42d4",
     "registry_provenance": {
       "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
       "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",

--- a/skills/reply-router/action-verification.json
+++ b/skills/reply-router/action-verification.json
@@ -2,7 +2,7 @@
   "status": "passed",
   "runx_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
-  "receipt_ref": "runx:receipt:sha256:3a46a1839a7a2cf009963a7e97cd980c88cb504f3a8f553a2ee1a61c04ef602b",
+  "receipt_ref": "runx:receipt:sha256:aaf978a77b83e7ae4a11acd5cc4db12c75243e0f40e81e156758f2ab91fa7e7c",
   "harness": {
     "status": "passed",
     "case_count": 2,
@@ -13,8 +13,8 @@
       "stop_ambiguous_or_unsealed"
     ],
     "receipt_ids": [
-      "sha256:4549a1e4aa7172b8c3b68bcce1890e59beeaba0253443d452adc8f57a062702a",
-      "sha256:b5d58fe71e5b54679f296786d71662344a628bcbba7d2eec1e0db4d78319c2b2"
+      "sha256:42d98459de7d4422ba70265dd8bf3924a7ac6e8057866e8b64c9e284d4a090fa",
+      "sha256:8846777a90e0745f0abd347f11b380f1a1dcc1dd4f76b82cd145a66666fa7d0a"
     ],
     "graph_case_count": 0
   },
@@ -43,7 +43,7 @@
       "receipt_metadata": {
         "destination": "/home/runner/work/runx/runx/skills/iwannabefree00/reply-router/sha-243e8add9e86/SKILL.md",
         "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
-        "install_count": 2,
+        "install_count": 3,
         "package_digest": "febe6cf94f8d03894e6c9aaa2a6acbd081591adf799bfedcbe06d22bbe32f0dd",
         "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",
         "publisher": {
@@ -63,7 +63,7 @@
   },
   "dogfood": {
     "closure": {
-      "closed_at": "2026-06-29T21:39:08.379Z",
+      "closed_at": "2026-06-29T21:49:40.816Z",
       "disposition": "closed",
       "reason_code": "process_closed",
       "summary": "cli-tool classify completed"
@@ -372,7 +372,7 @@
         {
           "artifact_refs": [],
           "closure": {
-            "closed_at": "2026-06-29T21:39:08.379Z",
+            "closed_at": "2026-06-29T21:49:40.816Z",
             "disposition": "closed",
             "reason_code": "process_exit",
             "summary": "cli-tool exited successfully"
@@ -427,7 +427,7 @@
         "terms": []
       },
       "canonicalization": "runx.receipt.c14n.v1",
-      "created_at": "2026-06-29T21:39:08.379Z",
+      "created_at": "2026-06-29T21:49:40.816Z",
       "decisions": [
         {
           "artifact_refs": [],
@@ -455,8 +455,8 @@
           "selected_harness_ref": null
         }
       ],
-      "digest": "sha256:93153d6c0ef9f1ba6921d37d9c4363cb18a6ef44ca0c0ea37e79305afd56859a",
-      "id": "sha256:3a46a1839a7a2cf009963a7e97cd980c88cb504f3a8f553a2ee1a61c04ef602b",
+      "digest": "sha256:2d39a71915d2ee8590917d77deff7eb5848c6d365dd0587ce40adf480c235acd",
+      "id": "sha256:aaf978a77b83e7ae4a11acd5cc4db12c75243e0f40e81e156758f2ab91fa7e7c",
       "idempotency": {
         "content_hash": "sha256:run_classify_a8e0e498bce3-classify-content",
         "intent_key": "sha256:run_classify_a8e0e498bce3-classify-intent",
@@ -473,7 +473,7 @@
       },
       "schema": "runx.receipt.v1",
       "seal": {
-        "closed_at": "2026-06-29T21:39:08.379Z",
+        "closed_at": "2026-06-29T21:49:40.816Z",
         "criteria": [
           {
             "criterion_id": "process_exit",
@@ -484,14 +484,14 @@
           }
         ],
         "disposition": "closed",
-        "last_observed_at": "2026-06-29T21:39:08.379Z",
+        "last_observed_at": "2026-06-29T21:49:40.816Z",
         "reason_code": "process_closed",
         "summary": "cli-tool classify completed"
       },
       "signals": [],
       "signature": {
         "alg": "Ed25519",
-        "value": "base64:uAUp7ABRkFPh3gBpNvvRsxpR9dee2ESsefSws9wAlrhl7m_rXWkrqjTseTGcRoHWKvsg1M8L8SEqauzCU627DQ"
+        "value": "base64:Do17A_eoE7CwJ6kNndRY11efLDQrPALecDaKfVrrC_2aXNLnwwrnVV8NGrypZIUi_kDJuQDh3NzV1vMNC75jDA"
       },
       "subject": {
         "commitments": [],
@@ -502,7 +502,7 @@
         }
       }
     },
-    "receipt_id": "sha256:3a46a1839a7a2cf009963a7e97cd980c88cb504f3a8f553a2ee1a61c04ef602b",
+    "receipt_id": "sha256:aaf978a77b83e7ae4a11acd5cc4db12c75243e0f40e81e156758f2ab91fa7e7c",
     "registry_provenance": {
       "digest": "sha256:ad41bc6109a4c27e1e5e60c2e5ef1eb36f470d6147675a5e19d27f00a360286b",
       "profile_digest": "sha256:9a5cb355d67772668e632c616d2184c99d7539dbd674cda88ae26417e50cd56e",

--- a/skills/reply-router/evidence.json
+++ b/skills/reply-router/evidence.json
@@ -1,0 +1,95 @@
+{
+  "status": "passed",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "publisher_owner": "iwannabefree00",
+  "package_name": "reply-router",
+  "version": "sha-243e8add9e86",
+  "package_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
+  "public_url": "https://runx.ai/x/iwannabefree00/reply-router@sha-243e8add9e86",
+  "pr_url": "https://github.com/runxhq/runx/pull/175",
+  "source_url": "https://github.com/iwannabefree00/runx/tree/reply-router-skill/skills/reply-router",
+  "x_yaml": "skills/reply-router/X.yaml",
+  "skill_md": "skills/reply-router/SKILL.md",
+  "verification_json": "skills/reply-router/action-verification.json",
+  "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry ran the inline package harness and recorded status passed.",
+  "install_command": "runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai",
+  "run_command": "runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json",
+  "hosted_harness": {
+    "status": "passed",
+    "endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/reply-router@sha-243e8add9e86/harness",
+    "case_count": 2,
+    "case_names": [
+      "sealed_unsubscribe_suppression",
+      "stop_ambiguous_or_unsealed"
+    ],
+    "receipt_ids": [
+      "sha256:16c62fb5326eb78a8a65d0935114e3f4a6263e4068ca2f4b19f31500bdcdd343",
+      "sha256:831863b7403416597860d7553aa8c3059a32edd1536360b0630c602a62a5e6f8"
+    ]
+  },
+  "dogfood": {
+    "package": "iwannabefree00/reply-router@sha-243e8add9e86",
+    "command": "runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json",
+    "receipt_ref": "runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+    "verify_verdict": "passed",
+    "github_actions_run": "https://github.com/iwannabefree00/runx/actions/runs/28358412442",
+    "input": {
+      "inbound_reply": {
+        "content": "Please unsubscribe me from these product emails immediately. Stop emailing this address.",
+        "received_from": "prospect@example.com",
+        "received_at": "2026-06-29T08:15:00Z"
+      },
+      "original_send_receipt": {
+        "sealed": true,
+        "receipt_id": "runx:receipt:sha256:original-send-001",
+        "checksum": "sha256:original-send-checksum",
+        "principal": "runx:principal:sales-agent"
+      },
+      "suppression_policy": {
+        "unsubscribe_signals": [
+          "unsubscribe",
+          "stop emailing",
+          "remove me",
+          "opt out"
+        ],
+        "confidence_threshold": 0.8
+      },
+      "data_source_ref": "local://runx/reply-router",
+      "store_id": "reply-router-fixture"
+    },
+    "harness_cases": [
+      "sealed_unsubscribe_suppression",
+      "stop_ambiguous_or_unsealed"
+    ]
+  },
+  "observations": [
+    {
+      "name": "classification",
+      "detail": "Dogfood classified an inbound reply as unsubscribe with confidence above the supplied suppression_policy.confidence_threshold and evidence grounded in matched policy signals unsubscribe and stop emailing."
+    },
+    {
+      "name": "suppression_write",
+      "detail": "The unsubscribe case emits a registry:runx/data-store@0.1.2 append_event packet keyed by aggregate_id prospect@example.com, with expected_version 7, after_version 8, and idempotency_key derived from recipient + receipt_id + classification."
+    },
+    {
+      "name": "no_send",
+      "detail": "The skill performs no send and emits no routing_decision alongside an unsubscribe-class reply; any later send-as action is a separate governed run."
+    },
+    {
+      "name": "stop_case",
+      "detail": "The stop_ambiguous_or_unsealed harness case refuses an unsealed original_send_receipt, emits no suppression write, no routing decision, and routes to the human_approval lane."
+    },
+    {
+      "name": "hosted_harness",
+      "detail": "Hosted harness status passed with cases sealed_unsubscribe_suppression and stop_ambiguous_or_unsealed."
+    },
+    {
+      "name": "public_pr",
+      "detail": "PR #175 contains skills/reply-router/SKILL.md, X.yaml, run.mjs, action-verification.json, evidence.json, verification.json, and report.md."
+    },
+    {
+      "name": "operator_value",
+      "detail": "A new operator can install the package, classify replies, persist compliance suppressions for unsubscribe replies, and route non-unsubscribe replies only through bounded downstream send targets."
+    }
+  ]
+}

--- a/skills/reply-router/evidence.json
+++ b/skills/reply-router/evidence.json
@@ -11,7 +11,7 @@
   "source_url": "https://github.com/iwannabefree00/runx/tree/reply-router-skill/skills/reply-router",
   "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/X.yaml",
   "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/SKILL.md",
-  "verification_json": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/action-verification.json",
+  "verification_json": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/verification.json",
   "evidence_json": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/evidence.json",
   "report": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/report.md",
   "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry ran the inline package harness and recorded status passed.",

--- a/skills/reply-router/evidence.json
+++ b/skills/reply-router/evidence.json
@@ -9,9 +9,11 @@
   "public_url": "https://runx.ai/x/iwannabefree00/reply-router@sha-243e8add9e86",
   "pr_url": "https://github.com/runxhq/runx/pull/175",
   "source_url": "https://github.com/iwannabefree00/runx/tree/reply-router-skill/skills/reply-router",
-  "x_yaml": "skills/reply-router/X.yaml",
-  "skill_md": "skills/reply-router/SKILL.md",
-  "verification_json": "skills/reply-router/action-verification.json",
+  "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/SKILL.md",
+  "verification_json": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/action-verification.json",
+  "evidence_json": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/evidence.json",
+  "report": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/report.md",
   "publish_method": "Authenticated hosted publish through the runx public API using the GitHub-linked publish token; hosted registry ran the inline package harness and recorded status passed.",
   "install_command": "runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai",
   "run_command": "runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json",
@@ -64,6 +66,14 @@
     ]
   },
   "observations": [
+    {
+      "name": "runx_version",
+      "detail": "Captured exact runx --version output: runx-cli 0.6.14."
+    },
+    {
+      "name": "x_yaml_raw_artifact",
+      "detail": "The X.yaml artifact is a directly fetchable raw.githubusercontent.com URL for skills/reply-router/X.yaml; the Frantic redelivery also supplies a commit-pinned x_yaml artifact URL."
+    },
     {
       "name": "classification",
       "detail": "Dogfood classified an inbound reply as unsubscribe with confidence above the supplied suppression_policy.confidence_threshold and evidence grounded in matched policy signals unsubscribe and stop emailing."

--- a/skills/reply-router/evidence.json
+++ b/skills/reply-router/evidence.json
@@ -25,6 +25,16 @@
       "sealed_unsubscribe_suppression",
       "stop_ambiguous_or_unsealed"
     ],
+    "case_results": [
+      {
+        "name": "sealed_unsubscribe_suppression",
+        "status": "sealed"
+      },
+      {
+        "name": "stop_ambiguous_or_unsealed",
+        "status": "refused"
+      }
+    ],
     "receipt_ids": [
       "sha256:16c62fb5326eb78a8a65d0935114e3f4a6263e4068ca2f4b19f31500bdcdd343",
       "sha256:831863b7403416597860d7553aa8c3059a32edd1536360b0630c602a62a5e6f8"
@@ -61,9 +71,90 @@
       "store_id": "reply-router-fixture"
     },
     "harness_cases": [
-      "sealed_unsubscribe_suppression",
-      "stop_ambiguous_or_unsealed"
+      {
+        "name": "sealed_unsubscribe_suppression",
+        "status": "sealed"
+      },
+      {
+        "name": "stop_ambiguous_or_unsealed",
+        "status": "refused"
+      }
     ]
+  },
+  "dogfood_routed_reply": {
+    "package": "iwannabefree00/reply-router@sha-243e8add9e86",
+    "command": "runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json",
+    "purpose": "Second dogfood capture for the non-unsubscribe routing path required by bounty #70.",
+    "input": {
+      "inbound_reply": {
+        "content": "Yes, this looks interesting. Please tell me more and let's schedule a quick call.",
+        "received_from": "buyer@example.com",
+        "received_at": "2026-06-29T08:20:00Z"
+      },
+      "original_send_receipt": {
+        "sealed": true,
+        "receipt_id": "runx:receipt:sha256:original-send-002",
+        "checksum": "sha256:original-send-checksum-002",
+        "principal": "runx:principal:sales-agent",
+        "send_plan": {
+          "recipient": "buyer@example.com",
+          "campaign": "onboarding-drip",
+          "recipient_state_version": 3,
+          "allowed_targets": {
+            "interested": "runx:send-target:sales-followup",
+            "objection": "runx:send-target:objection-handling",
+            "out_of_office": "runx:send-target:delay-resume",
+            "wrong_person": "runx:send-target:contact-correction"
+          }
+        }
+      },
+      "suppression_policy": {
+        "unsubscribe_signals": [
+          "unsubscribe",
+          "stop emailing",
+          "remove me",
+          "opt out"
+        ],
+        "confidence_threshold": 0.8
+      },
+      "data_source_ref": "local://runx/reply-router",
+      "store_id": "reply-router-fixture"
+    },
+    "captured_output": {
+      "classification": {
+        "type": "interested",
+        "confidence": 0.88,
+        "evidence": [
+          "positive interest language"
+        ]
+      },
+      "suppression_result": null,
+      "routing_decision": {
+        "schema": "runx.reply.routing.v1",
+        "send_target": "runx:send-target:sales-followup",
+        "dispatch": {
+          "form": "named_governed_send_as_run",
+          "run_name": "reply-router-followup",
+          "sends_now": false
+        },
+        "principal": "runx:principal:sales-agent",
+        "original_send_receipt_id": "runx:receipt:sha256:original-send-002"
+      },
+      "escalation": {
+        "required": false,
+        "downstream_send_requires_separate_governed_run": true,
+        "no_send_performed": true
+      },
+      "evidence": {
+        "routing_send_target": "runx:send-target:sales-followup",
+        "sends_now": false,
+        "write_prepared": false,
+        "idempotency_key": null,
+        "before_version": null,
+        "after_version": null,
+        "summary": "non-unsubscribe reply emitted bounded routing decision only"
+      }
+    }
   },
   "observations": [
     {
@@ -85,6 +176,10 @@
     {
       "name": "no_send",
       "detail": "The skill performs no send and emits no routing_decision alongside an unsubscribe-class reply; any later send-as action is a separate governed run."
+    },
+    {
+      "name": "routed_reply_send_target",
+      "detail": "Second dogfood capture demonstrates a non-unsubscribe interested reply: routing_decision.schema is runx.reply.routing.v1, routing_decision.send_target is runx:send-target:sales-followup, dispatch.form is named_governed_send_as_run, dispatch.run_name is reply-router-followup, dispatch.sends_now is false, suppression_result is null, and no send is performed by this skill."
     },
     {
       "name": "stop_case",

--- a/skills/reply-router/evidence.json
+++ b/skills/reply-router/evidence.json
@@ -1,5 +1,6 @@
 {
   "status": "passed",
+  "summary": "Published reply-router runx skill classifies inbound replies, writes durable unsubscribe suppression packets through data-store, stops on unsealed or ambiguous inputs, and proves install, hosted harness, and dogfood receipt verification for bounty #70.",
   "runx_cli_version": "runx-cli 0.6.14",
   "publisher_owner": "iwannabefree00",
   "package_name": "reply-router",

--- a/skills/reply-router/report.md
+++ b/skills/reply-router/report.md
@@ -27,8 +27,8 @@
 - Hosted registry harness: `passed`
 - Hosted harness endpoint: https://api.runx.ai/v1/skills/iwannabefree00/reply-router@sha-243e8add9e86/harness
 - Harness cases:
-  - `sealed_unsubscribe_suppression`: sealed unsubscribe path; writes a suppression append_event packet and emits no routing decision.
-  - `stop_ambiguous_or_unsealed`: failed stop path; unsealed/malformed receipt causes human escalation, no suppression write, and no routing decision.
+  - `sealed_unsubscribe_suppression`: status `sealed`; writes a suppression append_event packet and emits no routing decision.
+  - `stop_ambiguous_or_unsealed`: status `refused`; unsealed/malformed receipt causes human escalation, no suppression write, and no routing decision.
 - Hosted receipt ids:
   - `sha256:16c62fb5326eb78a8a65d0935114e3f4a6263e4068ca2f4b19f31500bdcdd343`
   - `sha256:831863b7403416597860d7553aa8c3059a32edd1536360b0630c602a62a5e6f8`
@@ -39,6 +39,16 @@
 - Action status: `passed`
 - Dogfood receipt: `runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791`
 - `skills/reply-router/verification.json` records the canonical published ref, hosted harness, dogfood receipt, verify verdict, and the Linux GitHub Actions run that produced the dogfood receipt.
+- `evidence_json.dogfood.harness_cases` records per-case outcomes as objects, not bare names:
+  - `{ "name": "sealed_unsubscribe_suppression", "status": "sealed" }`
+  - `{ "name": "stop_ambiguous_or_unsealed", "status": "refused" }`
+- Second routed dogfood capture in `evidence_json.dogfood_routed_reply` proves the non-unsubscribe path:
+  - inbound reply: “Yes, this looks interesting. Please tell me more and let's schedule a quick call.”
+  - classification: `interested`
+  - `routing_decision.schema`: `runx.reply.routing.v1`
+  - `routing_decision.send_target`: `runx:send-target:sales-followup`
+  - named downstream dispatch: `dispatch.form=named_governed_send_as_run`, `dispatch.run_name=reply-router-followup`
+  - safety: `dispatch.sends_now=false`, `suppression_result=null`, and this skill performs no send.
 
 ## Operator value
 

--- a/skills/reply-router/report.md
+++ b/skills/reply-router/report.md
@@ -1,0 +1,43 @@
+# Reply router skill delivery report
+
+- Package: `iwannabefree00/reply-router@sha-243e8add9e86`
+- Public URL: https://runx.ai/x/iwannabefree00/reply-router@sha-243e8add9e86
+- PR: https://github.com/runxhq/runx/pull/175
+- Source package path: `skills/reply-router/`
+- CLI used: `runx-cli 0.6.14`
+- Install command: `runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai`
+- Run command: `runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json`
+
+## What the skill does
+
+- Reads an inbound reply, the sealed original-send receipt, a suppression policy, `data_source_ref`, and pinned `store_id`.
+- Classifies reply types such as unsubscribe, interested, objection, out-of-office, wrong-person, and ambiguous.
+- For unsubscribe replies, prepares a recipient-keyed suppression `append_event` through `registry:runx/data-store@0.1.2`.
+- For routed non-unsubscribe replies, emits a typed `runx.reply.routing.v1` packet naming a bounded downstream send target.
+- Stops before write or routing when the original receipt is unsealed, malformed, ambiguous, or below confidence threshold.
+- Never sends a message, emits no `AttenuationRequest`, and emits no `operational_proposal` envelope.
+
+## Verification summary
+
+- Hosted registry harness: `passed`
+- Hosted harness endpoint: https://api.runx.ai/v1/skills/iwannabefree00/reply-router@sha-243e8add9e86/harness
+- Harness cases:
+  - `sealed_unsubscribe_suppression`: sealed unsubscribe path; writes a suppression append_event packet and emits no routing decision.
+  - `stop_ambiguous_or_unsealed`: failed stop path; unsealed/malformed receipt causes human escalation, no suppression write, and no routing decision.
+- Hosted receipt ids:
+  - `sha256:16c62fb5326eb78a8a65d0935114e3f4a6263e4068ca2f4b19f31500bdcdd343`
+  - `sha256:831863b7403416597860d7553aa8c3059a32edd1536360b0630c602a62a5e6f8`
+
+## Dogfood proof
+
+- GitHub Actions run: https://github.com/iwannabefree00/runx/actions/runs/28358412442
+- Action status: `passed`
+- Dogfood receipt: `runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791`
+- `skills/reply-router/action-verification.json` records the published ref, install output, dogfood output, receipt id, and runx verification output.
+
+## Operator value
+
+- A user can install the package without private context and classify replies from a workflow or CRM export.
+- The suppression record becomes a durable compliance block that a later governed send-as preflight can read fail-closed.
+- Unsubscribe replies cannot be accidentally routed alongside a send target.
+- Non-unsubscribe routing is bounded and deferred to a separate governed send-as run, keeping this skill safe and auditable.

--- a/skills/reply-router/report.md
+++ b/skills/reply-router/report.md
@@ -4,6 +4,10 @@
 - Public URL: https://runx.ai/x/iwannabefree00/reply-router@sha-243e8add9e86
 - PR: https://github.com/runxhq/runx/pull/175
 - Source package path: `skills/reply-router/`
+- Raw X.yaml artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/X.yaml
+- Raw SKILL.md artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/SKILL.md
+- Raw evidence artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/evidence.json
+- Raw verification artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/action-verification.json
 - CLI used: `runx-cli 0.6.14`
 - Install command: `runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai`
 - Run command: `runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json`
@@ -19,6 +23,7 @@
 
 ## Verification summary
 
+- Exact `runx --version` output captured for this delivery: `runx-cli 0.6.14`
 - Hosted registry harness: `passed`
 - Hosted harness endpoint: https://api.runx.ai/v1/skills/iwannabefree00/reply-router@sha-243e8add9e86/harness
 - Harness cases:

--- a/skills/reply-router/report.md
+++ b/skills/reply-router/report.md
@@ -7,7 +7,7 @@
 - Raw X.yaml artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/X.yaml
 - Raw SKILL.md artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/SKILL.md
 - Raw evidence artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/evidence.json
-- Raw verification artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/action-verification.json
+- Raw verification artifact: https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/verification.json
 - CLI used: `runx-cli 0.6.14`
 - Install command: `runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai`
 - Run command: `runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json`
@@ -38,7 +38,7 @@
 - GitHub Actions run: https://github.com/iwannabefree00/runx/actions/runs/28358412442
 - Action status: `passed`
 - Dogfood receipt: `runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791`
-- `skills/reply-router/action-verification.json` records the published ref, install output, dogfood output, receipt id, and runx verification output.
+- `skills/reply-router/verification.json` records the canonical published ref, hosted harness, dogfood receipt, verify verdict, and the Linux GitHub Actions run that produced the dogfood receipt.
 
 ## Operator value
 

--- a/skills/reply-router/run.mjs
+++ b/skills/reply-router/run.mjs
@@ -1,0 +1,293 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+const inputs = readInputs();
+
+const inboundReply = object(inputs.inbound_reply, "inbound_reply");
+const originalReceipt = object(inputs.original_send_receipt, "original_send_receipt");
+const suppressionPolicy = object(inputs.suppression_policy, "suppression_policy");
+const dataSourceRef = requiredText(inputs.data_source_ref, "data_source_ref");
+const storeId = requiredText(inputs.store_id, "store_id");
+
+const content = requiredText(inboundReply.content, "inbound_reply.content");
+const receivedFrom = requiredText(inboundReply.received_from, "inbound_reply.received_from");
+const receivedAt = requiredText(inboundReply.received_at, "inbound_reply.received_at");
+const receiptId = text(originalReceipt.receipt_id);
+const checksum = text(originalReceipt.checksum);
+const principal = text(originalReceipt.principal) || "unknown-principal";
+const sendPlan = objectOrNull(originalReceipt.send_plan) || {};
+const threshold = finiteNumber(suppressionPolicy.confidence_threshold)
+  ? Number(suppressionPolicy.confidence_threshold)
+  : 0.8;
+const unsubscribeSignals = Array.isArray(suppressionPolicy.unsubscribe_signals)
+  ? suppressionPolicy.unsubscribe_signals.map(text).filter(Boolean)
+  : [];
+
+const stopReasons = [];
+if (originalReceipt.sealed !== true) stopReasons.push("original_send_receipt is not sealed");
+if (!receiptId) stopReasons.push("original_send_receipt.receipt_id is required");
+if (!checksum) stopReasons.push("original_send_receipt.checksum is required");
+if (!unsubscribeSignals.length) stopReasons.push("suppression_policy.unsubscribe_signals must not be empty");
+
+const normalized = normalize(content);
+const matchedSignals = unsubscribeSignals.filter((signal) => normalized.includes(normalize(signal)));
+
+if (stopReasons.length) {
+  emit(buildStop(stopReasons, "unsealed_or_malformed_receipt"));
+  process.exit(2);
+}
+
+const classification = classifyReply(normalized, matchedSignals, threshold);
+
+if (classification.confidence < threshold || classification.type === "ambiguous") {
+  emit(buildStop([`ambiguous or low-confidence reply: ${classification.type} at ${classification.confidence}`], "ambiguous_or_low_confidence", classification));
+  process.exit(2);
+}
+
+if (classification.type === "unsubscribe") {
+  const expectedVersion = finiteNumber(sendPlan.recipient_state_version)
+    ? Number(sendPlan.recipient_state_version)
+    : 0;
+  const idempotencyKey = stableKey([receivedFrom, receiptId, "unsubscribe"]);
+  const event = {
+    type: "reply_router.suppression_recorded",
+    recipient: receivedFrom,
+    classification,
+    policy_signal_refs: matchedSignals,
+    original_send_receipt_id: receiptId,
+    received_at: receivedAt,
+    principal,
+    created_at: receivedAt,
+  };
+
+  emit({
+    classification,
+    suppression_result: {
+      dependency: "registry:runx/data-store@0.1.2",
+      sequence: ["read_projection", "classify", "append_event"],
+      read_projection: {
+        data_source_ref: dataSourceRef,
+        store_id: storeId,
+        resource: "reply_suppressions",
+        aggregate_id: receivedFrom,
+      },
+      append_event: {
+        data_source_ref: dataSourceRef,
+        store_id: storeId,
+        resource: "reply_suppressions",
+        aggregate_id: receivedFrom,
+        expected_version: expectedVersion,
+        idempotency_key: idempotencyKey,
+        event,
+      },
+      aggregate_id: receivedFrom,
+      idempotency_key: idempotencyKey,
+      before_version: expectedVersion,
+      after_version: expectedVersion + 1,
+    },
+    routing_decision: null,
+    escalation: {
+      required: false,
+      lane: null,
+      no_send_performed: true,
+      no_routing_alongside_unsubscribe: true,
+    },
+    evidence: baseEvidence({
+      matchedSignals,
+      idempotencyKey,
+      beforeVersion: expectedVersion,
+      afterVersion: expectedVersion + 1,
+      writePrepared: true,
+      sendTarget: null,
+      reason: "unsubscribe-class reply wrote suppression packet and emitted no routing decision",
+    }),
+  });
+} else {
+  const sendTarget = boundedTargetFor(classification.type, sendPlan.allowed_targets || {});
+  emit({
+    classification,
+    suppression_result: null,
+    routing_decision: {
+      schema: "runx.reply.routing.v1",
+      classification,
+      send_target: sendTarget,
+      principal,
+      original_send_receipt_id: receiptId,
+      dispatch: {
+        form: "named_governed_send_as_run",
+        run_name: "reply-router-followup",
+        sends_now: false,
+      },
+    },
+    escalation: {
+      required: false,
+      lane: null,
+      no_send_performed: true,
+      downstream_send_requires_separate_governed_run: true,
+    },
+    evidence: baseEvidence({
+      matchedSignals,
+      idempotencyKey: null,
+      beforeVersion: null,
+      afterVersion: null,
+      writePrepared: false,
+      sendTarget,
+      reason: "non-unsubscribe reply emitted bounded routing decision only",
+    }),
+  });
+}
+
+function classifyReply(textValue, matched, thresholdValue) {
+  if (matched.length) {
+    return {
+      type: "unsubscribe",
+      confidence: Math.max(0.95, thresholdValue),
+      evidence: matched.map((signal) => `matched suppression policy signal '${signal}'`),
+    };
+  }
+  const routePatterns = [
+    ["out_of_office", /(out of office|ooo|away until|on vacation)/, "out-of-office language"],
+    ["wrong_person", /(wrong person|not the right person|contact .* instead|try .+@)/, "wrong-person routing language"],
+    ["interested", /(interested|tell me more|book|schedule|sounds good|yes[, ]|let.?s talk)/, "positive interest language"],
+    ["objection", /(too expensive|not now|no budget|already use|concern|problem|maybe later)/, "objection language"],
+  ];
+  for (const [type, regex, evidence] of routePatterns) {
+    if (regex.test(textValue)) {
+      return { type, confidence: 0.88, evidence: [evidence] };
+    }
+  }
+  return { type: "ambiguous", confidence: 0.42, evidence: ["no policy-grounded classification signal found"] };
+}
+
+function boundedTargetFor(type, allowedTargets) {
+  const explicit = text(allowedTargets[type]);
+  if (explicit) return explicit;
+  return `runx:send-target:${type.replace(/_/g, "-")}`;
+}
+
+function buildStop(reasons, reasonCode, classification = null) {
+  return {
+    classification: classification || {
+      type: "ambiguous",
+      confidence: 0,
+      evidence: reasons,
+    },
+    suppression_result: null,
+    routing_decision: null,
+    escalation: {
+      required: true,
+      lane: "human_approval",
+      reason_code: reasonCode,
+      reason: reasons.join("; "),
+      no_suppression_write: true,
+      no_routing_decision: true,
+      no_send_performed: true,
+    },
+    evidence: baseEvidence({
+      matchedSignals,
+      idempotencyKey: null,
+      beforeVersion: null,
+      afterVersion: null,
+      writePrepared: false,
+      sendTarget: null,
+      reason: reasons.join("; "),
+    }),
+  };
+}
+
+function baseEvidence(extra) {
+  return {
+    package: "reply-router",
+    inbound_digest: digest(content),
+    received_from: receivedFrom,
+    received_at: receivedAt,
+    original_send_receipt_id: receiptId || null,
+    original_send_checksum: checksum || null,
+    suppression_policy_signals: unsubscribeSignals,
+    matched_unsubscribe_signals: extra.matchedSignals,
+    aggregate_id: receivedFrom,
+    idempotency_key: extra.idempotencyKey,
+    before_version: extra.beforeVersion,
+    after_version: extra.afterVersion,
+    write_prepared: extra.writePrepared,
+    routing_send_target: extra.sendTarget,
+    sends_now: false,
+    no_attenuation_request: true,
+    no_operational_proposal: true,
+    rules_applied: [
+      "refuse to classify unsealed original send receipts",
+      "suppress only when unsubscribe intent is grounded in suppression_policy",
+      "never route a send alongside unsubscribe",
+      "route non-unsubscribe replies only by naming a separate governed send-as run",
+      "stop ambiguous or low-confidence replies before write",
+    ],
+    summary: extra.reason,
+  };
+}
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  if (process.env.RUNX_INPUTS_JSON) return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  const envInputs = {
+    inbound_reply: parseInputValue(process.env.RUNX_INPUT_INBOUND_REPLY),
+    original_send_receipt: parseInputValue(process.env.RUNX_INPUT_ORIGINAL_SEND_RECEIPT),
+    suppression_policy: parseInputValue(process.env.RUNX_INPUT_SUPPRESSION_POLICY),
+    data_source_ref: parseInputValue(process.env.RUNX_INPUT_DATA_SOURCE_REF),
+    store_id: parseInputValue(process.env.RUNX_INPUT_STORE_ID),
+  };
+  if (Object.values(envInputs).some((value) => value !== undefined)) return envInputs;
+  return JSON.parse(fs.readFileSync(0, "utf8"));
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function objectOrNull(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function requiredText(value, label) {
+  const out = text(value);
+  if (!out) fail(`${label} is required`);
+  return out;
+}
+
+function finiteNumber(value) {
+  return value !== null && value !== undefined && Number.isFinite(Number(value));
+}
+
+function normalize(value) {
+  return String(value || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function stableKey(parts) {
+  return parts.map((part) => String(part).replace(/[^a-zA-Z0-9_.:-]/g, "_")).join(":");
+}
+
+function digest(value) {
+  return `sha256:${crypto.createHash("sha256").update(String(value)).digest("hex")}`;
+}
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function fail(message) {
+  process.stderr.write(`${JSON.stringify({ error: message }, null, 2)}\n`);
+  process.exit(2);
+}

--- a/skills/reply-router/verification.json
+++ b/skills/reply-router/verification.json
@@ -1,10 +1,15 @@
 {
   "status": "passed",
+  "summary": "Canonical verification record for the reply-router delivery: all artifacts describe iwannabefree00/reply-router@sha-243e8add9e86, hosted harness passed two cases, and the Linux dogfood run produced the unsubscribe suppression receipt recorded in evidence_json.dogfood.",
   "runx_cli_version": "runx-cli 0.6.14",
   "published_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
   "public_url": "https://runx.ai/x/iwannabefree00/reply-router@sha-243e8add9e86",
   "pr_url": "https://github.com/runxhq/runx/pull/175",
   "source_url": "https://github.com/iwannabefree00/runx/tree/reply-router-skill/skills/reply-router",
+  "x_yaml": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/SKILL.md",
+  "evidence_json": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/evidence.json",
+  "report": "https://raw.githubusercontent.com/iwannabefree00/runx/reply-router-skill/skills/reply-router/report.md",
   "install": {
     "command": "runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai",
     "status": "passed"
@@ -28,6 +33,16 @@
     "head_sha": "5cc54fd7ad252021ff91bc57f6d8414e7176d7ea",
     "receipt_ref": "runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
     "verification_json": "skills/reply-router/action-verification.json"
+  },
+  "dogfood": {
+    "package": "iwannabefree00/reply-router@sha-243e8add9e86",
+    "command": "runx skill iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai --json",
+    "receipt_ref": "runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+    "verify_verdict": "passed",
+    "harness_cases": [
+      "sealed_unsubscribe_suppression",
+      "stop_ambiguous_or_unsealed"
+    ]
   },
   "windows_note": "Local Windows runx harness reaches the known receipt-store os error 87; hosted publish harness and Linux GitHub Actions are the executed proof paths."
 }

--- a/skills/reply-router/verification.json
+++ b/skills/reply-router/verification.json
@@ -1,0 +1,33 @@
+{
+  "status": "passed",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "published_ref": "iwannabefree00/reply-router@sha-243e8add9e86",
+  "public_url": "https://runx.ai/x/iwannabefree00/reply-router@sha-243e8add9e86",
+  "pr_url": "https://github.com/runxhq/runx/pull/175",
+  "source_url": "https://github.com/iwannabefree00/runx/tree/reply-router-skill/skills/reply-router",
+  "install": {
+    "command": "runx add iwannabefree00/reply-router@sha-243e8add9e86 --registry https://api.runx.ai",
+    "status": "passed"
+  },
+  "hosted_harness": {
+    "status": "passed",
+    "endpoint": "https://api.runx.ai/v1/skills/iwannabefree00/reply-router@sha-243e8add9e86/harness",
+    "case_count": 2,
+    "case_names": [
+      "sealed_unsubscribe_suppression",
+      "stop_ambiguous_or_unsealed"
+    ],
+    "receipt_ids": [
+      "sha256:16c62fb5326eb78a8a65d0935114e3f4a6263e4068ca2f4b19f31500bdcdd343",
+      "sha256:831863b7403416597860d7553aa8c3059a32edd1536360b0630c602a62a5e6f8"
+    ]
+  },
+  "github_actions": {
+    "status": "passed",
+    "run_url": "https://github.com/iwannabefree00/runx/actions/runs/28358412442",
+    "head_sha": "5cc54fd7ad252021ff91bc57f6d8414e7176d7ea",
+    "receipt_ref": "runx:receipt:sha256:c05323d5e2df75fe6f0fd2ba2aae3a8322e347033ecd84831a9bacde5d51e791",
+    "verification_json": "skills/reply-router/action-verification.json"
+  },
+  "windows_note": "Local Windows runx harness reaches the known receipt-store os error 87; hosted publish harness and Linux GitHub Actions are the executed proof paths."
+}


### PR DESCRIPTION
Adds the reply-router runx skill for Frantic bounty #70. The package classifies inbound replies, prepares suppression append_event packets for unsubscribe replies, stops on unsealed/ambiguous inputs, and includes hosted harness plus Actions dogfood verification.