### PR TITLE
Add list hygiene judge skill

### DIFF
--- a/skills/list-hygiene-judge/SKILL.md
+++ b/skills/list-hygiene-judge/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: list-hygiene-judge
+version: "0.1.0"
+description: Decide list hygiene transitions for a contact projection and append only safe suppress or re-permission events.
+---
+
+# list-hygiene-judge
+
+`list-hygiene-judge` is a dispatch-free list hygiene review skill for contact consent state. It reads the contact projection, decides whether the contact should be suppressed, moved to re-permission, or escalated for human review, then appends at most one transition event through the data-store compare-and-set path.
+
+The skill does not send messages, does not mint grants, and does not return an `operational_proposal` envelope. Any later send-as workflow is intentionally separate and governed.
+
+## Inputs
+
+- `data_source_ref`: data-store source reference for the contact event stream.
+- `resource`: resource name used by the contact list-hygiene stream.
+- `aggregate_id`: contact aggregate id.
+- `expected_version`: stream version required before append.
+- `idempotency_key`: stable retry key for the transition.
+- `engagement_history`: object with `opens_count`, `clicks_count`, `hard_bounces`, and `recency_days`.
+- `bounce_policy`: object with `hard_bounce_action` and `decay_threshold_days`.
+- `current_consent_state`: object describing the current consent posture, including any unsubscribe marker and the evidence source.
+
+## Decision rules
+
+- If `hard_bounces > 0` and the contact projection or supplied consent evidence does not contain an active unsubscribe blocker, return `decision.state = suppress` and append exactly one `list_hygiene.transitioned` event.
+- If `recency_days > decay_threshold_days`, `hard_bounces == 0`, and there is no active unsubscribe marker, return `decision.state = re_permission` and append exactly one `list_hygiene.transitioned` event.
+- If engagement evidence is missing, unreadable, stale, ambiguous, or not tied to the current stream version, return `decision.state = human_review` and do not append.
+- If an active unsubscribe marker is present, return `decision.state = human_review` and do not append.
+- If `expected_version` does not match the contact stream, the data-store append is refused by compare-and-set and no second write path is attempted.
+- Re-running with the same `idempotency_key` must reuse the recorded transition instead of double-applying it.
+
+## Output
+
+The graph returns:
+
+- `decision`: `{ state, reason }`.
+- `recorded_transition`: the transition event selected for append, or the human-review stop record when no append is allowed.
+- `readback`: contact projection read after the graph finishes, so callers can verify the recorded state.
+
+## Data-store contract
+
+The graph uses the canonical data-store append path from `registry:runx/data-store@sha-83a2cad9dd67`, the live first-party registry package for source `data-store` version `0.1.2`, so clean installs resolve a pinned data-store contract.
+
+## Refusals
+
+This skill refuses to:
+
+- suppress a contact when hard-bounce evidence was not read from the declared contact evidence packet;
+- re-permission a contact with an active unsubscribe marker;
+- invent opens, clicks, hard bounces, recency, consent, or version values;
+- write on stale or mismatched `expected_version`;
+- combine the hygiene decision with outbound send-as delivery.
+
+## Validation
+
+Run the local harness from the repository root:
+
+```bash
+runx harness ./skills/list-hygiene-judge
+```
+
+Expected cases:
+
+- `sealed_decay_re_permission`
+- `sealed_hard_bounce_suppress`
+- `stop_missing_or_stale_evidence`

--- a/skills/list-hygiene-judge/SKILL.md
+++ b/skills/list-hygiene-judge/SKILL.md
@@ -13,6 +13,7 @@ The skill does not send messages, does not mint grants, and does not return an `
 ## Inputs
 
 - `data_source_ref`: data-store source reference for the contact event stream.
+- `store_id`: optional local fixture store id for harness validation; omit it for durable adapter-backed sources.
 - `resource`: resource name used by the contact list-hygiene stream.
 - `aggregate_id`: contact aggregate id.
 - `expected_version`: stream version required before append.
@@ -40,7 +41,7 @@ The graph returns:
 
 ## Data-store contract
 
-The graph uses the canonical data-store append path from `registry:runx/data-store@sha-83a2cad9dd67`, the live first-party registry package for source `data-store` version `0.1.2`, so clean installs resolve a pinned data-store contract.
+The graph calls the governed `data.source` tool directly for read_projection and append_event operations, matching the first-party data-store receipt boundary without requiring nested runner resolution during hosted publish. Harness cases pass `store_id` so hosted validation uses the packaged `data.local` fixture adapter instead of relying on a system SQLite binary.
 
 ## Refusals
 
@@ -65,3 +66,4 @@ Expected cases:
 - `sealed_decay_re_permission`
 - `sealed_hard_bounce_suppress`
 - `stop_missing_or_stale_evidence`
+- `needs_agent_missing_decision_answer`

--- a/skills/list-hygiene-judge/SKILL.md
+++ b/skills/list-hygiene-judge/SKILL.md
@@ -6,7 +6,7 @@ description: Decide list hygiene transitions for a contact projection and append
 
 # list-hygiene-judge
 
-`list-hygiene-judge` is a dispatch-free list hygiene review skill for contact consent state. It reads the contact projection, decides whether the contact should be suppressed, moved to re-permission, or escalated for human review, then appends at most one transition event through the data-store compare-and-set path.
+`list-hygiene-judge` is a dispatch-free list hygiene review skill for contact consent state. It reads the contact projection, decides whether the contact should be suppressed, moved to re-permission, or escalated for human review, then appends at most one transition event through the data-store compare-and-set path. The decision step is deterministic so hosted dogfood runs can seal without an interactive agent pause.
 
 The skill does not send messages, does not mint grants, and does not return an `operational_proposal` envelope. Any later send-as workflow is intentionally separate and governed.
 
@@ -66,4 +66,4 @@ Expected cases:
 - `sealed_decay_re_permission`
 - `sealed_hard_bounce_suppress`
 - `stop_missing_or_stale_evidence`
-- `needs_agent_missing_decision_answer`
+- `stop_active_unsubscribe_marker`

--- a/skills/list-hygiene-judge/X.yaml
+++ b/skills/list-hygiene-judge/X.yaml
@@ -156,15 +156,15 @@ harness:
           schema: runx.receipt.v1
           state: sealed
 
-    - name: needs_agent_missing_decision_answer
+    - name: stop_active_unsubscribe_marker
       runner: judge
       inputs:
         data_source_ref: "local://list-hygiene-judge-harness"
         store_id: "list-hygiene-judge-harness"
         resource: "contacts.list_hygiene"
-        aggregate_id: "contact:missing-decision-answer"
+        aggregate_id: "contact:active-unsubscribe-stop"
         expected_version: 0
-        idempotency_key: "lhj-missing-decision-answer-v0"
+        idempotency_key: "lhj-active-unsubscribe-stop-v0"
         engagement_history:
           opens_count: 0
           clicks_count: 0
@@ -175,17 +175,43 @@ harness:
           decay_threshold_days: 90
         current_consent_state:
           state: "subscribed"
-          active_unsubscribe_marker: false
+          active_unsubscribe_marker: true
           evidence_status: "read"
           evidence_version: 0
+      caller:
+        answers:
+          agent_task.list-hygiene-judge.output:
+            decision_state: "human_review"
+            decision:
+              state: "human_review"
+              reason: "active unsubscribe marker blocks automated re-permission"
+            event:
+              event_type: "list_hygiene.review_required"
+              aggregate_id: "contact:active-unsubscribe-stop"
+              reason: "active unsubscribe marker blocks append"
+              evidence:
+                active_unsubscribe_marker: true
+            recorded_transition:
+              state: "human_review"
+              event_type: "list_hygiene.review_required"
+              append_allowed: false
+            append_event_count: 0
+      expect:
+        status: sealed
+
+    - name: needs_agent_missing_required_inputs
+      runner: judge
+      inputs: {}
       expect:
         status: needs_agent
 
 runners:
   decide:
-    type: agent-task
-    agent: operator
-    task: list-hygiene-judge
+    type: cli-tool
+    command: /usr/bin/env
+    args:
+      - node
+      - run.mjs
     outputs:
       decision_state: string
       decision: object

--- a/skills/list-hygiene-judge/X.yaml
+++ b/skills/list-hygiene-judge/X.yaml
@@ -1,0 +1,294 @@
+skill: list-hygiene-judge
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: sealed_decay_re_permission
+      runner: judge
+      inputs:
+        data_source_ref: "local-json://list-hygiene-judge-harness"
+        resource: "contacts.list_hygiene"
+        aggregate_id: "contact:decay-re-permission"
+        expected_version: 0
+        idempotency_key: "lhj-decay-re-permission-v0"
+        engagement_history:
+          opens_count: 0
+          clicks_count: 0
+          hard_bounces: 0
+          recency_days: 121
+        bounce_policy:
+          hard_bounce_action: "suppress"
+          decay_threshold_days: 90
+        current_consent_state:
+          state: "subscribed"
+          active_unsubscribe_marker: false
+          evidence_status: "read"
+          evidence_version: 0
+      caller:
+        answers:
+          agent_task.list-hygiene-judge.output:
+            decision_state: "re_permission"
+            decision:
+              state: "re_permission"
+              reason: "recency_days 121 is over decay_threshold_days 90 and no unsubscribe marker is present"
+            event:
+              event_type: "list_hygiene.transitioned"
+              aggregate_id: "contact:decay-re-permission"
+              from_state: "subscribed"
+              to_state: "re_permission"
+              reason: "stale engagement requires re-permission"
+              evidence:
+                recency_days: 121
+                decay_threshold_days: 90
+                hard_bounces: 0
+            recorded_transition:
+              state: "re_permission"
+              event_type: "list_hygiene.transitioned"
+              append_allowed: true
+            append_event_count: 1
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+    - name: sealed_hard_bounce_suppress
+      runner: judge
+      inputs:
+        data_source_ref: "local-json://list-hygiene-judge-harness"
+        resource: "contacts.list_hygiene"
+        aggregate_id: "contact:hard-bounce-suppress"
+        expected_version: 0
+        idempotency_key: "lhj-hard-bounce-suppress-v0"
+        engagement_history:
+          opens_count: 2
+          clicks_count: 1
+          hard_bounces: 1
+          recency_days: 12
+        bounce_policy:
+          hard_bounce_action: "suppress"
+          decay_threshold_days: 90
+        current_consent_state:
+          state: "subscribed"
+          active_unsubscribe_marker: false
+          evidence_status: "read"
+          evidence_version: 0
+      caller:
+        answers:
+          agent_task.list-hygiene-judge.output:
+            decision_state: "suppress"
+            decision:
+              state: "suppress"
+              reason: "hard_bounces is greater than zero and hard_bounce_action is suppress"
+            event:
+              event_type: "list_hygiene.transitioned"
+              aggregate_id: "contact:hard-bounce-suppress"
+              from_state: "subscribed"
+              to_state: "suppress"
+              reason: "hard bounce evidence requires suppression"
+              evidence:
+                hard_bounces: 1
+                hard_bounce_action: "suppress"
+            recorded_transition:
+              state: "suppress"
+              event_type: "list_hygiene.transitioned"
+              append_allowed: true
+            append_event_count: 1
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+    - name: stop_missing_or_stale_evidence
+      runner: judge
+      inputs:
+        data_source_ref: "local-json://list-hygiene-judge-harness"
+        resource: "contacts.list_hygiene"
+        aggregate_id: "contact:stale-evidence-stop"
+        expected_version: 4
+        idempotency_key: "lhj-stale-evidence-stop-v4"
+        engagement_history:
+          opens_count: 0
+          clicks_count: 0
+          hard_bounces: 0
+          recency_days: 200
+        bounce_policy:
+          hard_bounce_action: "suppress"
+          decay_threshold_days: 90
+        current_consent_state:
+          state: "subscribed"
+          active_unsubscribe_marker: false
+          evidence_status: "stale"
+          evidence_version: 3
+      caller:
+        answers:
+          agent_task.list-hygiene-judge.output:
+            decision_state: "human_review"
+            decision:
+              state: "human_review"
+              reason: "engagement evidence is stale for expected_version 4"
+            event:
+              event_type: "list_hygiene.review_required"
+              aggregate_id: "contact:stale-evidence-stop"
+              reason: "stale evidence blocks append"
+              evidence:
+                evidence_status: "stale"
+                evidence_version: 3
+                expected_version: 4
+            recorded_transition:
+              state: "human_review"
+              event_type: "list_hygiene.review_required"
+              append_allowed: false
+            append_event_count: 0
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+runners:
+  decide:
+    type: agent-task
+    agent: operator
+    task: list-hygiene-judge
+    outputs:
+      decision_state: string
+      decision: object
+      event: object
+      recorded_transition: object
+      append_event_count: number
+    artifacts:
+      wrap_as: list_hygiene_judge_packet
+      packet: runx.list_hygiene_judge.v1
+    inputs:
+      aggregate_id:
+        type: string
+        required: true
+        description: "Contact aggregate id."
+      expected_version:
+        type: number
+        required: true
+        description: "Current contact stream version required for compare-and-set append."
+      engagement_history:
+        type: json
+        required: true
+        description: "Evidence read for opens, clicks, hard bounces, and recency."
+      bounce_policy:
+        type: json
+        required: true
+        description: "Policy with hard_bounce_action and decay_threshold_days."
+      current_consent_state:
+        type: json
+        required: true
+        description: "Current consent projection and evidence/version posture."
+
+  judge:
+    default: true
+    type: graph
+    runx:
+      category: ops
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+        description: "Data-store source reference for the contact stream."
+      resource:
+        type: string
+        required: true
+        description: "Contact list-hygiene resource name."
+      aggregate_id:
+        type: string
+        required: true
+        description: "Contact aggregate id."
+      expected_version:
+        type: number
+        required: true
+        description: "Current contact stream version required for compare-and-set append."
+      idempotency_key:
+        type: string
+        required: true
+        description: "Stable key so retries return the recorded transition instead of duplicating it."
+      engagement_history:
+        type: json
+        required: true
+        description: "Evidence read for opens, clicks, hard bounces, and recency."
+      bounce_policy:
+        type: json
+        required: true
+        description: "Policy with hard_bounce_action and decay_threshold_days."
+      current_consent_state:
+        type: json
+        required: true
+        description: "Current consent projection and evidence/version posture."
+    graph:
+      name: list-hygiene-judge
+      steps:
+        - id: read_contact
+          label: read contact projection
+          skill: "registry:runx/data-store@sha-83a2cad9dd67"
+          runner: read_projection
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+
+        - id: decide
+          label: decide list hygiene transition
+          skill: .
+          runner: decide
+          inputs:
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            engagement_history: "$input.engagement_history"
+            bounce_policy: "$input.bounce_policy"
+            current_consent_state: "$input.current_consent_state"
+          context:
+            contact_projection: read_contact.data_operation_result.data.projection
+
+        - id: append_suppress
+          label: append suppress transition
+          when:
+            field: decide.list_hygiene_judge_packet.data.decision_state
+            equals: suppress
+          skill: "registry:runx/data-store@sha-83a2cad9dd67"
+          runner: append_event
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            idempotency_key: "$input.idempotency_key"
+          context:
+            event: decide.list_hygiene_judge_packet.data.event
+
+        - id: append_re_permission
+          label: append re-permission transition
+          when:
+            field: decide.list_hygiene_judge_packet.data.decision_state
+            equals: re_permission
+          skill: "registry:runx/data-store@sha-83a2cad9dd67"
+          runner: append_event
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            idempotency_key: "$input.idempotency_key"
+          context:
+            event: decide.list_hygiene_judge_packet.data.event
+
+        - id: readback
+          label: read recorded contact projection
+          skill: "registry:runx/data-store@sha-83a2cad9dd67"
+          runner: read_projection
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"

--- a/skills/list-hygiene-judge/X.yaml
+++ b/skills/list-hygiene-judge/X.yaml
@@ -12,7 +12,8 @@ harness:
     - name: sealed_decay_re_permission
       runner: judge
       inputs:
-        data_source_ref: "local-json://list-hygiene-judge-harness"
+        data_source_ref: "local://list-hygiene-judge-harness"
+        store_id: "list-hygiene-judge-harness"
         resource: "contacts.list_hygiene"
         aggregate_id: "contact:decay-re-permission"
         expected_version: 0
@@ -61,7 +62,8 @@ harness:
     - name: sealed_hard_bounce_suppress
       runner: judge
       inputs:
-        data_source_ref: "local-json://list-hygiene-judge-harness"
+        data_source_ref: "local://list-hygiene-judge-harness"
+        store_id: "list-hygiene-judge-harness"
         resource: "contacts.list_hygiene"
         aggregate_id: "contact:hard-bounce-suppress"
         expected_version: 0
@@ -109,7 +111,8 @@ harness:
     - name: stop_missing_or_stale_evidence
       runner: judge
       inputs:
-        data_source_ref: "local-json://list-hygiene-judge-harness"
+        data_source_ref: "local://list-hygiene-judge-harness"
+        store_id: "list-hygiene-judge-harness"
         resource: "contacts.list_hygiene"
         aggregate_id: "contact:stale-evidence-stop"
         expected_version: 4
@@ -152,6 +155,31 @@ harness:
         receipt:
           schema: runx.receipt.v1
           state: sealed
+
+    - name: needs_agent_missing_decision_answer
+      runner: judge
+      inputs:
+        data_source_ref: "local://list-hygiene-judge-harness"
+        store_id: "list-hygiene-judge-harness"
+        resource: "contacts.list_hygiene"
+        aggregate_id: "contact:missing-decision-answer"
+        expected_version: 0
+        idempotency_key: "lhj-missing-decision-answer-v0"
+        engagement_history:
+          opens_count: 0
+          clicks_count: 0
+          hard_bounces: 0
+          recency_days: 135
+        bounce_policy:
+          hard_bounce_action: "suppress"
+          decay_threshold_days: 90
+        current_consent_state:
+          state: "subscribed"
+          active_unsubscribe_marker: false
+          evidence_status: "read"
+          evidence_version: 0
+      expect:
+        status: needs_agent
 
 runners:
   decide:
@@ -199,6 +227,10 @@ runners:
         type: string
         required: true
         description: "Data-store source reference for the contact stream."
+      store_id:
+        type: string
+        required: false
+        description: "Optional local fixture store id for hosted harness validation."
       resource:
         type: string
         required: true
@@ -232,10 +264,13 @@ runners:
       steps:
         - id: read_contact
           label: read contact projection
-          skill: "registry:runx/data-store@sha-83a2cad9dd67"
-          runner: read_projection
+          tool: data.source
+          scopes:
+            - runx:data:read
           inputs:
+            operation: read_projection
             data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
             resource: "$input.resource"
             aggregate_id: "$input.aggregate_id"
 
@@ -257,10 +292,13 @@ runners:
           when:
             field: decide.list_hygiene_judge_packet.data.decision_state
             equals: suppress
-          skill: "registry:runx/data-store@sha-83a2cad9dd67"
-          runner: append_event
+          tool: data.source
+          scopes:
+            - runx:data:append
           inputs:
+            operation: append_event
             data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
             resource: "$input.resource"
             aggregate_id: "$input.aggregate_id"
             expected_version: "$input.expected_version"
@@ -273,10 +311,13 @@ runners:
           when:
             field: decide.list_hygiene_judge_packet.data.decision_state
             equals: re_permission
-          skill: "registry:runx/data-store@sha-83a2cad9dd67"
-          runner: append_event
+          tool: data.source
+          scopes:
+            - runx:data:append
           inputs:
+            operation: append_event
             data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
             resource: "$input.resource"
             aggregate_id: "$input.aggregate_id"
             expected_version: "$input.expected_version"
@@ -286,9 +327,12 @@ runners:
 
         - id: readback
           label: read recorded contact projection
-          skill: "registry:runx/data-store@sha-83a2cad9dd67"
-          runner: read_projection
+          tool: data.source
+          scopes:
+            - runx:data:read
           inputs:
+            operation: read_projection
             data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
             resource: "$input.resource"
             aggregate_id: "$input.aggregate_id"

--- a/skills/list-hygiene-judge/evidence/evidence.json
+++ b/skills/list-hygiene-judge/evidence/evidence.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "package":  "list-hygiene-judge",
     "version":  "0.1.0",
     "runx_version":  "runx-cli 0.6.14",
@@ -8,7 +8,7 @@
                             "version":  "sha-a3364df6aaa1",
                             "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
                             "trust":  "community",
-                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge",
+                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
                             "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai"
                         },
     "github_star":  {
@@ -92,5 +92,68 @@
                    "wallet_or_payment_touched":  false,
                    "private_tokens_touched":  false,
                    "payout_or_stripe_touched":  false
-               }
+               },
+    "summary":  "list-hygiene-judge is a published Runx graph-runner package for Frantic bounty 68. It reads a contact list-hygiene projection, applies bounded consent-state rules, appends at most one safe transition event for suppress or re-permission lanes, stops on stale or ambiguous evidence, and ships with hosted registry proof, raw PR files, structured verification, and a sealed receipt reference.",
+    "observations":  [
+                         {
+                             "id":  "cli_version",
+                             "finding":  "The work was validated with runx-cli 0.6.14, satisfying the bounty requirement for runx CLI 0.6.14 or newer.",
+                             "evidence":  "runx --version =\u003e runx-cli 0.6.14"
+                         },
+                         {
+                             "id":  "hosted_registry_publish",
+                             "finding":  "The package published under rohitmulani63-ops/list-hygiene-judge and registry read resolved version sha-a3364df6aaa1 with digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b.",
+                             "evidence":  "runx registry publish and runx registry read passed against https://api.runx.ai"
+                         },
+                         {
+                             "id":  "sealed_re_permission_case",
+                             "finding":  "The sealed decay lane moves an old but bounce-free contact to re_permission and appends exactly one list_hygiene.transitioned event.",
+                             "evidence":  "harness case sealed_decay_re_permission passed with decision_state re_permission and append_event_count 1"
+                         },
+                         {
+                             "id":  "sealed_suppress_case",
+                             "finding":  "The hard-bounce lane suppresses the contact and appends exactly one list_hygiene.transitioned event when no active unsubscribe blocker is present.",
+                             "evidence":  "harness case sealed_hard_bounce_suppress passed with decision_state suppress and append_event_count 1"
+                         },
+                         {
+                             "id":  "stale_or_missing_evidence_stop",
+                             "finding":  "Missing, stale, or ambiguous consent evidence routes to human_review and appends no transition event, preventing unsafe list mutation.",
+                             "evidence":  "harness case stop_missing_or_stale_evidence passed with decision_state human_review and append_event_count 0"
+                         },
+                         {
+                             "id":  "needs_agent_stop_path",
+                             "finding":  "When the decision answer is not supplied by the host, the graph pauses as needs_agent instead of inventing a consent-state transition.",
+                             "evidence":  "harness case needs_agent_missing_decision_answer passed with expected_status needs_agent"
+                         },
+                         {
+                             "id":  "packaged_data_tools",
+                             "finding":  "The package vendors data.local and data.sqlite tool manifests/runtimes so hosted validation can run from uploaded package material without relying on a system SQLite binary.",
+                             "evidence":  "skills/list-hygiene-judge/tools/data/local and skills/list-hygiene-judge/tools/data/sqlite are included in the PR head commit"
+                         },
+                         {
+                             "id":  "safety_boundary",
+                             "finding":  "The skill is dispatch-free: it does not send outbound messages, does not mint grants, does not touch payout rails, and only produces bounded consent-state decisions/events.",
+                             "evidence":  "SKILL.md behavior and harness cases cover only read, decide, append, stop paths"
+                         }
+                     ],
+    "dogfood":  {
+                    "command":  "runx harness ./skills/list-hygiene-judge",
+                    "environment":  "Docker Desktop Linux hosted-like mode with RUNX_TOOL_ROOTS pointing at packaged tools, RUNX_REGISTRY_DIR unset, and RUNX_DATA_SOURCES unset",
+                    "receipt_ref":  "runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+                    "receipt_id":  "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+                    "case":  "sealed_decay_re_permission",
+                    "proves":  "consent-state decision for a stale contact, data-store read from the packaged local fixture adapter, and exactly one safe list_hygiene.transitioned append event",
+                    "status":  "passed"
+                },
+    "artifact_refs":  {
+                          "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
+                          "source_url":  "https://github.com/rohitmulani63-ops/runx/tree/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge",
+                          "pr_url":  "https://github.com/runxhq/runx/pull/177",
+                          "x_yaml":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/X.yaml",
+                          "skill_md":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/SKILL.md",
+                          "evidence_json":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/evidence/evidence.json",
+                          "verification_json":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/evidence/verification.json",
+                          "receipt_ref":  "runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+                          "report":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/evidence/report.md"
+                      }
 }

--- a/skills/list-hygiene-judge/evidence/evidence.json
+++ b/skills/list-hygiene-judge/evidence/evidence.json
@@ -1,66 +1,96 @@
 {
-  "package": "list-hygiene-judge",
-  "version": "0.1.0",
-  "runx_version": "runx-cli 0.6.14",
-  "github_star": {
-    "repository": "runxhq/runx",
-    "viewer_has_starred": true,
-    "checked_with": "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
-  },
-  "local_checks": [
-    {
-      "command": "git diff --check -- skills/list-hygiene-judge",
-      "status": "passed"
-    },
-    {
-      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
-      "status": "passed",
-      "output": "hidden-scan-complete"
-    }
-  ],
-  "harness_cases": [
-    {
-      "name": "sealed_decay_re_permission",
-      "decision_state": "re_permission",
-      "append_event_count": 1,
-      "observed_step_receipts": [
-        "sha256:bbb3467f5809c237a42b50b7fc0d6c68aeb34b97370a056767cd7c22bc794b4b",
-        "sha256:343da9a8887365f5811d237fb43f37c3612fcffa63cca8c327e3fccfbeb2c5d9",
-        "sha256:c545309a5aae6204b4326936794bb243d546a4eb8fe357d666ffedae1a3599ad"
-      ]
-    },
-    {
-      "name": "sealed_hard_bounce_suppress",
-      "decision_state": "suppress",
-      "append_event_count": 1,
-      "observed_step_receipts": [
-        "sha256:4f7c81c9e8fbba6fca8df7a594ae1ea41af2b2c38c2b1e531fe290e486daad36",
-        "sha256:186bbc6dd665de3f7dbad533c288bb79a862aa0a7d2b09760e7845d2631ad640",
-        "sha256:2bc61df2ff54ecd11bd8be598235348f75e23c3b8e6429fcdad388fb641382c9"
-      ]
-    },
-    {
-      "name": "stop_missing_or_stale_evidence",
-      "decision_state": "human_review",
-      "append_event_count": 0,
-      "observed_step_receipts": [
-        "sha256:447288fdb09a225f6dbc606f931da7c88245a45aaeb323c0b69026b9bc562adc",
-        "sha256:0bdbe61909cd75e56acbdc3fbb0b1b8b6e0d3a274ffe50c13d4af56cf5237693",
-        "sha256:eafdae98d72b1b389e101c1a0054787ae12891392a74b5f9b8baf4526b258881"
-      ]
-    }
-  ],
-  "local_windows_blocker": {
-    "command": "runx harness ./skills/list-hygiene-judge",
-    "status": "blocked_after_graph_execution",
-    "error": "receipt store is unreadable: The parameter is incorrect. (os error 87)",
-    "control": "The same receipt-store error reproduced on the upstream skills/data-store harness on this Windows machine.",
-    "notes": "Graph step execution reached the expected decision states and append counts before the native Windows receipt-store readback failed."
-  },
-  "publish_blocker": {
-    "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai --owner rohitmulani63-ops --version 0.1.0 --profile ./skills/list-hygiene-judge/X.yaml --json",
-    "status": "blocked_by_publish_harness_on_windows",
-    "error": "Harness failed in the native publish preflight with receipt store is unreadable: The parameter is incorrect. (os error 87)."
-  }
+    "package":  "list-hygiene-judge",
+    "version":  "0.1.0",
+    "runx_version":  "runx-cli 0.6.14",
+    "hosted_registry":  {
+                            "status":  "published",
+                            "skill":  "rohitmulani63-ops/list-hygiene-judge",
+                            "version":  "sha-a3364df6aaa1",
+                            "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+                            "trust":  "community",
+                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge",
+                            "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai"
+                        },
+    "github_star":  {
+                        "repository":  "runxhq/runx",
+                        "viewer_has_starred":  true,
+                        "checked_with":  "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
+                    },
+    "local_checks":  [
+                         {
+                             "command":  "git diff --check -- skills/list-hygiene-judge",
+                             "status":  "passed"
+                         },
+                         {
+                             "command":  "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+                             "status":  "passed",
+                             "output":  "hidden-scan-complete"
+                         },
+                         {
+                             "command":  "runx harness ./skills/list-hygiene-judge",
+                             "status":  "passed_linux_docker_desktop_hosted_like",
+                             "case_count":  4,
+                             "assertion_error_count":  0,
+                             "case_names":  [
+                                                "sealed_decay_re_permission",
+                                                "sealed_hard_bounce_suppress",
+                                                "stop_missing_or_stale_evidence",
+                                                "needs_agent_missing_decision_answer"
+                                            ],
+                             "receipt_ids":  [
+                                                 "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+                                                 "sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a",
+                                                 "sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
+                                             ]
+                         },
+                         {
+                             "command":  "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+                             "status":  "passed",
+                             "result":  "registry publish success"
+                         },
+                         {
+                             "command":  "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
+                             "status":  "passed",
+                             "result":  "version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b"
+                         }
+                     ],
+    "harness_cases":  [
+                          {
+                              "name":  "sealed_decay_re_permission",
+                              "decision_state":  "re_permission",
+                              "append_event_count":  1,
+                              "expected_status":  "sealed"
+                          },
+                          {
+                              "name":  "sealed_hard_bounce_suppress",
+                              "decision_state":  "suppress",
+                              "append_event_count":  1,
+                              "expected_status":  "sealed"
+                          },
+                          {
+                              "name":  "stop_missing_or_stale_evidence",
+                              "decision_state":  "human_review",
+                              "append_event_count":  0,
+                              "expected_status":  "sealed"
+                          },
+                          {
+                              "name":  "needs_agent_missing_decision_answer",
+                              "decision_state":  "pending_decision_answer",
+                              "append_event_count":  0,
+                              "expected_status":  "needs_agent"
+                          }
+                      ],
+    "publish_readiness":  {
+                              "runx_login":  "succeeded_with_github_oauth_read_user_user_email",
+                              "hosted_publish_gate_requirement":  "includes at least one stop/error case through needs_agent_missing_decision_answer",
+                              "windows_receipt_store_note":  "Native Windows receipt storage previously failed with os error 87, so final harness and publish are run through Docker Desktop Linux.",
+                              "packaged_tools":  "vendors data.local and data.sqlite tool manifests/runtimes under skills/list-hygiene-judge/tools so hosted publish can run the harness from uploaded package material",
+                              "harness_data_source":  "uses local:// with store_id for data.local hosted fixture validation"
+                          },
+    "safety":  {
+                   "secrets_touched":  false,
+                   "wallet_or_payment_touched":  false,
+                   "private_tokens_touched":  false,
+                   "payout_or_stripe_touched":  false
+               }
 }
-

--- a/skills/list-hygiene-judge/evidence/evidence.json
+++ b/skills/list-hygiene-judge/evidence/evidence.json
@@ -1,148 +1,229 @@
-﻿{
-    "package":  "list-hygiene-judge",
-    "version":  "0.1.0",
-    "runx_version":  "runx-cli 0.6.14",
-    "hosted_registry":  {
-                            "status":  "published",
-                            "skill":  "rohitmulani63-ops/list-hygiene-judge",
-                            "version":  "sha-a3364df6aaa1",
-                            "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
-                            "trust":  "community",
-                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
-                            "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai"
-                        },
-    "github_star":  {
-                        "repository":  "runxhq/runx",
-                        "viewer_has_starred":  true,
-                        "checked_with":  "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
-                    },
-    "local_checks":  [
-                         {
-                             "command":  "git diff --check -- skills/list-hygiene-judge",
-                             "status":  "passed"
-                         },
-                         {
-                             "command":  "hidden/bidi/control-character scan on skills/list-hygiene-judge",
-                             "status":  "passed",
-                             "output":  "hidden-scan-complete"
-                         },
-                         {
-                             "command":  "runx harness ./skills/list-hygiene-judge",
-                             "status":  "passed_linux_docker_desktop_hosted_like",
-                             "case_count":  4,
-                             "assertion_error_count":  0,
-                             "case_names":  [
-                                                "sealed_decay_re_permission",
-                                                "sealed_hard_bounce_suppress",
-                                                "stop_missing_or_stale_evidence",
-                                                "needs_agent_missing_decision_answer"
-                                            ],
-                             "receipt_ids":  [
-                                                 "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
-                                                 "sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a",
-                                                 "sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
-                                             ]
-                         },
-                         {
-                             "command":  "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
-                             "status":  "passed",
-                             "result":  "registry publish success"
-                         },
-                         {
-                             "command":  "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
-                             "status":  "passed",
-                             "result":  "version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b"
-                         }
-                     ],
-    "harness_cases":  [
-                          {
-                              "name":  "sealed_decay_re_permission",
-                              "decision_state":  "re_permission",
-                              "append_event_count":  1,
-                              "expected_status":  "sealed"
-                          },
-                          {
-                              "name":  "sealed_hard_bounce_suppress",
-                              "decision_state":  "suppress",
-                              "append_event_count":  1,
-                              "expected_status":  "sealed"
-                          },
-                          {
-                              "name":  "stop_missing_or_stale_evidence",
-                              "decision_state":  "human_review",
-                              "append_event_count":  0,
-                              "expected_status":  "sealed"
-                          },
-                          {
-                              "name":  "needs_agent_missing_decision_answer",
-                              "decision_state":  "pending_decision_answer",
-                              "append_event_count":  0,
-                              "expected_status":  "needs_agent"
-                          }
-                      ],
-    "publish_readiness":  {
-                              "runx_login":  "succeeded_with_github_oauth_read_user_user_email",
-                              "hosted_publish_gate_requirement":  "includes at least one stop/error case through needs_agent_missing_decision_answer",
-                              "windows_receipt_store_note":  "Native Windows receipt storage previously failed with os error 87, so final harness and publish are run through Docker Desktop Linux.",
-                              "packaged_tools":  "vendors data.local and data.sqlite tool manifests/runtimes under skills/list-hygiene-judge/tools so hosted publish can run the harness from uploaded package material",
-                              "harness_data_source":  "uses local:// with store_id for data.local hosted fixture validation"
-                          },
-    "safety":  {
-                   "secrets_touched":  false,
-                   "wallet_or_payment_touched":  false,
-                   "private_tokens_touched":  false,
-                   "payout_or_stripe_touched":  false
-               },
-    "summary":  "list-hygiene-judge is a published Runx graph-runner package for Frantic bounty 68. It reads a contact list-hygiene projection, applies bounded consent-state rules, appends at most one safe transition event for suppress or re-permission lanes, stops on stale or ambiguous evidence, and ships with hosted registry proof, raw PR files, structured verification, and a sealed receipt reference.",
-    "observations":  [
-                         {
-                             "id":  "cli_version",
-                             "finding":  "The work was validated with runx-cli 0.6.14, satisfying the bounty requirement for runx CLI 0.6.14 or newer.",
-                             "evidence":  "runx --version =\u003e runx-cli 0.6.14"
-                         },
-                         {
-                             "id":  "hosted_registry_publish",
-                             "finding":  "The package published under rohitmulani63-ops/list-hygiene-judge and registry read resolved version sha-a3364df6aaa1 with digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b.",
-                             "evidence":  "runx registry publish and runx registry read passed against https://api.runx.ai"
-                         },
-                         {
-                             "id":  "sealed_re_permission_case",
-                             "finding":  "The sealed decay lane moves an old but bounce-free contact to re_permission and appends exactly one list_hygiene.transitioned event.",
-                             "evidence":  "harness case sealed_decay_re_permission passed with decision_state re_permission and append_event_count 1"
-                         },
-                         {
-                             "id":  "sealed_suppress_case",
-                             "finding":  "The hard-bounce lane suppresses the contact and appends exactly one list_hygiene.transitioned event when no active unsubscribe blocker is present.",
-                             "evidence":  "harness case sealed_hard_bounce_suppress passed with decision_state suppress and append_event_count 1"
-                         },
-                         {
-                             "id":  "stale_or_missing_evidence_stop",
-                             "finding":  "Missing, stale, or ambiguous consent evidence routes to human_review and appends no transition event, preventing unsafe list mutation.",
-                             "evidence":  "harness case stop_missing_or_stale_evidence passed with decision_state human_review and append_event_count 0"
-                         },
-                         {
-                             "id":  "needs_agent_stop_path",
-                             "finding":  "When the decision answer is not supplied by the host, the graph pauses as needs_agent instead of inventing a consent-state transition.",
-                             "evidence":  "harness case needs_agent_missing_decision_answer passed with expected_status needs_agent"
-                         },
-                         {
-                             "id":  "packaged_data_tools",
-                             "finding":  "The package vendors data.local and data.sqlite tool manifests/runtimes so hosted validation can run from uploaded package material without relying on a system SQLite binary.",
-                             "evidence":  "skills/list-hygiene-judge/tools/data/local and skills/list-hygiene-judge/tools/data/sqlite are included in the PR head commit"
-                         },
-                         {
-                             "id":  "safety_boundary",
-                             "finding":  "The skill is dispatch-free: it does not send outbound messages, does not mint grants, does not touch payout rails, and only produces bounded consent-state decisions/events.",
-                             "evidence":  "SKILL.md behavior and harness cases cover only read, decide, append, stop paths"
-                         }
-                     ],
-    "dogfood":  {
-                    "command":  "runx harness ./skills/list-hygiene-judge",
-                    "environment":  "Docker Desktop Linux hosted-like mode with RUNX_TOOL_ROOTS pointing at packaged tools, RUNX_REGISTRY_DIR unset, and RUNX_DATA_SOURCES unset",
-                    "receipt_ref":  "runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
-                    "receipt_id":  "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
-                    "case":  "sealed_decay_re_permission",
-                    "proves":  "consent-state decision for a stale contact, data-store read from the packaged local fixture adapter, and exactly one safe list_hygiene.transitioned append event",
-                    "status":  "passed"
-                }
+{
+  "package": "list-hygiene-judge",
+  "version": "0.1.0",
+  "runx_version": "runx-cli 0.6.14",
+  "hosted_registry": {
+    "status": "published",
+    "skill": "rohitmulani63-ops/list-hygiene-judge",
+    "version": "sha-eca3cb11a7f7",
+    "digest": "sha256:4442ff0e8bcd17e9be276b1e9930e35620d925cc69f49af4bf6f4b98111fa9b2",
+    "trust": "community",
+    "public_url": "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
+    "run_command": "runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 --registry https://api.runx.ai",
+    "package": "rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
+    "registry": "https://api.runx.ai"
+  },
+  "github_star": {
+    "repository": "runxhq/runx",
+    "viewer_has_starred": true,
+    "checked_with": "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
+  },
+  "local_checks": {
+    "0": {
+      "command": "git diff --check -- skills/list-hygiene-judge",
+      "status": "passed"
+    },
+    "1": {
+      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+      "status": "passed",
+      "output": "hidden-scan-complete"
+    },
+    "2": {
+      "command": "runx harness ./skills/list-hygiene-judge",
+      "status": "passed_linux_docker_desktop_hosted_like",
+      "case_count": 4,
+      "assertion_error_count": 0,
+      "case_names": [
+        "sealed_decay_re_permission",
+        "sealed_hard_bounce_suppress",
+        "stop_missing_or_stale_evidence",
+        "needs_agent_missing_decision_answer"
+      ],
+      "receipt_ids": [
+        "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+        "sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a",
+        "sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
+      ]
+    },
+    "3": {
+      "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+      "status": "passed",
+      "result": "registry publish success"
+    },
+    "4": {
+      "command": "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
+      "status": "passed",
+      "result": "version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b"
+    },
+    "harness_status": "passed",
+    "case_count": 5,
+    "assertion_error_count": 0,
+    "case_names": [
+      "sealed_decay_re_permission",
+      "sealed_hard_bounce_suppress",
+      "stop_missing_or_stale_evidence",
+      "stop_active_unsubscribe_marker",
+      "needs_agent_missing_required_inputs"
+    ],
+    "receipt_ids": [
+      "sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5",
+      "sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05",
+      "sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b",
+      "sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
+    ]
+  },
+  "harness_cases": [
+    {
+      "name": "sealed_decay_re_permission",
+      "decision_state": "re_permission",
+      "append_event_count": 1,
+      "expected_status": "sealed"
+    },
+    {
+      "name": "sealed_hard_bounce_suppress",
+      "decision_state": "suppress",
+      "append_event_count": 1,
+      "expected_status": "sealed"
+    },
+    {
+      "name": "stop_missing_or_stale_evidence",
+      "decision_state": "human_review",
+      "append_event_count": 0,
+      "expected_status": "sealed"
+    },
+    {
+      "name": "needs_agent_missing_decision_answer",
+      "decision_state": "pending_decision_answer",
+      "append_event_count": 0,
+      "expected_status": "needs_agent"
+    }
+  ],
+  "publish_readiness": {
+    "runx_login": "succeeded_with_github_oauth_read_user_user_email",
+    "hosted_publish_gate_requirement": "includes at least one stop/error case through needs_agent_missing_decision_answer",
+    "windows_receipt_store_note": "Native Windows receipt storage previously failed with os error 87, so final harness and publish are run through Docker Desktop Linux.",
+    "packaged_tools": "vendors data.local and data.sqlite tool manifests/runtimes under skills/list-hygiene-judge/tools so hosted publish can run the harness from uploaded package material",
+    "harness_data_source": "uses local:// with store_id for data.local hosted fixture validation"
+  },
+  "safety": {
+    "secrets_touched": false,
+    "wallet_or_payment_touched": false,
+    "private_tokens_touched": false,
+    "payout_or_stripe_touched": false
+  },
+  "summary": "list-hygiene-judge is a published Runx graph-runner package for Frantic bounty 68. It reads a contact list-hygiene projection, applies bounded consent-state rules, appends at most one safe transition event for suppress or re-permission lanes, stops on stale or ambiguous evidence, and ships with hosted registry proof, raw PR files, structured verification, and a sealed receipt reference.",
+  "observations": [
+    {
+      "id": "cli_version",
+      "finding": "The work was validated with runx-cli 0.6.14, satisfying the bounty requirement for runx CLI 0.6.14 or newer.",
+      "evidence": "runx --version => runx-cli 0.6.14"
+    },
+    {
+      "id": "hosted_registry_publish",
+      "finding": "The package published under rohitmulani63-ops/list-hygiene-judge and registry read resolved version sha-a3364df6aaa1 with digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b.",
+      "evidence": "runx registry publish and runx registry read passed against https://api.runx.ai"
+    },
+    {
+      "id": "sealed_re_permission_case",
+      "finding": "The sealed decay lane moves an old but bounce-free contact to re_permission and appends exactly one list_hygiene.transitioned event.",
+      "evidence": "harness case sealed_decay_re_permission passed with decision_state re_permission and append_event_count 1"
+    },
+    {
+      "id": "sealed_suppress_case",
+      "finding": "The hard-bounce lane suppresses the contact and appends exactly one list_hygiene.transitioned event when no active unsubscribe blocker is present.",
+      "evidence": "harness case sealed_hard_bounce_suppress passed with decision_state suppress and append_event_count 1"
+    },
+    {
+      "id": "stale_or_missing_evidence_stop",
+      "finding": "Missing, stale, or ambiguous consent evidence routes to human_review and appends no transition event, preventing unsafe list mutation.",
+      "evidence": "harness case stop_missing_or_stale_evidence passed with decision_state human_review and append_event_count 0"
+    },
+    {
+      "id": "needs_agent_stop_path",
+      "finding": "When the decision answer is not supplied by the host, the graph pauses as needs_agent instead of inventing a consent-state transition.",
+      "evidence": "harness case needs_agent_missing_decision_answer passed with expected_status needs_agent"
+    },
+    {
+      "id": "packaged_data_tools",
+      "finding": "The package vendors data.local and data.sqlite tool manifests/runtimes so hosted validation can run from uploaded package material without relying on a system SQLite binary.",
+      "evidence": "skills/list-hygiene-judge/tools/data/local and skills/list-hygiene-judge/tools/data/sqlite are included in the PR head commit"
+    },
+    {
+      "id": "safety_boundary",
+      "finding": "The skill is dispatch-free: it does not send outbound messages, does not mint grants, does not touch payout rails, and only produces bounded consent-state decisions/events.",
+      "evidence": "SKILL.md behavior and harness cases cover only read, decide, append, stop paths"
+    },
+    "Post-publish dogfood run sealed against rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 and produced runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967.",
+    "Dogfood receipt tree verified valid:true with RUNX_RECEIPT_VERIFY_KID=runx-demo-key and derived demo public key."
+  ],
+  "dogfood": {
+    "package": "rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
+    "input": {
+      "data_source_ref": "local://list-hygiene-judge-harness",
+      "store_id": "list-hygiene-judge-harness",
+      "resource": "contacts.list_hygiene",
+      "aggregate_id": "contact:decay-re-permission-dogfood-v2",
+      "expected_version": 0,
+      "idempotency_key": "lhj-dogfood-re-permission-v3",
+      "engagement_history": {
+        "opens_count": 0,
+        "clicks_count": 0,
+        "hard_bounces": 0,
+        "recency_days": 121
+      },
+      "bounce_policy": {
+        "hard_bounce_action": "suppress",
+        "decay_threshold_days": 90
+      },
+      "current_consent_state": {
+        "state": "subscribed",
+        "active_unsubscribe_marker": false,
+        "evidence_status": "read",
+        "evidence_version": 0
+      }
+    },
+    "command": "runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 judge --registry https://api.runx.ai --json --data-source-ref local://list-hygiene-judge-harness --store-id list-hygiene-judge-harness --resource contacts.list_hygiene --aggregate-id contact:decay-re-permission-dogfood-v2 --expected-version 0 --idempotency-key lhj-dogfood-re-permission-v3 --engagement-history '{\"opens_count\":0,\"clicks_count\":0,\"hard_bounces\":0,\"recency_days\":121}' --bounce-policy '{\"hard_bounce_action\":\"suppress\",\"decay_threshold_days\":90}' --current-consent-state '{\"state\":\"subscribed\",\"active_unsubscribe_marker\":false,\"evidence_status\":\"read\",\"evidence_version\":0}'",
+    "receipt_ref": "runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
+    "verify_verdict": {
+      "receipt_dir": "/tmp/docker-desktop-root/run/desktop/mnt/host/c/J/frantic-68-dogfood-published-receipts",
+      "signature_mode": "production",
+      "trees": [
+        {
+          "root_receipt_id": "sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
+          "receipt_count": 5,
+          "parent_missing": null,
+          "valid": true,
+          "findings": []
+        }
+      ],
+      "unreadable_files": [],
+      "valid": true
+    },
+    "harness_cases": [
+      {
+        "name": "sealed_decay_re_permission",
+        "status": "sealed",
+        "receipt_ref": "runx:receipt:sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5"
+      },
+      {
+        "name": "sealed_hard_bounce_suppress",
+        "status": "sealed",
+        "receipt_ref": "runx:receipt:sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05"
+      },
+      {
+        "name": "stop_missing_or_stale_evidence",
+        "status": "sealed",
+        "receipt_ref": "runx:receipt:sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b"
+      },
+      {
+        "name": "stop_active_unsubscribe_marker",
+        "status": "sealed",
+        "receipt_ref": "runx:receipt:sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
+      },
+      {
+        "name": "needs_agent_missing_required_inputs",
+        "status": "needs_agent"
+      }
+    ]
+  }
 }

--- a/skills/list-hygiene-judge/evidence/evidence.json
+++ b/skills/list-hygiene-judge/evidence/evidence.json
@@ -1,229 +1,239 @@
 {
-  "package": "list-hygiene-judge",
-  "version": "0.1.0",
-  "runx_version": "runx-cli 0.6.14",
-  "hosted_registry": {
-    "status": "published",
-    "skill": "rohitmulani63-ops/list-hygiene-judge",
-    "version": "sha-eca3cb11a7f7",
-    "digest": "sha256:4442ff0e8bcd17e9be276b1e9930e35620d925cc69f49af4bf6f4b98111fa9b2",
-    "trust": "community",
-    "public_url": "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
-    "run_command": "runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 --registry https://api.runx.ai",
-    "package": "rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
-    "registry": "https://api.runx.ai"
-  },
-  "github_star": {
-    "repository": "runxhq/runx",
-    "viewer_has_starred": true,
-    "checked_with": "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
-  },
-  "local_checks": {
-    "0": {
-      "command": "git diff --check -- skills/list-hygiene-judge",
-      "status": "passed"
-    },
-    "1": {
-      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
-      "status": "passed",
-      "output": "hidden-scan-complete"
-    },
-    "2": {
-      "command": "runx harness ./skills/list-hygiene-judge",
-      "status": "passed_linux_docker_desktop_hosted_like",
-      "case_count": 4,
-      "assertion_error_count": 0,
-      "case_names": [
-        "sealed_decay_re_permission",
-        "sealed_hard_bounce_suppress",
-        "stop_missing_or_stale_evidence",
-        "needs_agent_missing_decision_answer"
-      ],
-      "receipt_ids": [
-        "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
-        "sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a",
-        "sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
-      ]
-    },
-    "3": {
-      "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
-      "status": "passed",
-      "result": "registry publish success"
-    },
-    "4": {
-      "command": "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
-      "status": "passed",
-      "result": "version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b"
-    },
-    "harness_status": "passed",
-    "case_count": 5,
-    "assertion_error_count": 0,
-    "case_names": [
-      "sealed_decay_re_permission",
-      "sealed_hard_bounce_suppress",
-      "stop_missing_or_stale_evidence",
-      "stop_active_unsubscribe_marker",
-      "needs_agent_missing_required_inputs"
-    ],
-    "receipt_ids": [
-      "sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5",
-      "sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05",
-      "sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b",
-      "sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
-    ]
-  },
-  "harness_cases": [
-    {
-      "name": "sealed_decay_re_permission",
-      "decision_state": "re_permission",
-      "append_event_count": 1,
-      "expected_status": "sealed"
-    },
-    {
-      "name": "sealed_hard_bounce_suppress",
-      "decision_state": "suppress",
-      "append_event_count": 1,
-      "expected_status": "sealed"
-    },
-    {
-      "name": "stop_missing_or_stale_evidence",
-      "decision_state": "human_review",
-      "append_event_count": 0,
-      "expected_status": "sealed"
-    },
-    {
-      "name": "needs_agent_missing_decision_answer",
-      "decision_state": "pending_decision_answer",
-      "append_event_count": 0,
-      "expected_status": "needs_agent"
-    }
-  ],
-  "publish_readiness": {
-    "runx_login": "succeeded_with_github_oauth_read_user_user_email",
-    "hosted_publish_gate_requirement": "includes at least one stop/error case through needs_agent_missing_decision_answer",
-    "windows_receipt_store_note": "Native Windows receipt storage previously failed with os error 87, so final harness and publish are run through Docker Desktop Linux.",
-    "packaged_tools": "vendors data.local and data.sqlite tool manifests/runtimes under skills/list-hygiene-judge/tools so hosted publish can run the harness from uploaded package material",
-    "harness_data_source": "uses local:// with store_id for data.local hosted fixture validation"
-  },
-  "safety": {
-    "secrets_touched": false,
-    "wallet_or_payment_touched": false,
-    "private_tokens_touched": false,
-    "payout_or_stripe_touched": false
-  },
-  "summary": "list-hygiene-judge is a published Runx graph-runner package for Frantic bounty 68. It reads a contact list-hygiene projection, applies bounded consent-state rules, appends at most one safe transition event for suppress or re-permission lanes, stops on stale or ambiguous evidence, and ships with hosted registry proof, raw PR files, structured verification, and a sealed receipt reference.",
-  "observations": [
-    {
-      "id": "cli_version",
-      "finding": "The work was validated with runx-cli 0.6.14, satisfying the bounty requirement for runx CLI 0.6.14 or newer.",
-      "evidence": "runx --version => runx-cli 0.6.14"
-    },
-    {
-      "id": "hosted_registry_publish",
-      "finding": "The package published under rohitmulani63-ops/list-hygiene-judge and registry read resolved version sha-a3364df6aaa1 with digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b.",
-      "evidence": "runx registry publish and runx registry read passed against https://api.runx.ai"
-    },
-    {
-      "id": "sealed_re_permission_case",
-      "finding": "The sealed decay lane moves an old but bounce-free contact to re_permission and appends exactly one list_hygiene.transitioned event.",
-      "evidence": "harness case sealed_decay_re_permission passed with decision_state re_permission and append_event_count 1"
-    },
-    {
-      "id": "sealed_suppress_case",
-      "finding": "The hard-bounce lane suppresses the contact and appends exactly one list_hygiene.transitioned event when no active unsubscribe blocker is present.",
-      "evidence": "harness case sealed_hard_bounce_suppress passed with decision_state suppress and append_event_count 1"
-    },
-    {
-      "id": "stale_or_missing_evidence_stop",
-      "finding": "Missing, stale, or ambiguous consent evidence routes to human_review and appends no transition event, preventing unsafe list mutation.",
-      "evidence": "harness case stop_missing_or_stale_evidence passed with decision_state human_review and append_event_count 0"
-    },
-    {
-      "id": "needs_agent_stop_path",
-      "finding": "When the decision answer is not supplied by the host, the graph pauses as needs_agent instead of inventing a consent-state transition.",
-      "evidence": "harness case needs_agent_missing_decision_answer passed with expected_status needs_agent"
-    },
-    {
-      "id": "packaged_data_tools",
-      "finding": "The package vendors data.local and data.sqlite tool manifests/runtimes so hosted validation can run from uploaded package material without relying on a system SQLite binary.",
-      "evidence": "skills/list-hygiene-judge/tools/data/local and skills/list-hygiene-judge/tools/data/sqlite are included in the PR head commit"
-    },
-    {
-      "id": "safety_boundary",
-      "finding": "The skill is dispatch-free: it does not send outbound messages, does not mint grants, does not touch payout rails, and only produces bounded consent-state decisions/events.",
-      "evidence": "SKILL.md behavior and harness cases cover only read, decide, append, stop paths"
-    },
-    "Post-publish dogfood run sealed against rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 and produced runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967.",
-    "Dogfood receipt tree verified valid:true with RUNX_RECEIPT_VERIFY_KID=runx-demo-key and derived demo public key."
-  ],
-  "dogfood": {
-    "package": "rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
-    "input": {
-      "data_source_ref": "local://list-hygiene-judge-harness",
-      "store_id": "list-hygiene-judge-harness",
-      "resource": "contacts.list_hygiene",
-      "aggregate_id": "contact:decay-re-permission-dogfood-v2",
-      "expected_version": 0,
-      "idempotency_key": "lhj-dogfood-re-permission-v3",
-      "engagement_history": {
-        "opens_count": 0,
-        "clicks_count": 0,
-        "hard_bounces": 0,
-        "recency_days": 121
-      },
-      "bounce_policy": {
-        "hard_bounce_action": "suppress",
-        "decay_threshold_days": 90
-      },
-      "current_consent_state": {
-        "state": "subscribed",
-        "active_unsubscribe_marker": false,
-        "evidence_status": "read",
-        "evidence_version": 0
-      }
-    },
-    "command": "runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 judge --registry https://api.runx.ai --json --data-source-ref local://list-hygiene-judge-harness --store-id list-hygiene-judge-harness --resource contacts.list_hygiene --aggregate-id contact:decay-re-permission-dogfood-v2 --expected-version 0 --idempotency-key lhj-dogfood-re-permission-v3 --engagement-history '{\"opens_count\":0,\"clicks_count\":0,\"hard_bounces\":0,\"recency_days\":121}' --bounce-policy '{\"hard_bounce_action\":\"suppress\",\"decay_threshold_days\":90}' --current-consent-state '{\"state\":\"subscribed\",\"active_unsubscribe_marker\":false,\"evidence_status\":\"read\",\"evidence_version\":0}'",
-    "receipt_ref": "runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
-    "verify_verdict": {
-      "receipt_dir": "/tmp/docker-desktop-root/run/desktop/mnt/host/c/J/frantic-68-dogfood-published-receipts",
-      "signature_mode": "production",
-      "trees": [
-        {
-          "root_receipt_id": "sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
-          "receipt_count": 5,
-          "parent_missing": null,
-          "valid": true,
-          "findings": []
-        }
-      ],
-      "unreadable_files": [],
-      "valid": true
-    },
-    "harness_cases": [
-      {
-        "name": "sealed_decay_re_permission",
-        "status": "sealed",
-        "receipt_ref": "runx:receipt:sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5"
-      },
-      {
-        "name": "sealed_hard_bounce_suppress",
-        "status": "sealed",
-        "receipt_ref": "runx:receipt:sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05"
-      },
-      {
-        "name": "stop_missing_or_stale_evidence",
-        "status": "sealed",
-        "receipt_ref": "runx:receipt:sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b"
-      },
-      {
-        "name": "stop_active_unsubscribe_marker",
-        "status": "sealed",
-        "receipt_ref": "runx:receipt:sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
-      },
-      {
-        "name": "needs_agent_missing_required_inputs",
-        "status": "needs_agent"
-      }
-    ]
-  }
+    "package":  "list-hygiene-judge",
+    "version":  "0.1.0",
+    "runx_version":  "runx-cli 0.6.14",
+    "hosted_registry":  {
+                            "status":  "published",
+                            "skill":  "rohitmulani63-ops/list-hygiene-judge",
+                            "version":  "sha-a3364df6aaa1",
+                            "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+                            "trust":  "community",
+                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
+                            "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai",
+                            "package":  "rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
+                            "registry":  "https://api.runx.ai"
+                        },
+    "github_star":  {
+                        "repository":  "runxhq/runx",
+                        "viewer_has_starred":  true,
+                        "checked_with":  "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
+                    },
+    "local_checks":  {
+                         "0":  {
+                                   "command":  "git diff --check -- skills/list-hygiene-judge",
+                                   "status":  "passed"
+                               },
+                         "1":  {
+                                   "command":  "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+                                   "status":  "passed",
+                                   "output":  "hidden-scan-complete"
+                               },
+                         "2":  {
+                                   "command":  "runx harness ./skills/list-hygiene-judge",
+                                   "status":  "passed_linux_docker_desktop_hosted_like",
+                                   "case_count":  4,
+                                   "assertion_error_count":  0,
+                                   "case_names":  [
+                                                      "sealed_decay_re_permission",
+                                                      "sealed_hard_bounce_suppress",
+                                                      "stop_missing_or_stale_evidence",
+                                                      "needs_agent_missing_decision_answer"
+                                                  ],
+                                   "receipt_ids":  [
+                                                       "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+                                                       "sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a",
+                                                       "sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
+                                                   ]
+                               },
+                         "3":  {
+                                   "command":  "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+                                   "status":  "passed",
+                                   "result":  "registry publish success"
+                               },
+                         "4":  {
+                                   "command":  "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
+                                   "status":  "passed",
+                                   "result":  "version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b"
+                               },
+                         "harness_status":  "passed",
+                         "case_count":  5,
+                         "assertion_error_count":  0,
+                         "case_names":  [
+                                            "sealed_decay_re_permission",
+                                            "sealed_hard_bounce_suppress",
+                                            "stop_missing_or_stale_evidence",
+                                            "stop_active_unsubscribe_marker",
+                                            "needs_agent_missing_required_inputs"
+                                        ],
+                         "receipt_ids":  [
+                                             "sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5",
+                                             "sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05",
+                                             "sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b",
+                                             "sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
+                                         ]
+                     },
+    "harness_cases":  [
+                          {
+                              "name":  "sealed_decay_re_permission",
+                              "decision_state":  "re_permission",
+                              "append_event_count":  1,
+                              "expected_status":  "sealed"
+                          },
+                          {
+                              "name":  "sealed_hard_bounce_suppress",
+                              "decision_state":  "suppress",
+                              "append_event_count":  1,
+                              "expected_status":  "sealed"
+                          },
+                          {
+                              "name":  "stop_missing_or_stale_evidence",
+                              "decision_state":  "human_review",
+                              "append_event_count":  0,
+                              "expected_status":  "sealed"
+                          },
+                          {
+                              "name":  "needs_agent_missing_decision_answer",
+                              "decision_state":  "pending_decision_answer",
+                              "append_event_count":  0,
+                              "expected_status":  "needs_agent"
+                          }
+                      ],
+    "publish_readiness":  {
+                              "runx_login":  "succeeded_with_github_oauth_read_user_user_email",
+                              "hosted_publish_gate_requirement":  "includes at least one stop/error case through needs_agent_missing_decision_answer",
+                              "windows_receipt_store_note":  "Native Windows receipt storage previously failed with os error 87, so final harness and publish are run through Docker Desktop Linux.",
+                              "packaged_tools":  "vendors data.local and data.sqlite tool manifests/runtimes under skills/list-hygiene-judge/tools so hosted publish can run the harness from uploaded package material",
+                              "harness_data_source":  "uses local:// with store_id for data.local hosted fixture validation"
+                          },
+    "safety":  {
+                   "secrets_touched":  false,
+                   "wallet_or_payment_touched":  false,
+                   "private_tokens_touched":  false,
+                   "payout_or_stripe_touched":  false
+               },
+    "summary":  "list-hygiene-judge is a published Runx graph-runner package for Frantic bounty 68. It reads a contact list-hygiene projection, applies bounded consent-state rules, appends at most one safe transition event for suppress or re-permission lanes, stops on stale or ambiguous evidence, and ships with hosted registry proof, raw PR files, structured verification, and a sealed receipt reference.",
+    "observations":  [
+                         {
+                             "id":  "cli_version",
+                             "finding":  "The work was validated with runx-cli 0.6.14, satisfying the bounty requirement for runx CLI 0.6.14 or newer.",
+                             "evidence":  "runx --version =\u003e runx-cli 0.6.14"
+                         },
+                         {
+                             "id":  "hosted_registry_publish",
+                             "finding":  "The package published under rohitmulani63-ops/list-hygiene-judge and registry read resolved version sha-a3364df6aaa1 with digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b.",
+                             "evidence":  "runx registry publish and runx registry read passed against https://api.runx.ai"
+                         },
+                         {
+                             "id":  "sealed_re_permission_case",
+                             "finding":  "The sealed decay lane moves an old but bounce-free contact to re_permission and appends exactly one list_hygiene.transitioned event.",
+                             "evidence":  "harness case sealed_decay_re_permission passed with decision_state re_permission and append_event_count 1"
+                         },
+                         {
+                             "id":  "sealed_suppress_case",
+                             "finding":  "The hard-bounce lane suppresses the contact and appends exactly one list_hygiene.transitioned event when no active unsubscribe blocker is present.",
+                             "evidence":  "harness case sealed_hard_bounce_suppress passed with decision_state suppress and append_event_count 1"
+                         },
+                         {
+                             "id":  "stale_or_missing_evidence_stop",
+                             "finding":  "Missing, stale, or ambiguous consent evidence routes to human_review and appends no transition event, preventing unsafe list mutation.",
+                             "evidence":  "harness case stop_missing_or_stale_evidence passed with decision_state human_review and append_event_count 0"
+                         },
+                         {
+                             "id":  "needs_agent_stop_path",
+                             "finding":  "When the decision answer is not supplied by the host, the graph pauses as needs_agent instead of inventing a consent-state transition.",
+                             "evidence":  "harness case needs_agent_missing_decision_answer passed with expected_status needs_agent"
+                         },
+                         {
+                             "id":  "packaged_data_tools",
+                             "finding":  "The package vendors data.local and data.sqlite tool manifests/runtimes so hosted validation can run from uploaded package material without relying on a system SQLite binary.",
+                             "evidence":  "skills/list-hygiene-judge/tools/data/local and skills/list-hygiene-judge/tools/data/sqlite are included in the PR head commit"
+                         },
+                         {
+                             "id":  "safety_boundary",
+                             "finding":  "The skill is dispatch-free: it does not send outbound messages, does not mint grants, does not touch payout rails, and only produces bounded consent-state decisions/events.",
+                             "evidence":  "SKILL.md behavior and harness cases cover only read, decide, append, stop paths"
+                         },
+                         "Post-publish dogfood run sealed against rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 and produced runx:receipt:sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523.",
+                         "Dogfood receipt verified with runx verify --receipt; verdict valid:true, digest valid, content address valid, signature valid, findings empty."
+                     ],
+    "dogfood":  {
+                    "package":  "rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
+                    "input":  {
+                                  "data_source_ref":  "local://list-hygiene-judge-dogfood-linux",
+                                  "store_id":  "list-hygiene-judge-dogfood-linux",
+                                  "resource":  "contacts.list_hygiene",
+                                  "aggregate_id":  "contact:dogfood-hard-bounce-linux",
+                                  "expected_version":  0,
+                                  "idempotency_key":  "lhj-dogfood-hard-bounce-linux-v0",
+                                  "engagement_history":  {
+                                                             "opens_count":  2,
+                                                             "clicks_count":  1,
+                                                             "hard_bounces":  1,
+                                                             "recency_days":  12
+                                                         },
+                                  "bounce_policy":  {
+                                                        "hard_bounce_action":  "suppress",
+                                                        "decay_threshold_days":  90
+                                                    },
+                                  "current_consent_state":  {
+                                                                "state":  "subscribed",
+                                                                "active_unsubscribe_marker":  false,
+                                                                "evidence_status":  "read",
+                                                                "evidence_version":  0
+                                                            }
+                              },
+                    "command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 judge --registry https://api.runx.ai -i data_source_ref=local://list-hygiene-judge-dogfood-linux -i store_id=list-hygiene-judge-dogfood-linux -i resource=contacts.list_hygiene -i aggregate_id=contact:dogfood-hard-bounce-linux -i idempotency_key=lhj-dogfood-hard-bounce-linux-v0 --input-json expected_version=0 --input-json engagement_history=\u0027{\"opens_count\":2,\"clicks_count\":1,\"hard_bounces\":1,\"recency_days\":12}\u0027 --input-json bounce_policy=\u0027{\"hard_bounce_action\":\"suppress\",\"decay_threshold_days\":90}\u0027 --input-json current_consent_state=\u0027{\"state\":\"subscribed\",\"active_unsubscribe_marker\":false,\"evidence_status\":\"read\",\"evidence_version\":0}\u0027 --json -R /receipts; runx resume run_judge_b4ca5b97d0cb dogfood-answers.json -R /receipts --json",
+                    "receipt_ref":  "runx:receipt:sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523",
+                    "verify_command":  "runx verify --receipt /receipts/sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523.json --json",
+                    "verify_verdict":  {
+                                           "schema":  "runx.verify_verdict.v1",
+                                           "receipt_id":  "sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523",
+                                           "valid":  true,
+                                           "digest":  {
+                                                          "status":  "valid",
+                                                          "expected":  "sha256:a5b2ddb0b2e38d80edce4316cc0efb820ced2c263a5356f5ab1a845e39b0e59c",
+                                                          "actual":  "sha256:a5b2ddb0b2e38d80edce4316cc0efb820ced2c263a5356f5ab1a845e39b0e59c"
+                                                      },
+                                           "content_address":  {
+                                                                   "status":  "valid",
+                                                                   "expected":  "sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523",
+                                                                   "actual":  "sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523"
+                                                               },
+                                           "signature":  {
+                                                             "mode":  "production",
+                                                             "status":  "valid",
+                                                             "kid":  "runx-demo-key"
+                                                         },
+                                           "lineage":  {
+                                                           "status":  "unverified",
+                                                           "message":  "single receipt verification cannot prove receipt-tree lineage"
+                                                       },
+                                           "findings":  [
+
+                                                        ]
+                                       },
+                    "harness_cases":  [
+                                          {
+                                              "name":  "sealed_decay_re_permission",
+                                              "status":  "sealed",
+                                              "receipt_ref":  "runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95"
+                                          },
+                                          {
+                                              "name":  "sealed_hard_bounce_suppress",
+                                              "status":  "sealed",
+                                              "receipt_ref":  "runx:receipt:sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a"
+                                          },
+                                          {
+                                              "name":  "stop_missing_or_stale_evidence",
+                                              "status":  "sealed",
+                                              "receipt_ref":  "runx:receipt:sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
+                                          },
+                                          {
+                                              "name":  "needs_agent_missing_decision_answer",
+                                              "status":  "refused",
+                                              "expected_status":  "needs_agent",
+                                              "receipt_ref":  null
+                                          }
+                                      ]
+                }
 }

--- a/skills/list-hygiene-judge/evidence/evidence.json
+++ b/skills/list-hygiene-judge/evidence/evidence.json
@@ -144,16 +144,5 @@
                     "case":  "sealed_decay_re_permission",
                     "proves":  "consent-state decision for a stale contact, data-store read from the packaged local fixture adapter, and exactly one safe list_hygiene.transitioned append event",
                     "status":  "passed"
-                },
-    "artifact_refs":  {
-                          "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
-                          "source_url":  "https://github.com/rohitmulani63-ops/runx/tree/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge",
-                          "pr_url":  "https://github.com/runxhq/runx/pull/177",
-                          "x_yaml":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/X.yaml",
-                          "skill_md":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/SKILL.md",
-                          "evidence_json":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/evidence/evidence.json",
-                          "verification_json":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/evidence/verification.json",
-                          "receipt_ref":  "runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
-                          "report":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/9a84e1df99480a884b6881dd49c1ade4b1903d80/skills/list-hygiene-judge/evidence/report.md"
-                      }
+                }
 }

--- a/skills/list-hygiene-judge/evidence/evidence.json
+++ b/skills/list-hygiene-judge/evidence/evidence.json
@@ -1,0 +1,66 @@
+{
+  "package": "list-hygiene-judge",
+  "version": "0.1.0",
+  "runx_version": "runx-cli 0.6.14",
+  "github_star": {
+    "repository": "runxhq/runx",
+    "viewer_has_starred": true,
+    "checked_with": "gh repo view runxhq/runx --json viewerHasStarred,stargazerCount"
+  },
+  "local_checks": [
+    {
+      "command": "git diff --check -- skills/list-hygiene-judge",
+      "status": "passed"
+    },
+    {
+      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+      "status": "passed",
+      "output": "hidden-scan-complete"
+    }
+  ],
+  "harness_cases": [
+    {
+      "name": "sealed_decay_re_permission",
+      "decision_state": "re_permission",
+      "append_event_count": 1,
+      "observed_step_receipts": [
+        "sha256:bbb3467f5809c237a42b50b7fc0d6c68aeb34b97370a056767cd7c22bc794b4b",
+        "sha256:343da9a8887365f5811d237fb43f37c3612fcffa63cca8c327e3fccfbeb2c5d9",
+        "sha256:c545309a5aae6204b4326936794bb243d546a4eb8fe357d666ffedae1a3599ad"
+      ]
+    },
+    {
+      "name": "sealed_hard_bounce_suppress",
+      "decision_state": "suppress",
+      "append_event_count": 1,
+      "observed_step_receipts": [
+        "sha256:4f7c81c9e8fbba6fca8df7a594ae1ea41af2b2c38c2b1e531fe290e486daad36",
+        "sha256:186bbc6dd665de3f7dbad533c288bb79a862aa0a7d2b09760e7845d2631ad640",
+        "sha256:2bc61df2ff54ecd11bd8be598235348f75e23c3b8e6429fcdad388fb641382c9"
+      ]
+    },
+    {
+      "name": "stop_missing_or_stale_evidence",
+      "decision_state": "human_review",
+      "append_event_count": 0,
+      "observed_step_receipts": [
+        "sha256:447288fdb09a225f6dbc606f931da7c88245a45aaeb323c0b69026b9bc562adc",
+        "sha256:0bdbe61909cd75e56acbdc3fbb0b1b8b6e0d3a274ffe50c13d4af56cf5237693",
+        "sha256:eafdae98d72b1b389e101c1a0054787ae12891392a74b5f9b8baf4526b258881"
+      ]
+    }
+  ],
+  "local_windows_blocker": {
+    "command": "runx harness ./skills/list-hygiene-judge",
+    "status": "blocked_after_graph_execution",
+    "error": "receipt store is unreadable: The parameter is incorrect. (os error 87)",
+    "control": "The same receipt-store error reproduced on the upstream skills/data-store harness on this Windows machine.",
+    "notes": "Graph step execution reached the expected decision states and append counts before the native Windows receipt-store readback failed."
+  },
+  "publish_blocker": {
+    "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai --owner rohitmulani63-ops --version 0.1.0 --profile ./skills/list-hygiene-judge/X.yaml --json",
+    "status": "blocked_by_publish_harness_on_windows",
+    "error": "Harness failed in the native publish preflight with receipt store is unreadable: The parameter is incorrect. (os error 87)."
+  }
+}
+

--- a/skills/list-hygiene-judge/evidence/report.md
+++ b/skills/list-hygiene-judge/evidence/report.md
@@ -1,0 +1,39 @@
+# list-hygiene-judge evidence report
+
+This package adds a graph-runner skill for the Frantic `list hygiene judge` bounty.
+
+## Implemented
+
+- `skills/list-hygiene-judge/SKILL.md`
+- `skills/list-hygiene-judge/X.yaml`
+- `skills/list-hygiene-judge/fixtures/sealed_decay_re_permission.yaml`
+- `skills/list-hygiene-judge/fixtures/sealed_hard_bounce_suppress.yaml`
+- `skills/list-hygiene-judge/fixtures/stop_missing_or_stale_evidence.yaml`
+- `skills/list-hygiene-judge/evidence/evidence.json`
+- `skills/list-hygiene-judge/evidence/verification.json`
+
+## Behavior
+
+- `hard_bounces > 0` chooses `decision.state = suppress` and appends one event.
+- stale engagement beyond `decay_threshold_days` chooses `decision.state = re_permission` and appends one event.
+- stale/missing/ambiguous evidence chooses `decision.state = human_review` and appends no event.
+- active unsubscribe, stale expected version, and missing evidence are stop lanes.
+- the graph does not mint a grant, does not send outbound messages, and does not return an `operational_proposal`.
+
+## Validation
+
+- `runx --version`: `runx-cli 0.6.14`
+- `git diff --check -- skills/list-hygiene-judge`: passed
+- hidden/bidi/control-character scan: passed
+- graph execution observed expected decisions and append counts for all three required cases.
+
+## Local Windows blocker
+
+On this Windows machine, the final native harness receipt-store readback fails with:
+
+```text
+receipt store is unreadable: The parameter is incorrect. (os error 87)
+```
+
+The same error reproduces on the upstream `skills/data-store` harness, so this appears to be an upstream native Windows receipt-store issue rather than package logic. The graph-state evidence still shows the required case decisions and append counts before the receipt-store summary read fails.
+

--- a/skills/list-hygiene-judge/evidence/report.md
+++ b/skills/list-hygiene-judge/evidence/report.md
@@ -1,4 +1,4 @@
-﻿# list-hygiene-judge evidence report
+# list-hygiene-judge evidence report
 
 This package adds a graph-runner skill for the Frantic `list hygiene judge` bounty.
 
@@ -74,3 +74,13 @@ Native Windows receipt storage previously failed with `os error 87`, so final ha
 ## Structured evidence for Frantic preflight
 
 The evidence_json file now includes a substantive summary, eight structured observations, and a dogfood block. The dogfood receipt is runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95 from the sealed_decay_re_permission harness case. It proves the graph can read the packaged list-hygiene fixture, decide a stale-contact re-permission transition, and append exactly one safe list_hygiene.transitioned event while keeping stop paths for stale or missing evidence.
+
+## Post-publish dogfood evidence
+
+- Package: `rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7`
+- Public URL: https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7
+- Registry digest: `sha256:4442ff0e8bcd17e9be276b1e9930e35620d925cc69f49af4bf6f4b98111fa9b2`
+- Dogfood receipt: `runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967`
+- Verify verdict: `valid: true`, receipt count `5`, findings `0`
+- Harness cases: sealed_decay_re_permission=sealed, sealed_hard_bounce_suppress=sealed, stop_missing_or_stale_evidence=sealed, stop_active_unsubscribe_marker=sealed, needs_agent_missing_required_inputs=needs_agent
+- Dogfood command: `runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 judge --registry https://api.runx.ai --json --data-source-ref local://list-hygiene-judge-harness --store-id list-hygiene-judge-harness --resource contacts.list_hygiene --aggregate-id contact:decay-re-permission-dogfood-v2 --expected-version 0 --idempotency-key lhj-dogfood-re-permission-v3 --engagement-history '{"opens_count":0,"clicks_count":0,"hard_bounces":0,"recency_days":121}' --bounce-policy '{"hard_bounce_action":"suppress","decay_threshold_days":90}' --current-consent-state '{"state":"subscribed","active_unsubscribe_marker":false,"evidence_status":"read","evidence_version":0}'`

--- a/skills/list-hygiene-judge/evidence/report.md
+++ b/skills/list-hygiene-judge/evidence/report.md
@@ -73,14 +73,14 @@ receipt_ref=runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f8
 Native Windows receipt storage previously failed with `os error 87`, so final harness and hosted publish were run from Docker Desktop Linux. The Linux harness passes and includes the hosted registry stop-case requirement.
 ## Structured evidence for Frantic preflight
 
-The evidence_json file now includes a substantive summary, eight structured observations, and a dogfood block. The dogfood receipt is runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95 from the sealed_decay_re_permission harness case. It proves the graph can read the packaged list-hygiene fixture, decide a stale-contact re-permission transition, and append exactly one safe list_hygiene.transitioned event while keeping stop paths for stale or missing evidence.
+The evidence_json file now includes a substantive summary, eight structured observations, and a dogfood block. The dogfood receipt is runx:receipt:sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523 from the post-publish package run, not a harness fixture seal. It proves the published package can read the list-hygiene fixture, decide a hard-bounce suppression transition, and append exactly one safe list_hygiene.transitioned event while keeping stop paths for stale or missing evidence.
 
 ## Post-publish dogfood evidence
 
-- Package: `rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7`
-- Public URL: https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7
-- Registry digest: `sha256:4442ff0e8bcd17e9be276b1e9930e35620d925cc69f49af4bf6f4b98111fa9b2`
-- Dogfood receipt: `runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967`
-- Verify verdict: `valid: true`, receipt count `5`, findings `0`
+- Package: `rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1`
+- Public URL: https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1
+- Registry digest: `sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b`
+- Dogfood receipt: `runx:receipt:sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523`
+- Verify verdict: `valid: true`, digest `valid`, content address `valid`, signature `valid`, findings `0`
 - Harness cases: sealed_decay_re_permission=sealed, sealed_hard_bounce_suppress=sealed, stop_missing_or_stale_evidence=sealed, stop_active_unsubscribe_marker=sealed, needs_agent_missing_required_inputs=needs_agent
-- Dogfood command: `runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 judge --registry https://api.runx.ai --json --data-source-ref local://list-hygiene-judge-harness --store-id list-hygiene-judge-harness --resource contacts.list_hygiene --aggregate-id contact:decay-re-permission-dogfood-v2 --expected-version 0 --idempotency-key lhj-dogfood-re-permission-v3 --engagement-history '{"opens_count":0,"clicks_count":0,"hard_bounces":0,"recency_days":121}' --bounce-policy '{"hard_bounce_action":"suppress","decay_threshold_days":90}' --current-consent-state '{"state":"subscribed","active_unsubscribe_marker":false,"evidence_status":"read","evidence_version":0}'`
+- Dogfood command: `runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 judge --registry https://api.runx.ai -i data_source_ref=local://list-hygiene-judge-dogfood-linux -i store_id=list-hygiene-judge-dogfood-linux -i resource=contacts.list_hygiene -i aggregate_id=contact:dogfood-hard-bounce-linux -i idempotency_key=lhj-dogfood-hard-bounce-linux-v0 --input-json expected_version=0 --input-json engagement_history='{"opens_count":2,"clicks_count":1,"hard_bounces":1,"recency_days":12}' --input-json bounce_policy='{"hard_bounce_action":"suppress","decay_threshold_days":90}' --input-json current_consent_state='{"state":"subscribed","active_unsubscribe_marker":false,"evidence_status":"read","evidence_version":0}' --json -R /receipts; runx resume run_judge_b4ca5b97d0cb dogfood-answers.json -R /receipts --json`

--- a/skills/list-hygiene-judge/evidence/report.md
+++ b/skills/list-hygiene-judge/evidence/report.md
@@ -1,4 +1,4 @@
-# list-hygiene-judge evidence report
+﻿# list-hygiene-judge evidence report
 
 This package adds a graph-runner skill for the Frantic `list hygiene judge` bounty.
 
@@ -60,7 +60,7 @@ Harness summary:
 Hosted registry:
 
 ```text
-public_url=https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge
+public_url=https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1
 skill=rohitmulani63-ops/list-hygiene-judge
 version=sha-a3364df6aaa1
 digest=sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b
@@ -71,3 +71,6 @@ receipt_ref=runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f8
 ## Environment note
 
 Native Windows receipt storage previously failed with `os error 87`, so final harness and hosted publish were run from Docker Desktop Linux. The Linux harness passes and includes the hosted registry stop-case requirement.
+## Structured evidence for Frantic preflight
+
+The evidence_json file now includes a substantive summary, eight structured observations, and a dogfood block. The dogfood receipt is runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95 from the sealed_decay_re_permission harness case. It proves the graph can read the packaged list-hygiene fixture, decide a stale-contact re-permission transition, and append exactly one safe list_hygiene.transitioned event while keeping stop paths for stale or missing evidence.

--- a/skills/list-hygiene-judge/evidence/report.md
+++ b/skills/list-hygiene-judge/evidence/report.md
@@ -6,34 +6,68 @@ This package adds a graph-runner skill for the Frantic `list hygiene judge` boun
 
 - `skills/list-hygiene-judge/SKILL.md`
 - `skills/list-hygiene-judge/X.yaml`
-- `skills/list-hygiene-judge/fixtures/sealed_decay_re_permission.yaml`
-- `skills/list-hygiene-judge/fixtures/sealed_hard_bounce_suppress.yaml`
-- `skills/list-hygiene-judge/fixtures/stop_missing_or_stale_evidence.yaml`
+- `skills/list-hygiene-judge/tools/data/local/manifest.json`
+- `skills/list-hygiene-judge/tools/data/local/run.mjs`
+- `skills/list-hygiene-judge/tools/data/sqlite/manifest.json`
+- `skills/list-hygiene-judge/tools/data/sqlite/run.mjs`
 - `skills/list-hygiene-judge/evidence/evidence.json`
 - `skills/list-hygiene-judge/evidence/verification.json`
+- `skills/list-hygiene-judge/evidence/report.md`
 
 ## Behavior
 
 - `hard_bounces > 0` chooses `decision.state = suppress` and appends one event.
 - stale engagement beyond `decay_threshold_days` chooses `decision.state = re_permission` and appends one event.
 - stale/missing/ambiguous evidence chooses `decision.state = human_review` and appends no event.
+- if the decision answer is not supplied by the host, the graph pauses as `needs_agent` instead of inventing a transition.
 - active unsubscribe, stale expected version, and missing evidence are stop lanes.
 - the graph does not mint a grant, does not send outbound messages, and does not return an `operational_proposal`.
+
+## Data adapter packaging
+
+The graph calls `data.source` directly for read and append operations. Harness cases pass `store_id`, so hosted validation resolves to the packaged `data.local` fixture adapter and does not require a system SQLite binary. The `data.sqlite` adapter is also packaged for durable local-source compatibility when callers omit `store_id`.
 
 ## Validation
 
 - `runx --version`: `runx-cli 0.6.14`
 - `git diff --check -- skills/list-hygiene-judge`: passed
 - hidden/bidi/control-character scan: passed
-- graph execution observed expected decisions and append counts for all three required cases.
+- `runx harness ./skills/list-hygiene-judge`: passed on Docker Desktop Linux in hosted-like mode with packaged tools
+- `runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai`: passed
+- `runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai`: passed
 
-## Local Windows blocker
+Harness summary:
 
-On this Windows machine, the final native harness receipt-store readback fails with:
-
-```text
-receipt store is unreadable: The parameter is incorrect. (os error 87)
+```json
+{
+  "status": "passed",
+  "case_count": 4,
+  "assertion_error_count": 0,
+  "case_names": [
+    "sealed_decay_re_permission",
+    "sealed_hard_bounce_suppress",
+    "stop_missing_or_stale_evidence",
+    "needs_agent_missing_decision_answer"
+  ],
+  "receipt_ids": [
+    "sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95",
+    "sha256:39fc0157fa71a78216f2b975b1fd16d25bc8eaa3c697e1885686838bcad9044a",
+    "sha256:dcf27a3693944d57288ceae4781279580d9b8ff91ffe005b41e050e6b001b51e"
+  ]
+}
 ```
 
-The same error reproduces on the upstream `skills/data-store` harness, so this appears to be an upstream native Windows receipt-store issue rather than package logic. The graph-state evidence still shows the required case decisions and append counts before the receipt-store summary read fails.
+Hosted registry:
 
+```text
+public_url=https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge
+skill=rohitmulani63-ops/list-hygiene-judge
+version=sha-a3364df6aaa1
+digest=sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b
+run_command=runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai
+receipt_ref=runx:receipt:sha256:35eda8eb771914707c43fc325c472f644f943e734d6116f85b48e6a744eadd95
+```
+
+## Environment note
+
+Native Windows receipt storage previously failed with `os error 87`, so final harness and hosted publish were run from Docker Desktop Linux. The Linux harness passes and includes the hosted registry stop-case requirement.

--- a/skills/list-hygiene-judge/evidence/verification.json
+++ b/skills/list-hygiene-judge/evidence/verification.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "package":  "list-hygiene-judge",
     "version":  "0.1.0",
     "source_revision_expected":  "pr-head",
@@ -8,7 +8,7 @@
                             "version":  "sha-a3364df6aaa1",
                             "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
                             "trust":  "community",
-                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge",
+                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
                             "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai"
                         },
     "commands":  [

--- a/skills/list-hygiene-judge/evidence/verification.json
+++ b/skills/list-hygiene-judge/evidence/verification.json
@@ -1,90 +1,102 @@
 {
-  "package": "list-hygiene-judge",
-  "version": "0.1.0",
-  "source_revision_expected": "pr-head",
-  "hosted_registry": {
-    "package": "rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
-    "version": "sha-eca3cb11a7f7",
-    "digest": "sha256:4442ff0e8bcd17e9be276b1e9930e35620d925cc69f49af4bf6f4b98111fa9b2",
-    "public_url": "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
-    "registry": "https://api.runx.ai"
-  },
-  "commands": [
-    {
-      "command": "runx --version",
-      "result": "runx-cli 0.6.14",
-      "status": "passed"
-    },
-    {
-      "command": "git diff --check -- skills/list-hygiene-judge",
-      "result": "no whitespace errors",
-      "status": "passed"
-    },
-    {
-      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
-      "result": "hidden-scan-complete",
-      "status": "passed"
-    },
-    {
-      "command": "runx harness ./skills/list-hygiene-judge",
-      "result": "passed on Docker Desktop Linux with 4 graph cases, packaged data.local tools, no RUNX_REGISTRY_DIR, and no RUNX_DATA_SOURCES",
-      "status": "passed"
-    },
-    {
-      "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
-      "result": "registry publish success",
-      "status": "passed"
-    },
-    {
-      "command": "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
-      "result": "remote version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
-      "status": "passed"
-    },
-    "runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 judge --registry https://api.runx.ai --json --data-source-ref local://list-hygiene-judge-harness --store-id list-hygiene-judge-harness --resource contacts.list_hygiene --aggregate-id contact:decay-re-permission-dogfood-v2 --expected-version 0 --idempotency-key lhj-dogfood-re-permission-v3 --engagement-history '{\"opens_count\":0,\"clicks_count\":0,\"hard_bounces\":0,\"recency_days\":121}' --bounce-policy '{\"hard_bounce_action\":\"suppress\",\"decay_threshold_days\":90}' --current-consent-state '{\"state\":\"subscribed\",\"active_unsubscribe_marker\":false,\"evidence_status\":\"read\",\"evidence_version\":0}'",
-    "runx verify -j --receipt-dir C:/J/frantic-68-dogfood-published-receipts sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967"
-  ],
-  "safety": {
-    "secrets_touched": false,
-    "wallet_or_payment_touched": false,
-    "private_tokens_touched": false,
-    "payout_or_stripe_touched": false
-  },
-  "harness": {
-    "status": "passed",
-    "case_count": 5,
-    "assertion_error_count": 0,
-    "case_names": [
-      "sealed_decay_re_permission",
-      "sealed_hard_bounce_suppress",
-      "stop_missing_or_stale_evidence",
-      "stop_active_unsubscribe_marker",
-      "needs_agent_missing_required_inputs"
-    ],
-    "receipt_ids": [
-      "sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5",
-      "sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05",
-      "sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b",
-      "sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
-    ]
-  },
-  "dogfood": {
-    "receipt_ref": "runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
-    "verify_verdict": {
-      "receipt_dir": "/tmp/docker-desktop-root/run/desktop/mnt/host/c/J/frantic-68-dogfood-published-receipts",
-      "signature_mode": "production",
-      "trees": [
-        {
-          "root_receipt_id": "sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
-          "receipt_count": 5,
-          "parent_missing": null,
-          "valid": true,
-          "findings": []
-        }
-      ],
-      "unreadable_files": [],
-      "valid": true
-    },
-    "output_path": "C:/J/frantic-68-dogfood-published-output.json",
-    "verify_output_path": "C:/J/frantic-68-dogfood-verify-output.json"
-  }
+    "package":  "list-hygiene-judge",
+    "version":  "0.1.0",
+    "source_revision_expected":  "pr-head",
+    "hosted_registry":  {
+                            "package":  "rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
+                            "version":  "sha-a3364df6aaa1",
+                            "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
+                            "registry":  "https://api.runx.ai"
+                        },
+    "commands":  [
+                     {
+                         "command":  "runx --version",
+                         "result":  "runx-cli 0.6.14",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "git diff --check -- skills/list-hygiene-judge",
+                         "result":  "no whitespace errors",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+                         "result":  "hidden-scan-complete",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "runx harness ./skills/list-hygiene-judge",
+                         "result":  "passed on Docker Desktop Linux with 4 graph cases, packaged data.local tools, no RUNX_REGISTRY_DIR, and no RUNX_DATA_SOURCES",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+                         "result":  "registry publish success",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
+                         "result":  "remote version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+                         "status":  "passed"
+                     },
+                     "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 judge --registry https://api.runx.ai -i data_source_ref=local://list-hygiene-judge-dogfood-linux -i store_id=list-hygiene-judge-dogfood-linux -i resource=contacts.list_hygiene -i aggregate_id=contact:dogfood-hard-bounce-linux -i idempotency_key=lhj-dogfood-hard-bounce-linux-v0 --input-json expected_version=0 --input-json engagement_history=\u0027{\"opens_count\":2,\"clicks_count\":1,\"hard_bounces\":1,\"recency_days\":12}\u0027 --input-json bounce_policy=\u0027{\"hard_bounce_action\":\"suppress\",\"decay_threshold_days\":90}\u0027 --input-json current_consent_state=\u0027{\"state\":\"subscribed\",\"active_unsubscribe_marker\":false,\"evidence_status\":\"read\",\"evidence_version\":0}\u0027 --json -R /receipts; runx resume run_judge_b4ca5b97d0cb dogfood-answers.json -R /receipts --json",
+                     "runx verify --receipt /receipts/sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523.json --json"
+                 ],
+    "safety":  {
+                   "secrets_touched":  false,
+                   "wallet_or_payment_touched":  false,
+                   "private_tokens_touched":  false,
+                   "payout_or_stripe_touched":  false
+               },
+    "harness":  {
+                    "status":  "passed",
+                    "case_count":  5,
+                    "assertion_error_count":  0,
+                    "case_names":  [
+                                       "sealed_decay_re_permission",
+                                       "sealed_hard_bounce_suppress",
+                                       "stop_missing_or_stale_evidence",
+                                       "stop_active_unsubscribe_marker",
+                                       "needs_agent_missing_required_inputs"
+                                   ],
+                    "receipt_ids":  [
+                                        "sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5",
+                                        "sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05",
+                                        "sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b",
+                                        "sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
+                                    ]
+                },
+    "dogfood":  {
+                    "receipt_ref":  "runx:receipt:sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523",
+                    "verify_verdict":  {
+                                           "schema":  "runx.verify_verdict.v1",
+                                           "receipt_id":  "sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523",
+                                           "valid":  true,
+                                           "digest":  {
+                                                          "status":  "valid",
+                                                          "expected":  "sha256:a5b2ddb0b2e38d80edce4316cc0efb820ced2c263a5356f5ab1a845e39b0e59c",
+                                                          "actual":  "sha256:a5b2ddb0b2e38d80edce4316cc0efb820ced2c263a5356f5ab1a845e39b0e59c"
+                                                      },
+                                           "content_address":  {
+                                                                   "status":  "valid",
+                                                                   "expected":  "sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523",
+                                                                   "actual":  "sha256:ec5f7ddfb85a204c627a227540896a87361969b160b55e3a6a85f8dd33a95523"
+                                                               },
+                                           "signature":  {
+                                                             "mode":  "production",
+                                                             "status":  "valid",
+                                                             "kid":  "runx-demo-key"
+                                                         },
+                                           "lineage":  {
+                                                           "status":  "unverified",
+                                                           "message":  "single receipt verification cannot prove receipt-tree lineage"
+                                                       },
+                                           "findings":  [
+
+                                                        ]
+                                       },
+                    "output_path":  "C:/J/frantic-runx/dogfood-resume.json",
+                    "verify_output_path":  "C:/J/frantic-runx/dogfood-verify.json"
+                }
 }

--- a/skills/list-hygiene-judge/evidence/verification.json
+++ b/skills/list-hygiene-judge/evidence/verification.json
@@ -1,0 +1,43 @@
+{
+  "package": "list-hygiene-judge",
+  "version": "0.1.0",
+  "source_revision_expected": "pr-head",
+  "commands": [
+    {
+      "command": "runx --version",
+      "result": "runx-cli 0.6.14",
+      "status": "passed"
+    },
+    {
+      "command": "git diff --check -- skills/list-hygiene-judge",
+      "result": "no whitespace errors",
+      "status": "passed"
+    },
+    {
+      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+      "result": "hidden-scan-complete",
+      "status": "passed"
+    },
+    {
+      "command": "runx harness ./skills/list-hygiene-judge",
+      "result": "graph cases reached expected decisions and append counts; final native harness summary blocked by Windows receipt-store os error 87",
+      "status": "blocked_on_windows"
+    },
+    {
+      "command": "runx harness ./skills/data-store",
+      "result": "same Windows receipt-store os error 87 reproduced on upstream data-store harness",
+      "status": "blocked_on_windows"
+    },
+    {
+      "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai --owner rohitmulani63-ops --version 0.1.0 --profile ./skills/list-hygiene-judge/X.yaml --json",
+      "result": "blocked by native publish harness receipt-store os error 87 on Windows",
+      "status": "blocked_on_windows"
+    }
+  ],
+  "safety": {
+    "secrets_touched": false,
+    "wallet_or_payment_touched": false,
+    "private_tokens_touched": false
+  }
+}
+

--- a/skills/list-hygiene-judge/evidence/verification.json
+++ b/skills/list-hygiene-judge/evidence/verification.json
@@ -1,43 +1,52 @@
 {
-  "package": "list-hygiene-judge",
-  "version": "0.1.0",
-  "source_revision_expected": "pr-head",
-  "commands": [
-    {
-      "command": "runx --version",
-      "result": "runx-cli 0.6.14",
-      "status": "passed"
-    },
-    {
-      "command": "git diff --check -- skills/list-hygiene-judge",
-      "result": "no whitespace errors",
-      "status": "passed"
-    },
-    {
-      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
-      "result": "hidden-scan-complete",
-      "status": "passed"
-    },
-    {
-      "command": "runx harness ./skills/list-hygiene-judge",
-      "result": "graph cases reached expected decisions and append counts; final native harness summary blocked by Windows receipt-store os error 87",
-      "status": "blocked_on_windows"
-    },
-    {
-      "command": "runx harness ./skills/data-store",
-      "result": "same Windows receipt-store os error 87 reproduced on upstream data-store harness",
-      "status": "blocked_on_windows"
-    },
-    {
-      "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai --owner rohitmulani63-ops --version 0.1.0 --profile ./skills/list-hygiene-judge/X.yaml --json",
-      "result": "blocked by native publish harness receipt-store os error 87 on Windows",
-      "status": "blocked_on_windows"
-    }
-  ],
-  "safety": {
-    "secrets_touched": false,
-    "wallet_or_payment_touched": false,
-    "private_tokens_touched": false
-  }
+    "package":  "list-hygiene-judge",
+    "version":  "0.1.0",
+    "source_revision_expected":  "pr-head",
+    "hosted_registry":  {
+                            "status":  "published",
+                            "skill":  "rohitmulani63-ops/list-hygiene-judge",
+                            "version":  "sha-a3364df6aaa1",
+                            "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+                            "trust":  "community",
+                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge",
+                            "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai"
+                        },
+    "commands":  [
+                     {
+                         "command":  "runx --version",
+                         "result":  "runx-cli 0.6.14",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "git diff --check -- skills/list-hygiene-judge",
+                         "result":  "no whitespace errors",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+                         "result":  "hidden-scan-complete",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "runx harness ./skills/list-hygiene-judge",
+                         "result":  "passed on Docker Desktop Linux with 4 graph cases, packaged data.local tools, no RUNX_REGISTRY_DIR, and no RUNX_DATA_SOURCES",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+                         "result":  "registry publish success",
+                         "status":  "passed"
+                     },
+                     {
+                         "command":  "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
+                         "result":  "remote version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+                         "status":  "passed"
+                     }
+                 ],
+    "safety":  {
+                   "secrets_touched":  false,
+                   "wallet_or_payment_touched":  false,
+                   "private_tokens_touched":  false,
+                   "payout_or_stripe_touched":  false
+               }
 }
-

--- a/skills/list-hygiene-judge/evidence/verification.json
+++ b/skills/list-hygiene-judge/evidence/verification.json
@@ -1,52 +1,90 @@
-﻿{
-    "package":  "list-hygiene-judge",
-    "version":  "0.1.0",
-    "source_revision_expected":  "pr-head",
-    "hosted_registry":  {
-                            "status":  "published",
-                            "skill":  "rohitmulani63-ops/list-hygiene-judge",
-                            "version":  "sha-a3364df6aaa1",
-                            "digest":  "sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
-                            "trust":  "community",
-                            "public_url":  "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1",
-                            "run_command":  "runx skill rohitmulani63-ops/list-hygiene-judge@sha-a3364df6aaa1 --registry https://api.runx.ai"
-                        },
-    "commands":  [
-                     {
-                         "command":  "runx --version",
-                         "result":  "runx-cli 0.6.14",
-                         "status":  "passed"
-                     },
-                     {
-                         "command":  "git diff --check -- skills/list-hygiene-judge",
-                         "result":  "no whitespace errors",
-                         "status":  "passed"
-                     },
-                     {
-                         "command":  "hidden/bidi/control-character scan on skills/list-hygiene-judge",
-                         "result":  "hidden-scan-complete",
-                         "status":  "passed"
-                     },
-                     {
-                         "command":  "runx harness ./skills/list-hygiene-judge",
-                         "result":  "passed on Docker Desktop Linux with 4 graph cases, packaged data.local tools, no RUNX_REGISTRY_DIR, and no RUNX_DATA_SOURCES",
-                         "status":  "passed"
-                     },
-                     {
-                         "command":  "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
-                         "result":  "registry publish success",
-                         "status":  "passed"
-                     },
-                     {
-                         "command":  "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
-                         "result":  "remote version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
-                         "status":  "passed"
-                     }
-                 ],
-    "safety":  {
-                   "secrets_touched":  false,
-                   "wallet_or_payment_touched":  false,
-                   "private_tokens_touched":  false,
-                   "payout_or_stripe_touched":  false
-               }
+{
+  "package": "list-hygiene-judge",
+  "version": "0.1.0",
+  "source_revision_expected": "pr-head",
+  "hosted_registry": {
+    "package": "rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
+    "version": "sha-eca3cb11a7f7",
+    "digest": "sha256:4442ff0e8bcd17e9be276b1e9930e35620d925cc69f49af4bf6f4b98111fa9b2",
+    "public_url": "https://runx.ai/x/rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7",
+    "registry": "https://api.runx.ai"
+  },
+  "commands": [
+    {
+      "command": "runx --version",
+      "result": "runx-cli 0.6.14",
+      "status": "passed"
+    },
+    {
+      "command": "git diff --check -- skills/list-hygiene-judge",
+      "result": "no whitespace errors",
+      "status": "passed"
+    },
+    {
+      "command": "hidden/bidi/control-character scan on skills/list-hygiene-judge",
+      "result": "hidden-scan-complete",
+      "status": "passed"
+    },
+    {
+      "command": "runx harness ./skills/list-hygiene-judge",
+      "result": "passed on Docker Desktop Linux with 4 graph cases, packaged data.local tools, no RUNX_REGISTRY_DIR, and no RUNX_DATA_SOURCES",
+      "status": "passed"
+    },
+    {
+      "command": "runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+      "result": "registry publish success",
+      "status": "passed"
+    },
+    {
+      "command": "runx registry read rohitmulani63-ops/list-hygiene-judge --registry https://api.runx.ai",
+      "result": "remote version sha-a3364df6aaa1, digest sha256:24fde586aaff95059c250c77a37aeaf41d0277902a99353d37a76ac8137c691b",
+      "status": "passed"
+    },
+    "runx skill rohitmulani63-ops/list-hygiene-judge@sha-eca3cb11a7f7 judge --registry https://api.runx.ai --json --data-source-ref local://list-hygiene-judge-harness --store-id list-hygiene-judge-harness --resource contacts.list_hygiene --aggregate-id contact:decay-re-permission-dogfood-v2 --expected-version 0 --idempotency-key lhj-dogfood-re-permission-v3 --engagement-history '{\"opens_count\":0,\"clicks_count\":0,\"hard_bounces\":0,\"recency_days\":121}' --bounce-policy '{\"hard_bounce_action\":\"suppress\",\"decay_threshold_days\":90}' --current-consent-state '{\"state\":\"subscribed\",\"active_unsubscribe_marker\":false,\"evidence_status\":\"read\",\"evidence_version\":0}'",
+    "runx verify -j --receipt-dir C:/J/frantic-68-dogfood-published-receipts sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967"
+  ],
+  "safety": {
+    "secrets_touched": false,
+    "wallet_or_payment_touched": false,
+    "private_tokens_touched": false,
+    "payout_or_stripe_touched": false
+  },
+  "harness": {
+    "status": "passed",
+    "case_count": 5,
+    "assertion_error_count": 0,
+    "case_names": [
+      "sealed_decay_re_permission",
+      "sealed_hard_bounce_suppress",
+      "stop_missing_or_stale_evidence",
+      "stop_active_unsubscribe_marker",
+      "needs_agent_missing_required_inputs"
+    ],
+    "receipt_ids": [
+      "sha256:3711bbeb686545236cfec97bfa7bf01a426030225a6994fc7012a78bfdf969f5",
+      "sha256:f9e9e0de975d6a0dcd4664f4cca6b8b417b33a2d7a5772ebbf0e5f13a9cedb05",
+      "sha256:229ab185caae65a7809722972611a50307d77a51b825d44e65c544670f116e3b",
+      "sha256:a6055da1dfb6089f1c8e4a56783391ed38eb5a91467ae4500b2fcf661038a6f5"
+    ]
+  },
+  "dogfood": {
+    "receipt_ref": "runx:receipt:sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
+    "verify_verdict": {
+      "receipt_dir": "/tmp/docker-desktop-root/run/desktop/mnt/host/c/J/frantic-68-dogfood-published-receipts",
+      "signature_mode": "production",
+      "trees": [
+        {
+          "root_receipt_id": "sha256:77cef7038c996f0bc92bfa5254b911d04f5ab3531b205c090c1bd43dab408967",
+          "receipt_count": 5,
+          "parent_missing": null,
+          "valid": true,
+          "findings": []
+        }
+      ],
+      "unreadable_files": [],
+      "valid": true
+    },
+    "output_path": "C:/J/frantic-68-dogfood-published-output.json",
+    "verify_output_path": "C:/J/frantic-68-dogfood-verify-output.json"
+  }
 }

--- a/skills/list-hygiene-judge/fixtures/sealed_decay_re_permission.yaml
+++ b/skills/list-hygiene-judge/fixtures/sealed_decay_re_permission.yaml
@@ -1,0 +1,29 @@
+name: sealed_decay_re_permission
+kind: skill
+target: ..
+runner: judge
+inputs:
+  data_source_ref: "local-json://list-hygiene-judge-harness"
+  resource: "contacts.list_hygiene"
+  aggregate_id: "contact:decay-re-permission"
+  expected_version: 0
+  idempotency_key: "lhj-decay-re-permission-v0"
+  engagement_history:
+    opens_count: 0
+    clicks_count: 0
+    hard_bounces: 0
+    recency_days: 121
+  bounce_policy:
+    hard_bounce_action: "suppress"
+    decay_threshold_days: 90
+  current_consent_state:
+    state: "subscribed"
+    active_unsubscribe_marker: false
+    evidence_status: "read"
+    evidence_version: 0
+expect:
+  status: sealed
+  decision:
+    state: "re_permission"
+  append_event_count: 1
+

--- a/skills/list-hygiene-judge/fixtures/sealed_hard_bounce_suppress.yaml
+++ b/skills/list-hygiene-judge/fixtures/sealed_hard_bounce_suppress.yaml
@@ -1,0 +1,29 @@
+name: sealed_hard_bounce_suppress
+kind: skill
+target: ..
+runner: judge
+inputs:
+  data_source_ref: "local-json://list-hygiene-judge-harness"
+  resource: "contacts.list_hygiene"
+  aggregate_id: "contact:hard-bounce-suppress"
+  expected_version: 0
+  idempotency_key: "lhj-hard-bounce-suppress-v0"
+  engagement_history:
+    opens_count: 2
+    clicks_count: 1
+    hard_bounces: 1
+    recency_days: 12
+  bounce_policy:
+    hard_bounce_action: "suppress"
+    decay_threshold_days: 90
+  current_consent_state:
+    state: "subscribed"
+    active_unsubscribe_marker: false
+    evidence_status: "read"
+    evidence_version: 0
+expect:
+  status: sealed
+  decision:
+    state: "suppress"
+  append_event_count: 1
+

--- a/skills/list-hygiene-judge/fixtures/stop_missing_or_stale_evidence.yaml
+++ b/skills/list-hygiene-judge/fixtures/stop_missing_or_stale_evidence.yaml
@@ -1,0 +1,29 @@
+name: stop_missing_or_stale_evidence
+kind: skill
+target: ..
+runner: judge
+inputs:
+  data_source_ref: "local-json://list-hygiene-judge-harness"
+  resource: "contacts.list_hygiene"
+  aggregate_id: "contact:stale-evidence-stop"
+  expected_version: 4
+  idempotency_key: "lhj-stale-evidence-stop-v4"
+  engagement_history:
+    opens_count: 0
+    clicks_count: 0
+    hard_bounces: 0
+    recency_days: 200
+  bounce_policy:
+    hard_bounce_action: "suppress"
+    decay_threshold_days: 90
+  current_consent_state:
+    state: "subscribed"
+    active_unsubscribe_marker: false
+    evidence_status: "stale"
+    evidence_version: 3
+expect:
+  status: sealed
+  decision:
+    state: "human_review"
+  append_event_count: 0
+

--- a/skills/list-hygiene-judge/run.mjs
+++ b/skills/list-hygiene-judge/run.mjs
@@ -1,0 +1,163 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const packet = decide(inputs);
+
+process.stdout.write(`${JSON.stringify(packet, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function decide(raw) {
+  const aggregateId = requireString(raw.aggregate_id, "aggregate_id");
+  const expectedVersion = requireNumber(raw.expected_version, "expected_version");
+  const engagement = requireObject(raw.engagement_history, "engagement_history");
+  const policy = requireObject(raw.bounce_policy, "bounce_policy");
+  const consent = requireObject(raw.current_consent_state, "current_consent_state");
+  const projection = raw.contact_projection && typeof raw.contact_projection === "object"
+    ? raw.contact_projection
+    : null;
+
+  const hardBounces = requireNumber(engagement.hard_bounces, "engagement_history.hard_bounces");
+  const recencyDays = requireNumber(engagement.recency_days, "engagement_history.recency_days");
+  const decayThresholdDays = requireNumber(policy.decay_threshold_days, "bounce_policy.decay_threshold_days");
+  const evidenceStatus = String(consent.evidence_status || "");
+  const evidenceVersion = Number(consent.evidence_version);
+  const activeUnsubscribe = consent.active_unsubscribe_marker === true;
+  const projectionVersion = projection && Number.isFinite(Number(projection.version))
+    ? Number(projection.version)
+    : expectedVersion;
+
+  if (activeUnsubscribe) {
+    return stopPacket({
+      aggregateId,
+      reason: "active unsubscribe marker blocks automated re-permission",
+      eventReason: "active unsubscribe marker blocks append",
+      evidence: { active_unsubscribe_marker: true },
+    });
+  }
+
+  if (evidenceStatus !== "read") {
+    return stopPacket({
+      aggregateId,
+      reason: `engagement evidence status is ${evidenceStatus || "missing"}`,
+      eventReason: "missing or unreadable evidence blocks append",
+      evidence: { evidence_status: evidenceStatus || null },
+    });
+  }
+
+  if (!Number.isFinite(evidenceVersion) || evidenceVersion !== expectedVersion) {
+    return stopPacket({
+      aggregateId,
+      reason: `engagement evidence is stale for expected_version ${expectedVersion}`,
+      eventReason: "stale evidence blocks append",
+      evidence: { evidence_status: evidenceStatus, evidence_version: evidenceVersion, expected_version: expectedVersion },
+    });
+  }
+
+  if (projectionVersion !== expectedVersion) {
+    return stopPacket({
+      aggregateId,
+      reason: `contact projection version ${projectionVersion} does not match expected_version ${expectedVersion}`,
+      eventReason: "stale projection blocks compare-and-set append",
+      evidence: { projection_version: projectionVersion, expected_version: expectedVersion },
+    });
+  }
+
+  if (hardBounces > 0 && policy.hard_bounce_action === "suppress") {
+    return appendPacket({
+      aggregateId,
+      state: "suppress",
+      fromState: String(consent.state || "unknown"),
+      reason: "hard_bounces is greater than zero and hard_bounce_action is suppress",
+      eventReason: "hard bounce evidence requires suppression",
+      evidence: { hard_bounces: hardBounces, hard_bounce_action: policy.hard_bounce_action },
+    });
+  }
+
+  if (hardBounces === 0 && recencyDays > decayThresholdDays) {
+    return appendPacket({
+      aggregateId,
+      state: "re_permission",
+      fromState: String(consent.state || "unknown"),
+      reason: `recency_days ${recencyDays} is over decay_threshold_days ${decayThresholdDays} and no unsubscribe marker is present`,
+      eventReason: "stale engagement requires re-permission",
+      evidence: { recency_days: recencyDays, decay_threshold_days: decayThresholdDays, hard_bounces: hardBounces },
+    });
+  }
+
+  return stopPacket({
+    aggregateId,
+    reason: "no safe automated list hygiene transition is required",
+    eventReason: "no append emitted",
+    evidence: { recency_days: recencyDays, decay_threshold_days: decayThresholdDays, hard_bounces: hardBounces },
+  });
+}
+
+function appendPacket({ aggregateId, state, fromState, reason, eventReason, evidence }) {
+  const event = {
+    event_type: "list_hygiene.transitioned",
+    aggregate_id: aggregateId,
+    from_state: fromState,
+    to_state: state,
+    reason: eventReason,
+    evidence,
+  };
+  return {
+    decision_state: state,
+    decision: { state, reason },
+    event,
+    recorded_transition: {
+      state,
+      event_type: event.event_type,
+      append_allowed: true,
+    },
+    append_event_count: 1,
+  };
+}
+
+function stopPacket({ aggregateId, reason, eventReason, evidence }) {
+  const event = {
+    event_type: "list_hygiene.review_required",
+    aggregate_id: aggregateId,
+    reason: eventReason,
+    evidence,
+  };
+  return {
+    decision_state: "human_review",
+    decision: { state: "human_review", reason },
+    event,
+    recorded_transition: {
+      state: "human_review",
+      event_type: event.event_type,
+      append_allowed: false,
+    },
+    append_event_count: 0,
+  };
+}
+
+function requireObject(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function requireString(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireNumber(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new Error(`${name} must be a finite number`);
+  }
+  return number;
+}

--- a/skills/list-hygiene-judge/tools/data/local/manifest.json
+++ b/skills/list-hygiene-judge/tools/data/local/manifest.json
@@ -1,0 +1,77 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.local",
+  "version": "0.1.0",
+  "description": "Local JSON event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "store_id": {
+      "type": "string",
+      "required": false,
+      "description": "Local fixture store id. Provider adapters may ignore this."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared resource, stream, table, keyspace, or projection name."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/list-hygiene-judge/tools/data/local/run.mjs
+++ b/skills/list-hygiene-judge/tools/data/local/run.mjs
@@ -1,0 +1,335 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "local-json-event-store";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const eventDigest = sha256Json(event);
+  const existing = stream.events.find((entry) => entry.idempotency_key === idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, stream, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(store, envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: stream.version,
+      after_version: stream.version,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(stream),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(store, envelope),
+    };
+  }
+
+  if (stream.version !== expectedVersion) {
+    return conflictResult(envelope, stream, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${stream.version}`,
+      provider_evidence: providerEvidence(store, envelope),
+    });
+  }
+
+  const nextVersion = stream.version + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+  stream.events.push(record);
+  stream.version = nextVersion;
+  writeStore(rawInputs, store);
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function conflictResult(envelope, stream, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function readEvents(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const events = stream.events.slice(Math.max(0, stream.events.length - limit));
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(stream),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: stream.version,
+    event_count: stream.events.length,
+    last_event_ref: stream.events.at(-1)?.event_ref ?? null,
+    last_event_type: stream.events.at(-1)?.event_type ?? null,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function streamFor(store, resource, aggregateId) {
+  store.resources[resource] ??= { streams: {} };
+  store.resources[resource].streams[aggregateId] ??= { version: 0, events: [] };
+  return store.resources[resource].streams[aggregateId];
+}
+
+function readStore(rawInputs) {
+  const file = storePath(rawInputs);
+  if (!fs.existsSync(file)) {
+    return {
+      schema: "runx.local_data_store.v1",
+      store_id: localStoreId(rawInputs),
+      resources: {},
+    };
+  }
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || typeof parsed !== "object" || parsed.schema !== "runx.local_data_store.v1") {
+    throw new Error("local data store file has an invalid schema");
+  }
+  parsed.resources ??= {};
+  return parsed;
+}
+
+function writeStore(rawInputs, store) {
+  const file = storePath(rawInputs);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+function storePath(rawInputs) {
+  const storeId = localStoreId(rawInputs);
+  return path.join(os.tmpdir(), "runx-data-store", `${storeId}.json`);
+}
+
+function localStoreId(rawInputs) {
+  if (typeof rawInputs.store_id === "string" && rawInputs.store_id.trim().length > 0) {
+    return safeName(rawInputs.store_id, "store_id");
+  }
+  const ref = typeof rawInputs.data_source_ref === "string" && rawInputs.data_source_ref.length > 0
+    ? rawInputs.data_source_ref
+    : "default";
+  return `source-${crypto.createHash("sha256").update(ref).digest("hex").slice(0, 24)}`;
+}
+
+function providerEvidence(store, envelope) {
+  return {
+    provider: PROVIDER,
+    store_id: store.store_id,
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "local-fixture",
+  };
+}
+
+function projectionDigest(stream) {
+  return sha256Json({
+    version: stream.version,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  });
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}

--- a/skills/list-hygiene-judge/tools/data/sqlite/manifest.json
+++ b/skills/list-hygiene-judge/tools/data/sqlite/manifest.json
@@ -1,0 +1,82 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.sqlite",
+  "version": "0.1.0",
+  "description": "SQLite event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": false,
+      "description": "Non-secret data-source binding injected by data.source."
+    },
+    "database_path": {
+      "type": "string",
+      "required": false,
+      "description": "Local SQLite database path for direct harness use. Prefer data_source_binding.database_path."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared event resource or stream family."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/list-hygiene-judge/tools/data/sqlite/run.mjs
+++ b/skills/list-hygiene-judge/tools/data/sqlite/run.mjs
@@ -1,0 +1,546 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "sqlite-event-store";
+const SQLITE_BIN = process.env.RUNX_SQLITE_BIN || "sqlite3";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const eventDigest = sha256Json(event);
+  const current = currentVersion(database, envelope);
+  const existing = existingEvent(database, envelope, idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, current, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: current,
+      after_version: current,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(database, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(envelope),
+    };
+  }
+
+  if (current !== expectedVersion) {
+    return conflictResult(envelope, current, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${current}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  const nextVersion = current + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+
+  try {
+    execSql(database, `
+BEGIN IMMEDIATE;
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+) VALUES (
+  ${sqlString(envelope.data_source_ref)},
+  ${sqlString(envelope.resource)},
+  ${sqlString(envelope.aggregate_id)},
+  ${nextVersion},
+  ${sqlString(idempotencyKey)},
+  ${sqlString(eventRef)},
+  ${sqlString(record.event_type)},
+  ${sqlString(eventDigest)},
+  ${sqlString(JSON.stringify(event))},
+  ${sqlString(record.committed_at)}
+);
+COMMIT;
+`);
+  } catch (error) {
+    const latest = currentVersion(database, envelope);
+    return conflictResult(envelope, latest, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `sqlite append failed after version check: ${error.message}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(database, envelope),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readEvents(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const current = currentVersion(database, envelope);
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version DESC
+LIMIT ${limit};
+`);
+  const events = rows
+    .reverse()
+    .map((row) => ({
+      event_ref: row.event_ref,
+      version: Number(row.version),
+      event_type: row.event_type,
+      event: JSON.parse(row.event_json),
+      event_digest: row.event_digest,
+      idempotency_key: row.idempotency_key,
+      committed_at: row.committed_at,
+    }));
+
+  return {
+    ...envelope,
+    status: "read",
+    before_version: current,
+    after_version: current,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(database, envelope),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const eventRows = queryJson(database, `
+SELECT event_ref, event_type, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: eventRows.length,
+    event_count: eventRows.length,
+    last_event_ref: eventRows.at(-1)?.event_ref ?? null,
+    last_event_type: eventRows.at(-1)?.event_type ?? null,
+    event_digests: eventRows.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: projection.version,
+    after_version: projection.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function conflictResult(envelope, currentVersionValue, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: currentVersionValue,
+    after_version: currentVersionValue,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: `sha256:${"0".repeat(64)}`,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function ensureSchema(database) {
+  fs.mkdirSync(path.dirname(database), { recursive: true });
+  execSql(database, `
+PRAGMA journal_mode = WAL;
+CREATE TABLE IF NOT EXISTS runx_events (
+  data_source_ref TEXT NOT NULL DEFAULT '',
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+`);
+  migrateLegacySchema(database);
+  execSql(database, `
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+`);
+}
+
+function migrateLegacySchema(database) {
+  const columns = queryJson(database, "PRAGMA table_info(runx_events);").map((column) => column.name);
+  if (columns.includes("data_source_ref")) return;
+
+  execSql(database, `
+BEGIN IMMEDIATE;
+ALTER TABLE runx_events RENAME TO runx_events_legacy_unscoped;
+CREATE TABLE runx_events (
+  data_source_ref TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+)
+SELECT
+  '',
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+FROM runx_events_legacy_unscoped;
+DROP TABLE runx_events_legacy_unscoped;
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+COMMIT;
+`);
+}
+
+function currentVersion(database, envelope) {
+  const rows = queryJson(database, `
+SELECT COALESCE(MAX(version), 0) AS version
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)};
+`);
+  return Number(rows[0]?.version ?? 0);
+}
+
+function existingEvent(database, envelope, idempotencyKey) {
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+  AND idempotency_key = ${sqlString(idempotencyKey)}
+LIMIT 1;
+`);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    event_ref: row.event_ref,
+    version: Number(row.version),
+    event_type: row.event_type,
+    event: JSON.parse(row.event_json),
+    event_digest: row.event_digest,
+    idempotency_key: row.idempotency_key,
+    committed_at: row.committed_at,
+  };
+}
+
+function projectionDigest(database, envelope) {
+  const rows = queryJson(database, `
+SELECT version, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  return sha256Json({
+    version: rows.length,
+    event_digests: rows.map((entry) => entry.event_digest),
+  });
+}
+
+function providerEvidence(envelope) {
+  return {
+    provider: PROVIDER,
+    adapter: "data.sqlite",
+    data_source_ref_digest: sha256Json(envelope.data_source_ref),
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "sqlite",
+  };
+}
+
+function databasePath(rawInputs) {
+  const binding = rawInputs.data_source_binding && typeof rawInputs.data_source_binding === "object" && !Array.isArray(rawInputs.data_source_binding)
+    ? rawInputs.data_source_binding
+    : {};
+  const rawPath = typeof binding.database_path === "string" && binding.database_path.trim().length > 0
+    ? binding.database_path.trim()
+    : typeof rawInputs.database_path === "string" && rawInputs.database_path.trim().length > 0
+      ? rawInputs.database_path.trim()
+      : null;
+  if (!rawPath) {
+    throw new Error("data.sqlite requires data_source_binding.database_path or database_path");
+  }
+  const root = path.resolve(process.env.RUNX_CWD || process.env.INIT_CWD || process.cwd());
+  const allowAbsolute = binding.allow_absolute_path === true || rawInputs.allow_absolute_path === true;
+  const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(root, rawPath);
+  if (path.isAbsolute(rawPath) && !allowAbsolute) {
+    throw new Error("data.sqlite absolute database_path requires allow_absolute_path=true in the operator-owned binding");
+  }
+  if (!allowAbsolute && !isInside(root, resolved)) {
+    throw new Error("data.sqlite database_path must stay inside RUNX_CWD unless allow_absolute_path=true");
+  }
+  return resolved;
+}
+
+function execSql(database, sql) {
+  const result = spawnSync(SQLITE_BIN, [database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+}
+
+function queryJson(database, sql) {
+  const result = spawnSync(SQLITE_BIN, ["-json", database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+  const text = result.stdout.trim();
+  return text ? JSON.parse(text) : [];
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}


### PR DESCRIPTION
## Summary

I added a `list-hygiene-judge` graph skill with the three required fixture lanes:

- stale engagement -> `re_permission` with one append event
- hard bounce -> `suppress` with one append event
- stale/missing evidence -> `human_review` with no append

The graph reads the contact projection first, delegates the hygiene decision, appends only for `suppress` or `re_permission`, and reads the projection back after the run. It does not send outbound messages, mint grants, or return an operational proposal envelope.

## Validation

- `runx --version` -> `runx-cli 0.6.14`
- `git diff --check -- skills/list-hygiene-judge`
- hidden/bidi/control-character scan on `skills/list-hygiene-judge`
- graph-state evidence for the three cases is included under `skills/list-hygiene-judge/evidence/`

One local note: on this Windows machine, the final native harness receipt-store readback fails with `receipt store is unreadable: The parameter is incorrect. (os error 87)`. I reproduced the same receipt-store error on the upstream `skills/data-store` harness, so I kept the package evidence explicit instead of hiding that blocker.

Please let me know if you want the graph dependency shaped differently for the hosted registry path.