### PR TITLE
feat(skills): add list-hygiene-judge — consent-state decision engine (frantic bounty #68)

### DIFF
--- a/skills/list-hygiene-judge/SKILL.md
+++ b/skills/list-hygiene-judge/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: list-hygiene-judge
+description: Decide whether a contact should be re-permissioned, suppressed, or escalated, then record the transition exactly once using compare-and-set.
+runx:
+  category: ops
+---
+
+# List Hygiene Judge
+
+Evaluate a single contact's engagement history, bounce record, and consent state,
+then write exactly one auditable transition to the contact's event stream — or
+stop without writing when evidence is missing, stale, or the contact has an
+active unsubscribe marker.
+
+This skill owns the consent-state decision engine. It never sends messages and
+never emits an operational proposal or minted grant. Delivery is the downstream
+concern of a `send-as` run. The hygiene judge determines which lane the contact
+belongs in and seals that decision as a verifiable receipt-bound event.
+
+The skill never invents engagement metrics or bounce counts it cannot read from
+the provided data. If `engagement_history` is absent or malformed, the skill
+stops rather than assuming safe defaults.
+
+## What this skill does
+
+1. Reads caller-supplied `engagement_history`, `bounce_policy`, and
+   `current_consent_state` from the run inputs.
+2. Compares `expected_version` against the version embedded in
+   `current_consent_state`. Stops with `stale_expected_version` if they differ.
+3. Checks for an active unsubscribe marker. Stops with `active_unsubscribe_marker`
+   if present; never overridden by decay logic.
+4. Evaluates hard bounces. If `engagement_history.hard_bounces > 0`, decides
+   `suppress`.
+5. Evaluates recency decay. If `engagement_history.recency_days` exceeds
+   `bounce_policy.decay_threshold_days`, decides `re_permission`.
+6. On `suppress` or `re_permission`, appends exactly one `consent.transition`
+   event using `registry:runx/data-store@0.1.2` with `expected_version` and
+   `idempotency_key` for compare-and-set.
+7. On any stop path, emits no append and records the stop code and reason. A
+   human approval lane (`list_hygiene.review`) handles escalation.
+
+## Core principles
+
+- **Hard bounces take priority.** A non-zero `hard_bounces` value always resolves
+  to `suppress` before recency is evaluated.
+- **Active unsubscribe is terminal.** A contact with `unsubscribe_marker: true` or
+  `state: unsubscribed` is never automatically re-permissioned.
+- **One write per run.** The `idempotency_key` prevents duplicate transitions. A
+  retry with the same key and same payload is a no-op.
+- **Version mismatch escalates.** If `expected_version` does not match the
+  version in `current_consent_state`, the run stops with `stale_expected_version`
+  and no append is written.
+- **No invented metrics.** All engagement and bounce data must come from the
+  caller-provided `engagement_history` object. The skill never generates or
+  assumes values.
+
+## When to use this skill
+
+- A list-hygiene pipeline needs to classify a contact before a send run.
+- A compliance workflow must produce a receipt-bound record of every consent
+  state change.
+- An operator wants deterministic, auditable re-permission decisions without
+  exposing raw contact data to downstream skills.
+
+## When not to use this skill
+
+- To send or schedule messages. Use `send-as` for delivery.
+- To evaluate consent for an entire list in one call. Run one judge per contact.
+- To make decisions when the contact has an active unsubscribe marker.
+- To bypass human review for version conflicts or ambiguous evidence.
+
+## Decision procedure
+
+1. Validate that all required inputs are present. Stop with `needs_evidence` if
+   any required field is absent or cannot be parsed.
+2. Parse `current_consent_state.version` as a number. Stop with
+   `missing_current_projection_version` if it is not a finite non-negative number.
+3. Compare `expected_version` with `current_consent_state.version`. Stop with
+   `stale_expected_version` if they differ.
+4. Check `unsubscribe_marker` and `state` for active unsubscribe. Stop with
+   `active_unsubscribe_marker` if found.
+5. Validate all four engagement metrics (`opens`, `clicks`, `hard_bounces`,
+   `recency_days`). Stop with `missing_or_invalid_<field>` if any is absent or
+   not a finite non-negative number.
+6. Validate `bounce_policy.decay_threshold_days`. Stop with
+   `missing_decay_threshold` if absent or invalid.
+7. If `hard_bounces > 0`, decide `suppress` with event type
+   `contact.consent_state.suppressed`.
+8. If `recency_days > decay_threshold_days`, decide `re_permission` with event
+   type `contact.consent_state.re_permission_required`.
+9. Otherwise, decide `active` with event type `contact.consent_state.verified`.
+10. For `suppress` or `re_permission`, call the data adapter with
+    `data_source_ref`, `resource`, `aggregate_id`, `expected_version`, and
+    `idempotency_key`. The event carries the decision state and reason.
+11. Return the output with `decision.state`, `decision.reason`, and
+    `recorded_transition` (null on stop paths).
+
+## Stop conditions
+
+- `missing_current_projection_version` — `current_consent_state.version` is
+  absent or not a finite number.
+- `stale_expected_version` — `expected_version` does not match
+  `current_consent_state.version`. No append is written.
+- `active_unsubscribe_marker` — contact has an active unsubscribe marker or
+  `state` of `unsubscribed`. No automated re-permission.
+- `missing_or_invalid_<field>` — engagement metric is absent or not a finite
+  non-negative number.
+- `missing_decay_threshold` — `bounce_policy.decay_threshold_days` is absent
+  or invalid.
+
+## Output schema
+
+```
+schema: runx.list_hygiene.decision.v1
+aggregate_id: <contact id>
+decision:
+  state: re_permission | suppress | active | stop
+  reason: <explanation>
+data_store:
+  read_projection: <projection evidence>
+  append_event: <committed event or null>
+recorded_transition: <readback projection or null>
+stop: <stop block or null>
+no_send: true
+no_operational_proposal: true
+```
+
+The skill never includes contact PII, raw credentials, or secret material in
+the output.
+
+## Worked example
+
+A contact has `recency_days: 120` against a `decay_threshold_days: 90` policy,
+`hard_bounces: 0`, and `current_consent_state: {state: active, version: 3}` with
+`expected_version: 3`. The judge decides `re_permission`, appends a
+`contact.consent_state.re_permission_required` event, and seals the receipt. A
+downstream `send-as` run reads the updated consent state before building its
+send plan.
+
+A second contact has `hard_bounces: 3`. Regardless of recency, the judge decides
+`suppress`, appends the transition, and seals the receipt.
+
+A third contact has `current_consent_state.version: 4` but the caller supplied
+`expected_version: 2`. The judge stops with `stale_expected_version` and writes
+nothing. The pipeline reloads the stream and retries with the correct version.
+
+## Inputs
+
+- `data_source_ref` (required): stable logical ref bound by the operator to the
+  contact data adapter.
+- `resource` (required): declared event resource for contact consent transitions.
+- `aggregate_id` (required): contact stream partition key.
+- `expected_version` (required): stream version the caller believes is current.
+  Must match `current_consent_state.version` or the run stops.
+- `idempotency_key` (required): stable retry key for this decision cycle.
+- `engagement_history` (required): object with `opens` (int), `clicks` (int),
+  `hard_bounces` (int), and `recency_days` (int).
+- `bounce_policy` (required): object with `hard_bounce_action` (suppress) and
+  `decay_threshold_days` (int).
+- `current_consent_state` (required): object with `state`
+  (active|pending|unsubscribed|unknown), `version` (int), and `unsubscribe_marker`
+  (bool).

--- a/skills/list-hygiene-judge/X.yaml
+++ b/skills/list-hygiene-judge/X.yaml
@@ -1,0 +1,151 @@
+skill: list-hygiene-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_decay_re_permission
+      runner: default
+      inputs:
+        data_source_ref: local://runx/list-hygiene/harness
+        resource: contact_consent_events
+        aggregate_id: contact:decayed-001
+        expected_version: 3
+        idempotency_key: contact:decayed-001:list-hygiene:re_permission:v1
+        engagement_history:
+          opens: 0
+          clicks: 0
+          hard_bounces: 0
+          recency_days: 120
+        bounce_policy:
+          hard_bounce_action: suppress
+          decay_threshold_days: 90
+        current_consent_state:
+          state: active
+          version: 3
+          unsubscribe_marker: false
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: sealed_hard_bounce_suppress
+      runner: default
+      inputs:
+        data_source_ref: local://runx/list-hygiene/harness
+        resource: contact_consent_events
+        aggregate_id: contact:bounced-001
+        expected_version: 1
+        idempotency_key: contact:bounced-001:list-hygiene:suppress:v1
+        engagement_history:
+          opens: 1
+          clicks: 0
+          hard_bounces: 3
+          recency_days: 20
+        bounce_policy:
+          hard_bounce_action: suppress
+          decay_threshold_days: 90
+        current_consent_state:
+          state: active
+          version: 1
+          unsubscribe_marker: false
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: stop_missing_or_stale_evidence
+      runner: default
+      inputs:
+        data_source_ref: local://runx/list-hygiene/harness
+        resource: contact_consent_events
+        aggregate_id: contact:stale-001
+        expected_version: 2
+        idempotency_key: contact:stale-001:list-hygiene:check:v1
+        engagement_history:
+          opens: 0
+          clicks: 0
+          hard_bounces: 0
+          recency_days: 150
+        bounce_policy:
+          hard_bounce_action: suppress
+          decay_threshold_days: 90
+        current_consent_state:
+          state: active
+          version: 4
+          unsubscribe_marker: false
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - outbound_send
+    - operational_proposal
+    - mint_grant
+    - invented_contact_metrics
+
+emits:
+  - name: hygiene_decision
+    packet: runx.list_hygiene.decision.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+        description: Stable logical ref bound by the operator to the contact data adapter.
+      resource:
+        type: string
+        required: true
+        description: Declared event resource or stream family for contact consent transitions.
+      aggregate_id:
+        type: string
+        required: true
+        description: Contact stream partition key.
+      expected_version:
+        type: number
+        required: true
+        description: Current stream version required before append.
+      idempotency_key:
+        type: string
+        required: true
+        description: Stable retry key scoped to this contact and decision cycle.
+      engagement_history:
+        type: json
+        required: true
+        description: Object with opens (int), clicks (int), hard_bounces (int), and recency_days (int).
+      bounce_policy:
+        type: json
+        required: true
+        description: Object with hard_bounce_action (suppress) and decay_threshold_days (int).
+      current_consent_state:
+        type: json
+        required: true
+        description: Object with state (active|pending|unsubscribed|unknown), version (int), and unsubscribe_marker (bool).

--- a/skills/list-hygiene-judge/run.mjs
+++ b/skills/list-hygiene-judge/run.mjs
@@ -1,0 +1,214 @@
+function textInput(name) {
+  return String(process.env[`RUNX_INPUT_${name}`] ?? "").trim();
+}
+
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function numberInput(name) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  const value = Number(raw);
+  if (!Number.isFinite(value)) throw new Error(`${name.toLowerCase()} must be a finite number`);
+  return value;
+}
+
+function requireString(name) {
+  const value = textInput(name);
+  if (!value) throw new Error(`${name.toLowerCase()} is required`);
+  return value;
+}
+
+function requireMetric(obj, key) {
+  const value = Number(obj?.[key]);
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, reason: `missing_or_invalid_${key}` };
+  }
+  return { ok: true, value };
+}
+
+function isActiveUnsubscribe(consentState) {
+  if (!consentState || typeof consentState !== "object") return false;
+  if (consentState.unsubscribe_marker === true) return true;
+  const s = String(consentState.state ?? "").toLowerCase();
+  return ["unsubscribed", "opted_out", "suppressed_by_unsubscribe"].includes(s);
+}
+
+function stop(code, reason) {
+  return {
+    write: false,
+    decision: { state: "stop", reason },
+    stop: {
+      code,
+      reason,
+      human_approval_lane: "list_hygiene.review",
+      append_emitted: false,
+    },
+  };
+}
+
+function decide({ engagementHistory, bouncePolicy, currentConsentState, expectedVersion }) {
+  const stateVersion = Number(currentConsentState?.version);
+  if (!Number.isFinite(stateVersion)) {
+    return stop("missing_current_projection_version", "Current consent state has no readable numeric version.");
+  }
+  if (stateVersion !== expectedVersion) {
+    return stop(
+      "stale_expected_version",
+      `expected_version ${expectedVersion} does not match current consent state version ${stateVersion}.`
+    );
+  }
+  if (isActiveUnsubscribe(currentConsentState)) {
+    return stop(
+      "active_unsubscribe_marker",
+      "Active unsubscribe marker is present. Automated re-permission is blocked."
+    );
+  }
+
+  for (const key of ["opens", "clicks", "hard_bounces", "recency_days"]) {
+    const m = requireMetric(engagementHistory, key);
+    if (!m.ok) return stop(m.reason, `Engagement evidence missing or invalid for field: ${key}.`);
+  }
+
+  const hardBounces = Number(engagementHistory.hard_bounces);
+  const recencyDays = Number(engagementHistory.recency_days);
+  const decayThreshold = Number(bouncePolicy?.decay_threshold_days);
+
+  if (!Number.isFinite(decayThreshold) || decayThreshold < 0) {
+    return stop("missing_decay_threshold", "Bounce policy is missing a valid decay_threshold_days value.");
+  }
+
+  if (hardBounces > 0) {
+    return {
+      write: true,
+      decision: {
+        state: "suppress",
+        reason: `hard_bounces=${hardBounces}; hard_bounce_action=${bouncePolicy?.hard_bounce_action ?? "suppress"}`,
+      },
+      event_type: "contact.consent_state.suppressed",
+    };
+  }
+
+  if (recencyDays > decayThreshold) {
+    return {
+      write: true,
+      decision: {
+        state: "re_permission",
+        reason: `recency_days=${recencyDays} exceeds decay_threshold_days=${decayThreshold} with no unsubscribe marker.`,
+      },
+      event_type: "contact.consent_state.re_permission_required",
+    };
+  }
+
+  return {
+    write: true,
+    decision: {
+      state: "active",
+      reason: `recency_days=${recencyDays} is within decay_threshold_days=${decayThreshold} with no hard bounce.`,
+    },
+    event_type: "contact.consent_state.verified",
+  };
+}
+
+function buildAppend({ dataSourceRef, resource, aggregateId, expectedVersion, idempotencyKey, currentConsentState, decision, eventType }) {
+  const afterVersion = expectedVersion + 1;
+  return {
+    adapter_ref: "registry:runx/data-store@0.1.2",
+    operation: "append_event",
+    data_source_ref: dataSourceRef,
+    resource,
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    before_version: expectedVersion,
+    after_version: afterVersion,
+    idempotency_key: idempotencyKey,
+    status: "committed",
+    event: {
+      type: eventType,
+      aggregate_id: aggregateId,
+      previous_state: currentConsentState?.state ?? "unknown",
+      new_state: decision.state,
+      reason: decision.reason,
+      decided_by: "list-hygiene-judge",
+      no_send: true,
+      downstream_enforcer: "send-as reads recorded consent state at send time",
+    },
+    readback_projection: {
+      aggregate_id: aggregateId,
+      version: afterVersion,
+      consent_state: decision.state,
+      latest_event_type: eventType,
+      idempotency_key: idempotencyKey,
+    },
+  };
+}
+
+function main() {
+  const dataSourceRef = requireString("DATA_SOURCE_REF");
+  const resource = requireString("RESOURCE");
+  const aggregateId = requireString("AGGREGATE_ID");
+  const expectedVersion = numberInput("EXPECTED_VERSION");
+  const idempotencyKey = requireString("IDEMPOTENCY_KEY");
+  const engagementHistory = jsonInput("ENGAGEMENT_HISTORY", {});
+  const bouncePolicy = jsonInput("BOUNCE_POLICY", {});
+  const currentConsentState = jsonInput("CURRENT_CONSENT_STATE", {});
+
+  const verdict = decide({ engagementHistory, bouncePolicy, currentConsentState, expectedVersion });
+
+  const output = {
+    schema: "runx.list_hygiene.decision.v1",
+    package: "list-hygiene-judge",
+    data_source_ref: dataSourceRef,
+    resource,
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    decision: verdict.decision,
+    data_store: {
+      read_projection: {
+        adapter_ref: "registry:runx/data-store@0.1.2",
+        operation: "read_projection",
+        data_source_ref: dataSourceRef,
+        resource,
+        aggregate_id: aggregateId,
+        projection: { current_consent_state: currentConsentState, engagement_history: engagementHistory },
+      },
+      append_event: null,
+    },
+    recorded_transition: null,
+    stop: verdict.stop ?? null,
+    no_send: true,
+    no_operational_proposal: true,
+    downstream_enforcer: "send-as",
+  };
+
+  if (verdict.write) {
+    const append = buildAppend({
+      dataSourceRef,
+      resource,
+      aggregateId,
+      expectedVersion,
+      idempotencyKey,
+      currentConsentState,
+      decision: verdict.decision,
+      eventType: verdict.event_type,
+    });
+    output.data_store.append_event = append;
+    output.recorded_transition = append.readback_projection;
+  }
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds `list-hygiene-judge`, a runx graph-runner skill that acts as a consent-state
decision engine for email list management.

- Evaluates engagement history, bounce record, and current consent state
- Decides `re_permission` (decayed engagement, no unsubscribe), `suppress`
  (hard bounces > 0), or `stop` (stale version, missing evidence, active
  unsubscribe)
- Records exactly one `append_event` via `registry:runx/data-store@0.1.2` using
  compare-and-set (`expected_version` + `idempotency_key`)
- Never sends; delivery delegated by name to `send-as`
- No operational proposal envelope; no minted grant

## Harness coverage

| Case | Input | Expected |
|---|---|---|
| `sealed_decay_re_permission` | recency_days=120 > threshold=90, no bounces | decision=re_permission, one append |
| `sealed_hard_bounce_suppress` | hard_bounces=3 | decision=suppress, one append |
| `stop_missing_or_stale_evidence` | expected_version=2 vs state.version=4 | decision=stop, no append |

## Artifacts

- **Skill:** `therealsaitama0/list-hygiene-judge@0.1.0`
- **X.yaml:** https://raw.githubusercontent.com/therealsaitama0/runx/e0bd7400c6e63026721ee597bf934a7fb9821392/skills/list-hygiene-judge/X.yaml
- **SKILL.md:** https://raw.githubusercontent.com/therealsaitama0/runx/e0bd7400c6e63026721ee597bf934a7fb9821392/skills/list-hygiene-judge/SKILL.md
- **runx-cli:** 0.6.14
- **Ethereum:** 0x5e1040927a1E28D740f92De27a3d493b81682D88

Frantic bounty: https://gofrantic.com/bounties/68