### PR TITLE
Add marketing operations judge skills

### DIFF
--- a/docs/frantic-62-69-verification/evidence.json
+++ b/docs/frantic-62-69-verification/evidence.json
@@ -1,0 +1,114 @@
+{
+  "schema": "frantic.runx_batch_verification.v1",
+  "verified_at": "2026-06-30T08:18:00Z",
+  "environment": {
+    "os": "Ubuntu-24.04 under WSL",
+    "runx_cli": "runx-cli 0.6.14",
+    "repository": "runxhq/runx",
+    "pull_request": "https://github.com/runxhq/runx/pull/182",
+    "notes": [
+      "Windows runx receipt-store errors were avoided by rerunning the same packages under WSL.",
+      "All package harnesses below passed with zero assertion errors.",
+      "These are local governed-run receipts from the WSL harness pass; final Frantic delivery still requires registry publish and hosted/post-publish receipt verification."
+    ]
+  },
+  "packages": [
+    {
+      "bounty": 62,
+      "package": "spam-risk-reviewer",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["low-risk-verified-sender", "high-risk-incomplete-auth-poor-list"],
+      "receipt_ids": [
+        "sha256:7ef0f269689bc2ff35226fe3133e8613d525811118b6bc7937317049f9f43205",
+        "sha256:c314f48cb5f012444d2f660e2005bafdeabf9ad07509bcbc9d02d6cf3195ca84"
+      ],
+      "assertion_error_count": 0
+    },
+    {
+      "bounty": 63,
+      "package": "renewal-risk-judge",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["high_risk_with_save_play", "missing_usage_signals_stop"],
+      "receipt_ids": [
+        "sha256:fff1a2c2cdd14a4f216ea25024afbf2fef0795746f7d6b449125750ef9cfd8c9",
+        "sha256:d6044a8b757ebdaa041d975c7460d76b9e16bfbc001bcf6b6edfa30aa29a5a4d"
+      ],
+      "assertion_error_count": 0
+    },
+    {
+      "bounty": 64,
+      "package": "oncall-alert-triage",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["sealed_escalate_checkout_alert", "stop_unsealed_runbook_needs_agent"],
+      "receipt_ids": [
+        "sha256:3f46d77af5f51dbdf4c221355cdcb9dbb5cb861790f8cfd1591e60b037a514ce",
+        "sha256:6de43ed8bc3a5ec997420dae427e147d19c766b2849c1dd22987fa574760133e"
+      ],
+      "assertion_error_count": 0
+    },
+    {
+      "bounty": 65,
+      "package": "deliverability-judge",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["sealed_healthy_signals_continue", "contradictory_signals_escalate"],
+      "receipt_ids": [
+        "sha256:f78b9de7ca479a87ac1a96da677b9b0157a907a6936557ef1a1e0884b67111c2",
+        "sha256:fb738b92286084fda544eeda8a96fb3abad76c483a1f409857252f5cf335a4bb"
+      ],
+      "assertion_error_count": 0
+    },
+    {
+      "bounty": 66,
+      "package": "flaky-test-judge",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["quarantine_justified", "missing_run_history"],
+      "receipt_ids": [
+        "sha256:e3133233b7c9235b70a0afee183830d1f58be9cce2927c36cbfa167fa98ad318",
+        "sha256:2d790adb8c32d545bc9a2fc51eebc58c26fa225ff58b832697b0c4aaad6ef660"
+      ],
+      "assertion_error_count": 0
+    },
+    {
+      "bounty": 67,
+      "package": "mandate-planner",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["in_grant_charter", "out_of_grant_charter"],
+      "receipt_ids": [
+        "sha256:6279b810f16e3fa727a1ca0cd4c3beb8fc707b90dba5bcb96f2304bcdcbcd5e2"
+      ],
+      "assertion_error_count": 0,
+      "human_lane_note": "out_of_grant_charter is expected to stop at needs_agent and therefore does not create a sealed receipt."
+    },
+    {
+      "bounty": 68,
+      "package": "list-hygiene-judge",
+      "status": "passed",
+      "case_count": 3,
+      "case_names": ["sealed_decay_re_permission", "sealed_hard_bounce_suppress", "stop_missing_or_stale_evidence"],
+      "receipt_ids": [
+        "sha256:3e6a6fb9143fbb53d2f828b8d5835793951dca72b310c096ecb9563e2d84914a",
+        "sha256:8849d3de1593b0257fee66919ef60a228053f412e3f56373357c38547dcf3bae",
+        "sha256:e4706337c606d5440cb0985f2453975a5289f9a1da7f36c40072d54c3a5ae490"
+      ],
+      "assertion_error_count": 0
+    },
+    {
+      "bounty": 69,
+      "package": "escalation-judge",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": ["sealed_priority_escalation", "stop_no_threshold_no_change"],
+      "receipt_ids": [
+        "sha256:67940c880083d596b4842a8d6f54f80f6018219cae28c2752bfba9ec595743fa",
+        "sha256:3e19f43f9f58884c677c324a27727d09124215ac5be7b6a275a77e8955246361"
+      ],
+      "assertion_error_count": 0
+    }
+  ]
+}

--- a/docs/frantic-62-69-verification/report.md
+++ b/docs/frantic-62-69-verification/report.md
@@ -1,0 +1,32 @@
+# Frantic #62-#69 runx skill verification report
+
+This report covers the eight prepared runx skill packages in PR
+<https://github.com/runxhq/runx/pull/182>.
+
+All packages were tested under Ubuntu-24.04 in WSL using `runx-cli 0.6.14`.
+The earlier Windows receipt-store issue is not present in this environment.
+
+| Bounty | Package | Harness result | Cases |
+| --- | --- | --- | --- |
+| #62 | `spam-risk-reviewer` | passed | `low-risk-verified-sender`, `high-risk-incomplete-auth-poor-list` |
+| #63 | `renewal-risk-judge` | passed | `high_risk_with_save_play`, `missing_usage_signals_stop` |
+| #64 | `oncall-alert-triage` | passed | `sealed_escalate_checkout_alert`, `stop_unsealed_runbook_needs_agent` |
+| #65 | `deliverability-judge` | passed | `sealed_healthy_signals_continue`, `contradictory_signals_escalate` |
+| #66 | `flaky-test-judge` | passed | `quarantine_justified`, `missing_run_history` |
+| #67 | `mandate-planner` | passed | `in_grant_charter`, `out_of_grant_charter` |
+| #68 | `list-hygiene-judge` | passed | `sealed_decay_re_permission`, `sealed_hard_bounce_suppress`, `stop_missing_or_stale_evidence` |
+| #69 | `escalation-judge` | passed | `sealed_priority_escalation`, `stop_no_threshold_no_change` |
+
+The package source lives under `skills/<package>/`. Each package has an
+`X.yaml`, `SKILL.md`, `run.mjs`, and deterministic fixtures. The skills are
+read-only or bounded packet emitters; public sends, authority minting, direct
+money movement, deployment, and live external effects are either absent or
+routed to explicit downstream governed lanes.
+
+Remaining before final Frantic delivery:
+
+1. successfully claim the bounty slot;
+2. publish the exact package to the runx registry;
+3. run hosted registry harness;
+4. run a post-publish dogfood invocation;
+5. verify the emitted receipt and submit the final Frantic artifact fields.

--- a/skills/deliverability-judge/SKILL.md
+++ b/skills/deliverability-judge/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: deliverability-judge
+description: Fuse sealed deliverability evidence into a read-only continue, throttle, or pause recommendation without emitting effects.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  evidence:
+    type: json
+    required: true
+    description: Sealed provider evidence with postmaster, bounce, complaint, and placement signals.
+  policy:
+    type: json
+    required: true
+    description: Operator thresholds for reputation, bounce rate, and complaint rate.
+runx:
+  category: compliance
+  input_resolution:
+    required:
+      - evidence
+      - policy
+---
+
+# Deliverability Judge
+
+`deliverability-judge` sits upstream of any send or throttle rail. It fuses
+sealed provider evidence into one read-only verdict and recommendation:
+`continue`, `throttle`, or `pause`.
+
+It does not send, throttle, hold state, mint authority, emit an Effect, create an
+`operational_proposal.v1` envelope, or create an `AttenuationRequest`.
+Contradictory or partial signals seal as an escalation record instead of a
+recommendation. A human or downstream deliverability lane may later dispatch a
+separate governed throttle run by name.
+
+## Inputs
+
+- `evidence.postmaster_report`
+- `evidence.bounce_metrics`
+- `evidence.complaint_metrics`
+- `evidence.placement_probe`
+- `policy.min_reputation_score`
+- `policy.max_bounce_pct`
+- `policy.max_complaint_pct`
+
+Each evidence signal must be sealed and carry `source` and `timestamp`.
+
+## Decision rules
+
+- Healthy reputation, bounce, complaint, and placement signals emit
+  `verdict.state: healthy` and `recommendation.action: continue`.
+- Degraded but non-contradictory signals emit `throttle` or `pause` depending
+  on severity.
+- High reputation contradicted by high bounce or complaint rates refuses to
+  fuse and escalates.
+- Missing or unsealed signals refuse to fuse and escalate.
+- The runner never invents missing signals.
+
+## Verification
+
+Local harness:
+
+```bash
+runx harness ./skills/deliverability-judge --json
+```
+
+Dogfood fixture run:
+
+```bash
+runx skill ./skills/deliverability-judge --json \
+  --input-json evidence=@fixtures/healthy-evidence.json \
+  --input-json policy=@fixtures/operator-policy.json
+```
+

--- a/skills/deliverability-judge/X.yaml
+++ b/skills/deliverability-judge/X.yaml
@@ -1,0 +1,113 @@
+skill: deliverability-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_healthy_signals_continue
+      runner: default
+      inputs:
+        evidence:
+          postmaster_report:
+            sealed: true
+            source: google-postmaster://example.com/reputation/2026-06-30
+            timestamp: "2026-06-30T07:00:00Z"
+            reputation_score: 96
+          bounce_metrics:
+            sealed: true
+            source: esp://example.com/bounces/2026-06-30
+            timestamp: "2026-06-30T07:01:00Z"
+            bounce_pct: 0.4
+          complaint_metrics:
+            sealed: true
+            source: esp://example.com/complaints/2026-06-30
+            timestamp: "2026-06-30T07:02:00Z"
+            complaint_pct: 0.02
+          placement_probe:
+            sealed: true
+            source: seedlist://example.com/probe/2026-06-30
+            timestamp: "2026-06-30T07:03:00Z"
+            inbox_pct: 97
+        policy:
+          min_reputation_score: 80
+          max_bounce_pct: 2
+          max_complaint_pct: 0.1
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: contradictory_signals_escalate
+      runner: default
+      inputs:
+        evidence:
+          postmaster_report:
+            sealed: true
+            source: google-postmaster://example.com/reputation/2026-06-30
+            timestamp: "2026-06-30T07:00:00Z"
+            reputation_score: 95
+          bounce_metrics:
+            sealed: true
+            source: esp://example.com/bounces/2026-06-30
+            timestamp: "2026-06-30T07:01:00Z"
+            bounce_pct: 8.5
+          complaint_metrics:
+            sealed: true
+            source: esp://example.com/complaints/2026-06-30
+            timestamp: "2026-06-30T07:02:00Z"
+            complaint_pct: 0.03
+          placement_probe:
+            sealed: true
+            source: seedlist://example.com/probe/2026-06-30
+            timestamp: "2026-06-30T07:03:00Z"
+            inbox_pct: 94
+        policy:
+          min_reputation_score: 80
+          max_bounce_pct: 2
+          max_complaint_pct: 0.1
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+policy:
+  allow:
+    - provider: deliverability-evidence
+      method: READ
+      scope: deliverability:evidence:read
+  deny:
+    - effect.emit
+    - throttle.apply
+    - send.execute
+    - authority.mint
+    - operational_proposal
+    - attenuation_request
+
+emits:
+  - name: deliverability_verdict
+    packet: runx.deliverability.verdict.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      evidence:
+        type: json
+        required: true
+      policy:
+        type: json
+        required: true
+

--- a/skills/deliverability-judge/evidence.json
+++ b/skills/deliverability-judge/evidence.json
@@ -1,0 +1,115 @@
+{
+  "schema": "frantic.runx_skill_evidence.v1",
+  "bounty": 65,
+  "package": "deliverability-judge",
+  "version": "0.1.0",
+  "prepared_at": "2026-06-30T07:30:00Z",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "publisher_owner": "TODO: publish owner after GitHub login",
+  "registry_ref": "TODO: <owner>/deliverability-judge@0.1.0 or registry sha version",
+  "public_url": "TODO: https://runx.ai/x/<owner>/deliverability-judge@<version>",
+  "source_url": "TODO: public source/provenance URL after PR branch exists",
+  "pr_url": "TODO: https://github.com/runxhq/runx/pull/<number>",
+  "raw_x_yaml": "TODO: raw URL from PR head commit",
+  "raw_skill_md": "TODO: raw URL from PR head commit",
+  "verification_json": "verification.json",
+  "receipt_ref": "TODO: post-publish dogfood receipt_ref",
+  "publish_method": "runx login --provider github --for publish; runx registry publish ./skills/deliverability-judge/SKILL.md --registry https://api.runx.ai",
+  "install_command": "runx add <owner>/deliverability-judge@<version>",
+  "local_harness_command": "runx harness ./skills/deliverability-judge --receipt-dir ./.runx-receipts --json",
+  "hosted_harness_status": "TODO: run after registry publish",
+  "dogfood_command": "TODO post-publish: runx skill <owner>/deliverability-judge@<version> --json ...; runx verify --receipt <receipt.json> --json",
+  "observations": {
+    "harness_case_names": [
+      "sealed_healthy_signals_continue",
+      "contradictory_signals_escalate"
+    ],
+    "verdict": {
+      "state": "healthy",
+      "confidence_window": [
+        0.84,
+        0.93
+      ],
+      "reason": "All sealed deliverability signals satisfy operator thresholds."
+    },
+    "signal_evaluations": [
+      {
+        "name": "postmaster_report",
+        "sealed_source": "google-postmaster://example.com/reputation/2026-06-30",
+        "timestamp": "2026-06-30T07:00:00Z",
+        "metric": "reputation_score",
+        "value": 96,
+        "policy": ">= 80",
+        "pass": true
+      },
+      {
+        "name": "bounce_metrics",
+        "sealed_source": "esp://example.com/bounces/2026-06-30",
+        "timestamp": "2026-06-30T07:01:00Z",
+        "metric": "bounce_pct",
+        "value": 0.4,
+        "policy": "<= 2",
+        "pass": true
+      },
+      {
+        "name": "complaint_metrics",
+        "sealed_source": "esp://example.com/complaints/2026-06-30",
+        "timestamp": "2026-06-30T07:02:00Z",
+        "metric": "complaint_pct",
+        "value": 0.02,
+        "policy": "<= 0.1",
+        "pass": true
+      },
+      {
+        "name": "placement_probe",
+        "sealed_source": "seedlist://example.com/probe/2026-06-30",
+        "timestamp": "2026-06-30T07:03:00Z",
+        "metric": "inbox_pct",
+        "value": 97,
+        "policy": ">= 90",
+        "pass": true
+      }
+    ],
+    "recommendation": {
+      "action": "continue",
+      "evidence_hash": "sha256:1668a0c0a3b883f6e67ffa181b79a75d6853dc57ada91df148c5e063af40810c",
+      "read_only": true
+    },
+    "refused_reason": {
+      "code": "contradictory_signals",
+      "reason": "Signals contradict: strong reputation or placement conflicts with out-of-policy negative rates, so no recommendation is emitted.",
+      "contradicting_or_missing_signals": [
+        "postmaster_report_vs_bounce_metrics",
+        "placement_probe_vs_negative_rates"
+      ]
+    },
+    "receipt_id": "TODO: unavailable locally because Windows runx receipt store failed before sealing",
+    "authority_boundary": {
+      "minted": false,
+      "effects_emitted": false,
+      "operational_proposal_v1": false,
+      "attenuation_request": false,
+      "sends_executed": false,
+      "throttle_applied": false,
+      "state_held": false
+    }
+  },
+  "dogfood": {
+    "package": "TODO: <owner>/deliverability-judge@<version>",
+    "input": "fixtures/healthy-evidence.json + fixtures/operator-policy.json",
+    "command": "TODO: post-publish runx skill command",
+    "receipt_ref": "TODO",
+    "verify_verdict": "TODO",
+    "harness_cases": [
+      {
+        "name": "sealed_healthy_signals_continue",
+        "status": "local runner logic passed; receipt not sealed on this Windows host"
+      },
+      {
+        "name": "contradictory_signals_escalate",
+        "status": "local runner logic passed; receipt not sealed on this Windows host"
+      }
+    ]
+  }
+}
+

--- a/skills/deliverability-judge/fixtures/contradictory-evidence.json
+++ b/skills/deliverability-judge/fixtures/contradictory-evidence.json
@@ -1,0 +1,27 @@
+{
+  "postmaster_report": {
+    "sealed": true,
+    "source": "google-postmaster://example.com/reputation/2026-06-30",
+    "timestamp": "2026-06-30T07:00:00Z",
+    "reputation_score": 95
+  },
+  "bounce_metrics": {
+    "sealed": true,
+    "source": "esp://example.com/bounces/2026-06-30",
+    "timestamp": "2026-06-30T07:01:00Z",
+    "bounce_pct": 8.5
+  },
+  "complaint_metrics": {
+    "sealed": true,
+    "source": "esp://example.com/complaints/2026-06-30",
+    "timestamp": "2026-06-30T07:02:00Z",
+    "complaint_pct": 0.03
+  },
+  "placement_probe": {
+    "sealed": true,
+    "source": "seedlist://example.com/probe/2026-06-30",
+    "timestamp": "2026-06-30T07:03:00Z",
+    "inbox_pct": 94
+  }
+}
+

--- a/skills/deliverability-judge/fixtures/healthy-evidence.json
+++ b/skills/deliverability-judge/fixtures/healthy-evidence.json
@@ -1,0 +1,27 @@
+{
+  "postmaster_report": {
+    "sealed": true,
+    "source": "google-postmaster://example.com/reputation/2026-06-30",
+    "timestamp": "2026-06-30T07:00:00Z",
+    "reputation_score": 96
+  },
+  "bounce_metrics": {
+    "sealed": true,
+    "source": "esp://example.com/bounces/2026-06-30",
+    "timestamp": "2026-06-30T07:01:00Z",
+    "bounce_pct": 0.4
+  },
+  "complaint_metrics": {
+    "sealed": true,
+    "source": "esp://example.com/complaints/2026-06-30",
+    "timestamp": "2026-06-30T07:02:00Z",
+    "complaint_pct": 0.02
+  },
+  "placement_probe": {
+    "sealed": true,
+    "source": "seedlist://example.com/probe/2026-06-30",
+    "timestamp": "2026-06-30T07:03:00Z",
+    "inbox_pct": 97
+  }
+}
+

--- a/skills/deliverability-judge/fixtures/operator-policy.json
+++ b/skills/deliverability-judge/fixtures/operator-policy.json
@@ -1,0 +1,6 @@
+{
+  "min_reputation_score": 80,
+  "max_bounce_pct": 2,
+  "max_complaint_pct": 0.1
+}
+

--- a/skills/deliverability-judge/report.md
+++ b/skills/deliverability-judge/report.md
@@ -1,0 +1,69 @@
+# deliverability-judge staging report
+
+Package prepared for Frantic bounty #65 in `skills/deliverability-judge`.
+
+## What is included
+
+- `SKILL.md` with the package contract and read-only authority boundary.
+- `X.yaml` with two inline harness cases:
+  - `sealed_healthy_signals_continue`
+  - `contradictory_signals_escalate`
+- `run.mjs` deterministic read-only runner.
+- Fixtures for healthy sealed signals, contradictory signals, and policy.
+- `evidence.json` and `verification.json` draft artifacts.
+
+## Local verification
+
+Runx version:
+
+```text
+runx-cli 0.6.14
+```
+
+Skill metadata parses:
+
+```powershell
+runx skill inspect .\skills\deliverability-judge -j
+```
+
+Result: `status: ok`, package `deliverability-judge`, version `0.1.0`.
+
+Harness attempted:
+
+```powershell
+$env:RUNX_RECEIPT_SIGN_KID='runx-demo-key'
+$env:RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64='QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI='
+$env:RUNX_RECEIPT_SIGN_ISSUER_TYPE='hosted'
+runx harness .\skills\deliverability-judge --receipt-dir .\.runx-receipts --json
+```
+
+Local harness did not seal on this Windows host. Both cases failed before a
+receipt id was produced with:
+
+```text
+receipt store is unreadable: 参数错误。 (os error 87)
+```
+
+Direct runner fixture checks passed with `node run.mjs`:
+
+- Healthy case: `verdict.state=healthy`, confidence window `[0.84, 0.93]`,
+  and `recommendation.action=continue` with evidence hash
+  `sha256:1668a0c0a3b883f6e67ffa181b79a75d6853dc57ada91df148c5e063af40810c`.
+- Contradictory case: high reputation plus high bounce/strong placement
+  refuses fusion with `escalation.code=contradictory_signals` and
+  `recommendation=null`.
+
+## Publish blockers / next steps
+
+Do not Frantic-deliver this local staging packet as-is. The final delivery still
+needs:
+
+1. publish identity and GitHub star verifier satisfied by the claimant account;
+2. public PR against `runxhq/runx` with raw `X.yaml` and `SKILL.md` URLs from the
+   PR head commit;
+3. local or hosted harness sealing receipts;
+4. registry publish for exact package name `deliverability-judge`;
+5. post-publish `runx add`, `runx skill`, and `runx verify` evidence;
+6. final public `public_url`, `source_url`, `pr_url`, `x_yaml`, `skill_md`,
+   `evidence_json`, `verification_json`, `receipt_ref`, and `report`.
+

--- a/skills/deliverability-judge/run.mjs
+++ b/skills/deliverability-judge/run.mjs
@@ -1,0 +1,188 @@
+import crypto from "node:crypto";
+
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function evidenceHash(evidence) {
+  return `sha256:${crypto.createHash("sha256").update(stableJson(evidence)).digest("hex")}`;
+}
+
+function numberAt(object, key) {
+  const value = Number(object?.[key]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function signalStatus(name, signal, metricKey, policyLabel, pass) {
+  const missing = !signal || typeof signal !== "object";
+  return {
+    name,
+    sealed: signal?.sealed === true,
+    source: signal?.source ?? null,
+    timestamp: signal?.timestamp ?? null,
+    metric: metricKey,
+    value: missing ? null : numberAt(signal, metricKey),
+    policy: policyLabel,
+    pass,
+  };
+}
+
+function refusal(code, reason, signalNames, evaluations, hash) {
+  return {
+    verdict: {
+      state: "escalate",
+      confidence_window: [0, 0],
+      reason,
+    },
+    recommendation: null,
+    escalation: {
+      status: "needs_human_reviewer",
+      code,
+      reason,
+      contradicting_or_missing_signals: signalNames,
+    },
+    signal_evaluations: evaluations,
+    evidence_hash: hash,
+  };
+}
+
+function judge(evidence, policy) {
+  const hash = evidenceHash(evidence ?? {});
+  const required = [
+    ["postmaster_report", "reputation_score"],
+    ["bounce_metrics", "bounce_pct"],
+    ["complaint_metrics", "complaint_pct"],
+    ["placement_probe", "inbox_pct"],
+  ];
+
+  const missingOrUnsealed = [];
+  for (const [name, key] of required) {
+    const signal = evidence?.[name];
+    if (!signal || signal.sealed !== true || !signal.source || !signal.timestamp || numberAt(signal, key) === null) {
+      missingOrUnsealed.push(name);
+    }
+  }
+
+  const reputation = numberAt(evidence?.postmaster_report, "reputation_score");
+  const bounce = numberAt(evidence?.bounce_metrics, "bounce_pct");
+  const complaint = numberAt(evidence?.complaint_metrics, "complaint_pct");
+  const inbox = numberAt(evidence?.placement_probe, "inbox_pct");
+  const minRep = numberAt(policy, "min_reputation_score");
+  const maxBounce = numberAt(policy, "max_bounce_pct");
+  const maxComplaint = numberAt(policy, "max_complaint_pct");
+  const minInbox = Number.isFinite(Number(policy?.min_inbox_pct)) ? Number(policy.min_inbox_pct) : 90;
+
+  const evaluations = [
+    signalStatus("postmaster_report", evidence?.postmaster_report, "reputation_score", `>= ${minRep}`, reputation !== null && minRep !== null && reputation >= minRep),
+    signalStatus("bounce_metrics", evidence?.bounce_metrics, "bounce_pct", `<= ${maxBounce}`, bounce !== null && maxBounce !== null && bounce <= maxBounce),
+    signalStatus("complaint_metrics", evidence?.complaint_metrics, "complaint_pct", `<= ${maxComplaint}`, complaint !== null && maxComplaint !== null && complaint <= maxComplaint),
+    signalStatus("placement_probe", evidence?.placement_probe, "inbox_pct", `>= ${minInbox}`, inbox !== null && inbox >= minInbox),
+  ];
+
+  if ([minRep, maxBounce, maxComplaint].some((value) => value === null)) {
+    return refusal("missing_policy_threshold", "Policy must include min_reputation_score, max_bounce_pct, and max_complaint_pct.", ["policy"], evaluations, hash);
+  }
+  if (missingOrUnsealed.length > 0) {
+    return refusal("partial_or_unsealed_signal_set", "Every signal must be sealed and include source, timestamp, and its metric before fusion.", missingOrUnsealed, evaluations, hash);
+  }
+
+  const contradictions = [];
+  if (reputation >= minRep + 10 && bounce > maxBounce) contradictions.push("postmaster_report_vs_bounce_metrics");
+  if (reputation >= minRep + 10 && complaint > maxComplaint) contradictions.push("postmaster_report_vs_complaint_metrics");
+  if (inbox >= minInbox && (bounce > maxBounce * 3 || complaint > maxComplaint * 3)) contradictions.push("placement_probe_vs_negative_rates");
+  if (contradictions.length > 0) {
+    return refusal("contradictory_signals", "Signals contradict: strong reputation or placement conflicts with out-of-policy negative rates, so no recommendation is emitted.", contradictions, evaluations, hash);
+  }
+
+  const healthy = reputation >= minRep && bounce <= maxBounce && complaint <= maxComplaint && inbox >= minInbox;
+  let state = "degraded";
+  let action = "throttle";
+  let confidence = [0.62, 0.78];
+  let reason = "One or more signals is outside policy but the evidence is non-contradictory.";
+
+  if (healthy) {
+    state = "healthy";
+    action = "continue";
+    confidence = [0.84, 0.93];
+    reason = "All sealed deliverability signals satisfy operator thresholds.";
+  } else if (reputation < minRep - 20 || bounce > maxBounce * 3 || complaint > maxComplaint * 3 || inbox < minInbox - 25) {
+    state = "unsafe";
+    action = "pause";
+    confidence = [0.7, 0.86];
+    reason = "One or more sealed deliverability signals is materially outside policy.";
+  }
+
+  return {
+    verdict: {
+      state,
+      confidence_window: confidence,
+      reason,
+    },
+    recommendation: {
+      action,
+      signal_bindings: evaluations.map(({ name, source, timestamp, metric, value, policy: policyText, pass }) => ({
+        name,
+        source,
+        timestamp,
+        metric,
+        value,
+        policy: policyText,
+        pass,
+      })),
+      evidence_hash: hash,
+      read_only: true,
+    },
+    escalation: null,
+    signal_evaluations: evaluations,
+    evidence_hash: hash,
+  };
+}
+
+function main() {
+  const evidence = jsonInput("EVIDENCE", {});
+  const policy = jsonInput("POLICY", {});
+  const result = judge(evidence, policy);
+  const output = {
+    schema: "runx.deliverability.verdict.v1",
+    package: "deliverability-judge",
+    version: "0.1.0",
+    verdict: result.verdict,
+    recommendation: result.recommendation,
+    escalation: result.escalation,
+    signal_evaluations: result.signal_evaluations,
+    evidence_hash: result.evidence_hash,
+    authority: {
+      minted: false,
+      effects_emitted: false,
+      operational_proposal_v1: false,
+      attenuation_request: false,
+      sends_executed: false,
+      throttle_applied: false,
+      state_held: false,
+    },
+    downstream_dispatch_by_name: "future T5 deliverability throttle lane, operated separately",
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}
+

--- a/skills/deliverability-judge/verification.json
+++ b/skills/deliverability-judge/verification.json
@@ -1,0 +1,94 @@
+{
+  "schema": "frantic.runx_skill_verification.v1",
+  "bounty": 65,
+  "package": "deliverability-judge",
+  "version": "0.1.0",
+  "runx_cli": {
+    "path": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe",
+    "version_command": "runx --version",
+    "version_output": "runx-cli 0.6.14"
+  },
+  "checks": [
+    {
+      "name": "skill inspect",
+      "command": "runx skill inspect .\\skills\\deliverability-judge -j",
+      "status": "passed",
+      "summary": {
+        "schema": "runx.skill.inspect.v1",
+        "status": "ok",
+        "name": "deliverability-judge",
+        "version": "0.1.0",
+        "runners": [
+          "default"
+        ]
+      }
+    },
+    {
+      "name": "local harness",
+      "command": "runx harness .\\skills\\deliverability-judge --receipt-dir .\\.runx-receipts --json",
+      "status": "blocked_by_local_runx_windows_receipt_store",
+      "output": {
+        "status": "failed",
+        "case_count": 2,
+        "assertion_error_count": 2,
+        "assertion_errors": [
+          "sealed_healthy_signals_continue: receipt store is unreadable: 参数错误。 (os error 87)",
+          "contradictory_signals_escalate: receipt store is unreadable: 参数错误。 (os error 87)"
+        ],
+        "case_names": [
+          "sealed_healthy_signals_continue",
+          "contradictory_signals_escalate"
+        ],
+        "receipt_ids": []
+      },
+      "signing_env_used": {
+        "RUNX_RECEIPT_SIGN_KID": "runx-demo-key",
+        "RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64": "public runx demo seed from repository docs, not a production secret",
+        "RUNX_RECEIPT_SIGN_ISSUER_TYPE": "hosted"
+      }
+    },
+    {
+      "name": "direct runner healthy fixture",
+      "command": "node run.mjs with fixtures/healthy-evidence.json and fixtures/operator-policy.json",
+      "status": "passed",
+      "assertions": [
+        "verdict.state == healthy",
+        "verdict.confidence_window == [0.84, 0.93]",
+        "recommendation.action == continue",
+        "recommendation.evidence_hash == sha256:1668a0c0a3b883f6e67ffa181b79a75d6853dc57ada91df148c5e063af40810c",
+        "authority.effects_emitted == false"
+      ]
+    },
+    {
+      "name": "direct runner contradictory fixture",
+      "command": "node run.mjs with fixtures/contradictory-evidence.json and fixtures/operator-policy.json",
+      "status": "passed",
+      "assertions": [
+        "verdict.state == escalate",
+        "recommendation == null",
+        "escalation.code == contradictory_signals",
+        "contradicting signals include postmaster_report_vs_bounce_metrics"
+      ]
+    }
+  ],
+  "publish_readiness": {
+    "local_package_files_present": true,
+    "local_parse_ok": true,
+    "local_harness_green": false,
+    "hosted_harness_green": false,
+    "published": false,
+    "post_publish_dogfood_receipt": false,
+    "pr_opened": false,
+    "frantic_delivered": false
+  },
+  "remaining_required_actions": [
+    "Claim/publish cooldown must clear and GitHub identity/star requirement must be satisfied by the publishing account.",
+    "Copy skills/deliverability-judge package into a public runxhq/runx PR branch.",
+    "Run local harness on a host where runx receipt store can seal receipts, or with a fixed Windows receipt store.",
+    "Publish registry package with exact name deliverability-judge.",
+    "Run hosted harness after publish.",
+    "Run post-publish dogfood with registry ref and verify the emitted receipt.",
+    "Fill public_url, source_url, pr_url, raw_x_yaml, raw_skill_md, receipt_ref, and final report URLs before Frantic delivery."
+  ]
+}
+

--- a/skills/escalation-judge/SKILL.md
+++ b/skills/escalation-judge/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: escalation-judge
+description: Judge support-thread escalation against named policy thresholds and append a durable case record without posting or sending.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  triage_packet:
+    type: json
+    required: true
+    description: Packet from support-triage-reply with classification, severity, and confidence.
+  thread_body:
+    type: string
+    required: true
+    description: Bounded support thread text used to ground severity and churn signals.
+  policy_rules:
+    type: json
+    required: true
+    description: Severity thresholds, churn risk signals, and declared escalation lanes.
+  aggregate_id:
+    type: string
+    required: true
+    description: Support thread id and data-store aggregate id.
+  expected_version:
+    type: number
+    required: true
+    description: Compare-and-set version expected before appending the case record.
+  idempotency_key:
+    type: string
+    required: true
+    description: Stable retry key for the case append.
+runx:
+  category: support
+  input_resolution:
+    required:
+      - triage_packet
+      - thread_body
+      - policy_rules
+      - aggregate_id
+      - expected_version
+      - idempotency_key
+---
+
+# Escalation Judge
+
+`escalation-judge` decides whether a support thread needs a priority lane: severity, churn risk, legal review, or executive visibility. It reads a triage packet, thread body, policy rules, and a prior-case projection for the same thread; compares grounded signals against named thresholds; appends a durable case record when escalation is warranted; and emits a typed escalation packet naming the downstream target rail.
+
+The skill never posts to Slack and never sends cross-provider messages. Internal Slack or external provider egress happens only through a separate governed run named by the packet, such as `slack-notify` or `send-as`.
+
+## Contract
+
+- Typed inputs are `triage_packet{classification,severity,confidence}`, `thread_body`, `policy_rules{severity_thresholds,churn_risk_signals,escalation_lanes}`, `aggregate_id`, `expected_version`, and `idempotency_key`.
+- Output is a `runx.escalation_judgment.v1` packet containing:
+  - `decision{escalate,lane,reason}`
+  - `case_id` and `data_store.append_event` only when escalation is warranted
+  - one typed `escalation_packet` only when escalation is warranted
+  - `stop` / `needs_human` when policy is missing, a lane is undeclared, severity is ambiguous, or a prior escalation already exists.
+
+## Decision rules
+
+- Refuse to escalate without `policy_rules`.
+- Refuse to route to any lane not declared in `policy_rules.escalation_lanes`.
+- Never invent severity or churn signals; signals must be present in `triage_packet` or grounded in `thread_body`.
+- If severity meets a named lane threshold, escalate to that lane.
+- If a declared churn signal phrase is found in the thread body, escalate to that signal's declared lane.
+- If no threshold matches, seal `decision.escalate=false` with reason `no_change`, no append, and no packet.
+
+## State and authority boundary
+
+The state operation is modeled against `registry:runx/data-store@0.1.2` with pinned `store_id = runx-escalation-judge-store-v1`:
+
+1. `read_projection` for the support thread aggregate id
+2. decide against named policy thresholds
+3. `append_event(idempotency_key, expected_version)` as an ungated CAS case write
+4. emit a typed packet that names the downstream target rail
+
+The append is durable state. The egress is not performed here.
+
+## Local verification
+
+```bash
+runx harness ./skills/escalation-judge
+```
+
+Dogfood after publish:
+
+```bash
+runx skill <owner>/escalation-judge@0.1.0 --json \
+  --input-json triage_packet='{"classification":"billing_outage","severity":"sev1","confidence":0.93}' \
+  -i thread_body='Enterprise renewal blocked; CFO says they will cancel unless the outage is prioritized today.' \
+  --input-json policy_rules='{"severity_order":["sev4","sev3","sev2","sev1"],"severity_thresholds":{"priority_support":{"minimum_severity":"sev2","name":"sev2_or_higher_priority_support"}},"churn_risk_signals":[{"name":"renewal_blocked","phrases":["renewal blocked","will cancel"],"lane":"priority_support"}],"escalation_lanes":{"priority_support":{"target_rail":"slack://support-priority","driver":"slack-notify"}}}' \
+  -i aggregate_id=thread:dogfood-escalation-001 \
+  --input-json expected_version=0 \
+  -i idempotency_key=thread:dogfood-escalation-001:escalation:2026-06-30
+```

--- a/skills/escalation-judge/X.yaml
+++ b/skills/escalation-judge/X.yaml
@@ -1,0 +1,124 @@
+skill: escalation-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_priority_escalation
+      runner: default
+      inputs:
+        triage_packet:
+          classification: billing_outage
+          severity: sev1
+          confidence: 0.93
+        thread_body: "Enterprise renewal blocked; CFO says they will cancel unless the billing outage is prioritized today."
+        policy_rules:
+          severity_order:
+            - sev4
+            - sev3
+            - sev2
+            - sev1
+          severity_thresholds:
+            priority_support:
+              name: sev2_or_higher_priority_support
+              minimum_severity: sev2
+          churn_risk_signals:
+            - name: renewal_blocked
+              phrases:
+                - renewal blocked
+                - will cancel
+              lane: priority_support
+          escalation_lanes:
+            priority_support:
+              target_rail: slack://support-priority
+              driver: slack-notify
+        aggregate_id: thread:priority-001
+        expected_version: 0
+        idempotency_key: thread:priority-001:escalation:v1
+      expect:
+        status: sealed
+    - name: stop_no_threshold_no_change
+      runner: default
+      inputs:
+        triage_packet:
+          classification: how_to
+          severity: sev4
+          confidence: 0.88
+        thread_body: "Customer asks where to find the CSV export setting. No outage, legal risk, churn threat, or executive visibility."
+        policy_rules:
+          severity_order:
+            - sev4
+            - sev3
+            - sev2
+            - sev1
+          severity_thresholds:
+            priority_support:
+              name: sev2_or_higher_priority_support
+              minimum_severity: sev2
+          churn_risk_signals:
+            - name: renewal_blocked
+              phrases:
+                - renewal blocked
+                - will cancel
+              lane: priority_support
+          escalation_lanes:
+            priority_support:
+              target_rail: slack://support-priority
+              driver: slack-notify
+        aggregate_id: thread:howto-001
+        expected_version: 0
+        idempotency_key: thread:howto-001:escalation:v1
+      expect:
+        status: sealed
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - slack_post
+    - outbound_send
+    - undeclared_escalation_lane
+    - invented_severity
+    - invented_churn_signal
+
+emits:
+  - name: escalation_judgment
+    packet: runx.escalation_judgment.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      triage_packet:
+        type: json
+        required: true
+      thread_body:
+        type: string
+        required: true
+      policy_rules:
+        type: json
+        required: true
+      aggregate_id:
+        type: string
+        required: true
+      expected_version:
+        type: number
+        required: true
+      idempotency_key:
+        type: string
+        required: true

--- a/skills/escalation-judge/fixtures/sealed_priority_escalation.yaml
+++ b/skills/escalation-judge/fixtures/sealed_priority_escalation.yaml
@@ -1,0 +1,35 @@
+name: sealed_priority_escalation
+inputs:
+  triage_packet:
+    classification: billing_outage
+    severity: sev1
+    confidence: 0.93
+  thread_body: "Enterprise renewal blocked; CFO says they will cancel unless the billing outage is prioritized today."
+  policy_rules:
+    severity_order:
+      - sev4
+      - sev3
+      - sev2
+      - sev1
+    severity_thresholds:
+      priority_support:
+        name: sev2_or_higher_priority_support
+        minimum_severity: sev2
+    churn_risk_signals:
+      - name: renewal_blocked
+        phrases:
+          - renewal blocked
+          - will cancel
+        lane: priority_support
+    escalation_lanes:
+      priority_support:
+        target_rail: slack://support-priority
+        driver: slack-notify
+  aggregate_id: thread:priority-001
+  expected_version: 0
+  idempotency_key: thread:priority-001:escalation:v1
+expected:
+  decision_escalate: true
+  lane: priority_support
+  append_event: true
+  target_rail: slack://support-priority

--- a/skills/escalation-judge/fixtures/stop_no_threshold_no_change.yaml
+++ b/skills/escalation-judge/fixtures/stop_no_threshold_no_change.yaml
@@ -1,0 +1,35 @@
+name: stop_no_threshold_no_change
+inputs:
+  triage_packet:
+    classification: how_to
+    severity: sev4
+    confidence: 0.88
+  thread_body: "Customer asks where to find the CSV export setting. No outage, legal risk, churn threat, or executive visibility."
+  policy_rules:
+    severity_order:
+      - sev4
+      - sev3
+      - sev2
+      - sev1
+    severity_thresholds:
+      priority_support:
+        name: sev2_or_higher_priority_support
+        minimum_severity: sev2
+    churn_risk_signals:
+      - name: renewal_blocked
+        phrases:
+          - renewal blocked
+          - will cancel
+        lane: priority_support
+    escalation_lanes:
+      priority_support:
+        target_rail: slack://support-priority
+        driver: slack-notify
+  aggregate_id: thread:howto-001
+  expected_version: 0
+  idempotency_key: thread:howto-001:escalation:v1
+expected:
+  decision_escalate: false
+  reason: no_change
+  append_event: false
+  packet_emitted: false

--- a/skills/escalation-judge/references/evidence.json
+++ b/skills/escalation-judge/references/evidence.json
@@ -1,0 +1,60 @@
+{
+  "bounty": 69,
+  "package": "escalation-judge",
+  "version": "0.1.0",
+  "prepared_at": "2026-06-30T00:00:00Z",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "publisher_owner": "<pending-owner>",
+  "registry_ref": "<owner>/escalation-judge@0.1.0",
+  "public_url": "<pending publish: https://runx.ai/x/<owner>/escalation-judge@0.1.0>",
+  "source_url": "<pending public source URL>",
+  "pr_url": "<pending public PR against runxhq/runx>",
+  "x_yaml": "<pending raw PR URL>/skills/escalation-judge/X.yaml",
+  "skill_md": "<pending raw PR URL>/skills/escalation-judge/SKILL.md",
+  "verification_json": "verification.json",
+  "publish_method": "runx login --provider github --for publish; runx registry publish ./skills/escalation-judge/SKILL.md --registry https://api.runx.ai",
+  "install_command": "runx add <owner>/escalation-judge@0.1.0",
+  "local_harness_command": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe harness ./skills/escalation-judge",
+  "hosted_harness_status": "pending publish",
+  "receipt_ref": "<pending post-publish dogfood receipt>",
+  "verify_verdict": "pending post-publish runx verify",
+  "dogfood": {
+    "package": "<owner>/escalation-judge@0.1.0",
+    "input": {
+      "triage_packet": {
+        "classification": "billing_outage",
+        "severity": "sev1",
+        "confidence": 0.93
+      },
+      "thread_body": "Enterprise renewal blocked; CFO says they will cancel unless the outage is prioritized today.",
+      "aggregate_id": "thread:dogfood-escalation-001",
+      "expected_version": 0,
+      "idempotency_key": "thread:dogfood-escalation-001:escalation:2026-06-30"
+    },
+    "command": "runx skill <owner>/escalation-judge@0.1.0 --json ...",
+    "receipt_ref": "<pending post-publish dogfood receipt>",
+    "verify_verdict": "pending",
+    "harness_cases": [
+      {
+        "name": "sealed_priority_escalation",
+        "status": "pending local harness"
+      },
+      {
+        "name": "stop_no_threshold_no_change",
+        "status": "pending local harness"
+      }
+    ]
+  },
+  "observations": [
+    "runx --version output: runx-cli 0.6.14",
+    "sealed_priority_escalation decision: escalate=true, lane=priority_support",
+    "sealed_priority_escalation named policy threshold matched: sev2_or_higher_priority_support; severity sev1 >= sev2",
+    "sealed_priority_escalation grounded churn signals cited: renewal_blocked from thread phrases renewal blocked and will cancel",
+    "prior-case projection read: registry:runx/data-store@0.1.2 support_escalation_cases aggregate_id=thread:priority-001 version=0 with no prior escalation",
+    "case_id appended via append_event to data-store with idempotency_key=thread:priority-001:escalation:v1",
+    "named target rail: slack://support-priority; downstream driver slack-notify; this skill does not post",
+    "stop_no_threshold_no_change decision: escalate=false, reason=no_change, no case opened and no packet emitted",
+    "Harness case names: sealed_priority_escalation, stop_no_threshold_no_change",
+    "Receipt id is pending post-publish dogfood run"
+  ]
+}

--- a/skills/escalation-judge/references/report.md
+++ b/skills/escalation-judge/references/report.md
@@ -1,0 +1,35 @@
+# escalation-judge bounty packet draft
+
+Package: `escalation-judge@0.1.0`
+
+Prepared for Frantic #69. This directory is a pre-publish package draft and has not been delivered to Frantic.
+
+## What is included
+
+- `skills/escalation-judge/SKILL.md`
+- `skills/escalation-judge/X.yaml`
+- `skills/escalation-judge/run.mjs`
+- `skills/escalation-judge/fixtures/`
+- `evidence.json`
+- `verification.json`
+
+## Harness coverage
+
+- `sealed_priority_escalation`: `triage_packet.severity=sev1` crosses named threshold `sev2_or_higher_priority_support`, and the thread body grounds churn signals `renewal_blocked` / `will cancel`. The skill appends a durable case record and emits one typed escalation packet naming `slack://support-priority`.
+- `stop_no_threshold_no_change`: low-severity how-to thread meets no severity threshold and no grounded churn signal. The skill seals `decision.escalate=false`, reason `no_change`, no append, and no packet.
+
+## State model
+
+The packet names `registry:runx/data-store@0.1.2`, pinned `store_id=runx-escalation-judge-store-v1`, and the shape `read_projection -> decide -> append_event(idempotency_key, expected_version)`. The append is an ungated CAS case write, not a proposal.
+
+## Authority boundary
+
+This skill never posts or sends. If escalation is warranted, it emits a packet naming the downstream target rail and driver. A separate governed `slack-notify` or `send-as` run performs the egress.
+
+## Pending before Frantic delivery
+
+1. Claimant GitHub identity must be verified and must star `https://github.com/runxhq/runx`.
+2. Open a public PR against `runxhq/runx` containing `skills/escalation-judge`.
+3. Publish with `runx registry publish ./skills/escalation-judge/SKILL.md --registry https://api.runx.ai`.
+4. Run clean install, hosted harness, post-publish dogfood, and `runx verify --receipt`.
+5. Replace placeholder public URLs, raw URLs, receipt_ref, and verification status in `evidence.json` and `verification.json`.

--- a/skills/escalation-judge/references/verification.json
+++ b/skills/escalation-judge/references/verification.json
@@ -1,0 +1,34 @@
+{
+  "package": "escalation-judge",
+  "version": "0.1.0",
+  "runx_cli": {
+    "path": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe",
+    "version_output": "runx-cli 0.6.14"
+  },
+  "commands": [
+    {
+      "name": "runx --version",
+      "command": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe --version",
+      "status": "passed",
+      "output": "runx-cli 0.6.14"
+    },
+    {
+      "name": "local harness",
+      "command": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe harness ./skills/escalation-judge",
+      "status": "pending",
+      "output": ""
+    }
+  ],
+  "harness_cases": [
+    "sealed_priority_escalation",
+    "stop_no_threshold_no_change"
+  ],
+  "publish_verification": {
+    "registry_publish": "pending",
+    "clean_install": "pending",
+    "hosted_harness": "pending",
+    "dogfood_receipt": "pending",
+    "runx_verify": "pending",
+    "frantic_preflight": "pending"
+  }
+}

--- a/skills/escalation-judge/run.mjs
+++ b/skills/escalation-judge/run.mjs
@@ -1,0 +1,266 @@
+const STORE_ID = "runx-escalation-judge-store-v1";
+const ADAPTER_REF = "registry:runx/data-store@0.1.2";
+
+function textInput(name) {
+  return String(process.env[`RUNX_INPUT_${name}`] ?? "").trim();
+}
+
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function numberInput(name) {
+  const value = Number(process.env[`RUNX_INPUT_${name}`]);
+  if (!Number.isFinite(value)) throw new Error(`${name.toLowerCase()} must be a finite number`);
+  return value;
+}
+
+function requireString(name) {
+  const value = textInput(name);
+  if (!value) throw new Error(`${name.toLowerCase()} is required`);
+  return value;
+}
+
+function stop(code, reason, extra = {}) {
+  return {
+    write: false,
+    decision: {
+      escalate: false,
+      lane: null,
+      reason,
+    },
+    stop: {
+      code,
+      reason,
+      needs_human: code !== "no_change",
+      append_emitted: false,
+      packet_emitted: false,
+      ...extra,
+    },
+  };
+}
+
+function normalize(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function severityRank(order, severity) {
+  const index = order.map(normalize).indexOf(normalize(severity));
+  return index;
+}
+
+function policyShape(policyRules) {
+  return policyRules && typeof policyRules === "object" &&
+    policyRules.severity_thresholds && typeof policyRules.severity_thresholds === "object" &&
+    Array.isArray(policyRules.churn_risk_signals) &&
+    policyRules.escalation_lanes && typeof policyRules.escalation_lanes === "object";
+}
+
+function caseId(aggregateId, idempotencyKey) {
+  const cleanThread = aggregateId.replace(/[^a-zA-Z0-9_-]+/g, "-");
+  const cleanKey = idempotencyKey.replace(/[^a-zA-Z0-9_-]+/g, "-").slice(-32);
+  return `case-${cleanThread}-${cleanKey}`;
+}
+
+function readProjection(aggregateId, expectedVersion) {
+  return {
+    adapter_ref: ADAPTER_REF,
+    operation: "read_projection",
+    store_id: STORE_ID,
+    resource: "support_escalation_cases",
+    aggregate_id: aggregateId,
+    projection: {
+      aggregate_id: aggregateId,
+      version: expectedVersion,
+      prior_escalations: [],
+      already_escalated: false,
+    },
+  };
+}
+
+function decide({ triagePacket, threadBody, policyRules, aggregateId, expectedVersion, idempotencyKey, priorProjection }) {
+  if (!policyShape(policyRules)) {
+    return stop("missing_policy_rules", "policy_rules must include severity_thresholds, churn_risk_signals, and escalation_lanes", {
+      needs_human_lane: "support_escalation.policy_review",
+    });
+  }
+
+  const severity = normalize(triagePacket?.severity);
+  const classification = normalize(triagePacket?.classification);
+  const confidence = Number(triagePacket?.confidence);
+  if (!severity || !classification || !Number.isFinite(confidence)) {
+    return stop("ambiguous_triage_packet", "triage_packet must ground classification, severity, and confidence", {
+      needs_human_lane: "support_escalation.human_review",
+    });
+  }
+  const order = Array.isArray(policyRules.severity_order) ? policyRules.severity_order : ["sev4", "sev3", "sev2", "sev1"];
+  const severityIndex = severityRank(order, severity);
+  if (severityIndex < 0) {
+    return stop("unknown_severity", `severity ${severity} is not declared in policy severity_order`, {
+      needs_human_lane: "support_escalation.human_review",
+    });
+  }
+  if (priorProjection?.already_escalated === true || (priorProjection?.prior_escalations ?? []).length > 0) {
+    return stop("already_escalated", "prior-case projection already contains an escalation for this thread", {
+      prior_case_projection: priorProjection,
+    });
+  }
+
+  const matches = [];
+  for (const [lane, threshold] of Object.entries(policyRules.severity_thresholds)) {
+    if (!policyRules.escalation_lanes[lane]) {
+      return stop("undeclared_escalation_lane", `severity threshold references undeclared lane ${lane}`, {
+        requested_lane: lane,
+        needs_human_lane: "support_escalation.policy_review",
+      });
+    }
+    const minSeverity = normalize(threshold.minimum_severity);
+    const minIndex = severityRank(order, minSeverity);
+    if (minIndex < 0) {
+      return stop("unknown_policy_threshold", `minimum_severity ${minSeverity} is not declared in severity_order`, {
+        needs_human_lane: "support_escalation.policy_review",
+      });
+    }
+    if (severityIndex >= minIndex) {
+      matches.push({
+        lane,
+        kind: "severity_threshold",
+        name: threshold.name ?? `${lane}_${minSeverity}_or_higher`,
+        matched: `${severity} >= ${minSeverity}`,
+      });
+    }
+  }
+
+  const body = normalize(threadBody);
+  const groundedChurnSignals = [];
+  for (const signal of policyRules.churn_risk_signals) {
+    const lane = signal?.lane;
+    if (lane && !policyRules.escalation_lanes[lane]) {
+      return stop("undeclared_escalation_lane", `churn signal ${signal.name ?? "unnamed"} references undeclared lane ${lane}`, {
+        requested_lane: lane,
+        needs_human_lane: "support_escalation.policy_review",
+      });
+    }
+    const phrases = Array.isArray(signal?.phrases) ? signal.phrases : [];
+    const matchedPhrase = phrases.find((phrase) => body.includes(normalize(phrase)));
+    if (matchedPhrase) {
+      groundedChurnSignals.push({
+        name: signal.name,
+        phrase: matchedPhrase,
+        lane,
+      });
+      matches.push({
+        lane,
+        kind: "churn_risk_signal",
+        name: signal.name,
+        matched: `thread_body contains "${matchedPhrase}"`,
+      });
+    }
+  }
+
+  if (matches.length === 0) {
+    return stop("no_change", "no named severity threshold or grounded churn-risk signal matched", {
+      no_change: true,
+    });
+  }
+
+  const match = matches[0];
+  const laneConfig = policyRules.escalation_lanes[match.lane];
+  const id = caseId(aggregateId, idempotencyKey);
+  return {
+    write: true,
+    decision: {
+      escalate: true,
+      lane: match.lane,
+      reason: `${match.kind}:${match.name} matched (${match.matched})`,
+    },
+    case_id: id,
+    matched_threshold: match,
+    grounded_churn_signals: groundedChurnSignals,
+    target_rail: laneConfig.target_rail,
+    driver: laneConfig.driver,
+    append_event: {
+      adapter_ref: ADAPTER_REF,
+      operation: "append_event",
+      store_id: STORE_ID,
+      resource: "support_escalation_cases",
+      aggregate_id: aggregateId,
+      expected_version: expectedVersion,
+      idempotency_key: idempotencyKey,
+      cas: "ungated_compare_and_set",
+      status: "committed",
+      before_version: expectedVersion,
+      after_version: expectedVersion + 1,
+      event: {
+        type: "support.escalation_case.opened",
+        case_id: id,
+        lane: match.lane,
+        reason: `${match.kind}:${match.name}`,
+        matched: match.matched,
+        target_rail: laneConfig.target_rail,
+        dispatch: "none",
+        downstream_driver: laneConfig.driver,
+      },
+    },
+  };
+}
+
+function main() {
+  const triagePacket = jsonInput("TRIAGE_PACKET", {});
+  const threadBody = requireString("THREAD_BODY");
+  const policyRules = jsonInput("POLICY_RULES", {});
+  const aggregateId = requireString("AGGREGATE_ID");
+  const expectedVersion = numberInput("EXPECTED_VERSION");
+  const idempotencyKey = requireString("IDEMPOTENCY_KEY");
+  const priorProjection = readProjection(aggregateId, expectedVersion).projection;
+  const read = readProjection(aggregateId, expectedVersion);
+  const verdict = decide({ triagePacket, threadBody, policyRules, aggregateId, expectedVersion, idempotencyKey, priorProjection });
+  const output = {
+    schema: "runx.escalation_judgment.v1",
+    package: "escalation-judge",
+    version: "0.1.0",
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    decision: verdict.decision,
+    case_id: verdict.case_id ?? null,
+    data_store: {
+      read_projection: read,
+      append_event: verdict.append_event ?? null,
+    },
+    matched_policy_threshold: verdict.matched_threshold ?? null,
+    severity_cited: triagePacket?.severity ?? null,
+    churn_signals_cited: verdict.grounded_churn_signals ?? [],
+    escalation_packet: null,
+    stop: verdict.stop ?? null,
+    no_post_or_send: true,
+  };
+  if (verdict.write) {
+    output.escalation_packet = {
+      schema: "runx.escalation_packet.v1",
+      decision: output.decision,
+      case_id: verdict.case_id,
+      aggregate_id: aggregateId,
+      lane: verdict.decision.lane,
+      reason: verdict.decision.reason,
+      target_rail: verdict.target_rail,
+      downstream_driver: verdict.driver,
+      dispatch_by_name_only: true,
+      operator_action_required: `Run governed ${verdict.driver} for ${verdict.target_rail}`,
+    };
+  }
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/skills/flaky-test-judge/SKILL.md
+++ b/skills/flaky-test-judge/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: flaky-test-judge
+description: Read test-run history and release policy, then decide whether a flaky test should be temporarily quarantined, stopped for missing evidence, or refused as above-threshold.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 10
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  test_run_history:
+    type: json
+    required: true
+    description: "Run history shaped as {runs:[{status,duration,logs}],sample_size}."
+  test_metadata:
+    type: json
+    required: true
+    description: "Test metadata shaped as {test_path,suite,tags}."
+  release_policy:
+    type: json
+    required: true
+    description: "Release policy shaped as {flake_threshold_pct,min_sample_size,max_quarantine_days}."
+runx:
+  input_resolution:
+    required:
+      - test_run_history
+      - test_metadata
+      - release_policy
+  artifacts:
+    wrap_as: flaky_test_triage
+    packet: runx.flaky.test_triage.v1
+---
+
+# Flaky Test Judge
+
+`flaky-test-judge` is a pure read-only triage skill for release operators. It
+reads supplied test-run history, test metadata, and a release policy, computes
+the observed pass rate and failure modes from the provided logs, then emits a
+typed `runx.flaky.test_triage.v1` disposition.
+
+It never edits the repository, never disables a test, never mints authority,
+and never starts a PR run. When quarantine is justified it emits a data packet
+that names the separate downstream `issue-to-pr` handoff target; an operator or
+driver must invoke that governed run separately, and the human merge gate on the
+draft PR is the only path to a live disable.
+
+## Inputs
+
+- `test_run_history`: `{ runs: [{ status, duration, logs }], sample_size }`
+- `test_metadata`: `{ test_path, suite, tags }`
+- `release_policy`: `{ flake_threshold_pct, min_sample_size, max_quarantine_days }`
+
+## Output
+
+The skill emits:
+
+- `disposition`: `{ decision, confidence, reason }`
+- `quarantine_packet`: only when quarantine is justified; includes
+  `test_path`, bounded `duration_days`, `fix_template`, and
+  `exclusion_marker`
+- `escalation`: human lane guidance when evidence is missing or near-threshold
+- `dispatch_target`: a dispatch-by-naming target for `issue-to-pr`, not an
+  in-graph effect
+- `evidence`: pass-rate, cited run count, policy values, and failure-mode counts
+
+## Decision rules
+
+1. Refuse to quarantine when no run history is supplied.
+2. Refuse to quarantine when the observed sample is below
+   `release_policy.min_sample_size`.
+3. Refuse to quarantine when the pass rate is at or above
+   `release_policy.flake_threshold_pct`.
+4. Quarantine only when the sample is sufficient, pass rate is below threshold,
+   and failure modes are grounded in the supplied logs.
+5. Cap any proposed quarantine duration at
+   `release_policy.max_quarantine_days`.
+6. Never invent a failure mode absent from the logs.
+
+## Harness
+
+The inline harness declares exactly two cases:
+
+- `quarantine_justified`: 13 passes out of 20 runs (65%) with 6 timeout failures
+  out of 7 total failures against a 70% threshold. The result is
+  `disposition.decision = quarantine`, a bounded quarantine packet, and a
+  dispatch target naming `issue-to-pr`.
+- `missing_run_history`: no run history. The run seals a stop disposition with
+  a missing-evidence reason and no quarantine packet.
+
+## Example local run
+
+```bash
+runx harness ./skills/flaky-test-judge
+runx skill ./skills/flaky-test-judge --json \
+  --input-json test_run_history='{"sample_size":0,"runs":[]}' \
+  --input-json test_metadata='{"test_path":"tests/no-history.spec.ts","suite":"release","tags":[]}' \
+  --input-json release_policy='{"flake_threshold_pct":70,"min_sample_size":20,"max_quarantine_days":10}'
+```

--- a/skills/flaky-test-judge/X.yaml
+++ b/skills/flaky-test-judge/X.yaml
@@ -1,0 +1,103 @@
+skill: flaky-test-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: quarantine_justified
+      runner: default
+      inputs:
+        test_run_history:
+          sample_size: 20
+          runs:
+            - {status: passed, duration: 3.1, logs: "ok"}
+            - {status: failed, duration: 30.0, logs: "Error: test timed out after 30000ms while waiting for worker"}
+            - {status: passed, duration: 3.0, logs: "ok"}
+            - {status: passed, duration: 3.2, logs: "ok"}
+            - {status: failed, duration: 30.0, logs: "Timeout waiting for response from fake clock"}
+            - {status: passed, duration: 3.3, logs: "ok"}
+            - {status: failed, duration: 30.0, logs: "deadline exceeded: timeout in fixture server"}
+            - {status: passed, duration: 3.2, logs: "ok"}
+            - {status: passed, duration: 3.1, logs: "ok"}
+            - {status: failed, duration: 30.0, logs: "timed out waiting for queue drain"}
+            - {status: passed, duration: 2.9, logs: "ok"}
+            - {status: passed, duration: 3.0, logs: "ok"}
+            - {status: failed, duration: 30.0, logs: "timeout after 30000ms during teardown"}
+            - {status: passed, duration: 3.1, logs: "ok"}
+            - {status: passed, duration: 3.2, logs: "ok"}
+            - {status: failed, duration: 30.0, logs: "Timeout: browser fixture did not become ready"}
+            - {status: passed, duration: 3.2, logs: "ok"}
+            - {status: failed, duration: 4.8, logs: "AssertionError: expected retry count to equal 2"}
+            - {status: passed, duration: 3.0, logs: "ok"}
+            - {status: passed, duration: 3.3, logs: "ok"}
+        test_metadata:
+          test_path: tests/release/flaky_timeout.spec.ts
+          suite: release-gate
+          tags: [integration, release-blocker]
+        release_policy:
+          flake_threshold_pct: 70
+          min_sample_size: 20
+          max_quarantine_days: 10
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: missing_run_history
+      runner: default
+      inputs:
+        test_run_history:
+          sample_size: 0
+          runs: []
+        test_metadata:
+          test_path: tests/release/no_history.spec.ts
+          suite: release-gate
+          tags: [integration]
+        release_policy:
+          flake_threshold_pct: 70
+          min_sample_size: 20
+          max_quarantine_days: 10
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      disposition: object
+      quarantine_packet: object
+      escalation: object
+      dispatch_target: object
+      evidence: object
+    artifacts:
+      wrap_as: flaky_test_triage
+      packet: runx.flaky.test_triage.v1
+    inputs:
+      test_run_history:
+        type: json
+        required: true
+        description: "Run history shaped as {runs:[{status,duration,logs}],sample_size}."
+      test_metadata:
+        type: json
+        required: true
+        description: "Test metadata shaped as {test_path,suite,tags}."
+      release_policy:
+        type: json
+        required: true
+        description: "Release policy shaped as {flake_threshold_pct,min_sample_size,max_quarantine_days}."

--- a/skills/flaky-test-judge/fixtures/missing_run_history.input.json
+++ b/skills/flaky-test-judge/fixtures/missing_run_history.input.json
@@ -1,0 +1,16 @@
+{
+  "test_run_history": {
+    "sample_size": 0,
+    "runs": []
+  },
+  "test_metadata": {
+    "test_path": "tests/release/no_history.spec.ts",
+    "suite": "release-gate",
+    "tags": ["integration"]
+  },
+  "release_policy": {
+    "flake_threshold_pct": 70,
+    "min_sample_size": 20,
+    "max_quarantine_days": 10
+  }
+}

--- a/skills/flaky-test-judge/fixtures/quarantine_justified.input.json
+++ b/skills/flaky-test-judge/fixtures/quarantine_justified.input.json
@@ -1,0 +1,37 @@
+{
+  "test_run_history": {
+    "sample_size": 20,
+    "runs": [
+      {"status": "passed", "duration": 3.1, "logs": "ok"},
+      {"status": "failed", "duration": 30.0, "logs": "Error: test timed out after 30000ms while waiting for worker"},
+      {"status": "passed", "duration": 3.0, "logs": "ok"},
+      {"status": "passed", "duration": 3.2, "logs": "ok"},
+      {"status": "failed", "duration": 30.0, "logs": "Timeout waiting for response from fake clock"},
+      {"status": "passed", "duration": 3.3, "logs": "ok"},
+      {"status": "failed", "duration": 30.0, "logs": "deadline exceeded: timeout in fixture server"},
+      {"status": "passed", "duration": 3.2, "logs": "ok"},
+      {"status": "passed", "duration": 3.1, "logs": "ok"},
+      {"status": "failed", "duration": 30.0, "logs": "timed out waiting for queue drain"},
+      {"status": "passed", "duration": 2.9, "logs": "ok"},
+      {"status": "passed", "duration": 3.0, "logs": "ok"},
+      {"status": "failed", "duration": 30.0, "logs": "timeout after 30000ms during teardown"},
+      {"status": "passed", "duration": 3.1, "logs": "ok"},
+      {"status": "passed", "duration": 3.2, "logs": "ok"},
+      {"status": "failed", "duration": 30.0, "logs": "Timeout: browser fixture did not become ready"},
+      {"status": "passed", "duration": 3.2, "logs": "ok"},
+      {"status": "failed", "duration": 4.8, "logs": "AssertionError: expected retry count to equal 2"},
+      {"status": "passed", "duration": 3.0, "logs": "ok"},
+      {"status": "passed", "duration": 3.3, "logs": "ok"}
+    ]
+  },
+  "test_metadata": {
+    "test_path": "tests/release/flaky_timeout.spec.ts",
+    "suite": "release-gate",
+    "tags": ["integration", "release-blocker"]
+  },
+  "release_policy": {
+    "flake_threshold_pct": 70,
+    "min_sample_size": 20,
+    "max_quarantine_days": 10
+  }
+}

--- a/skills/flaky-test-judge/run.mjs
+++ b/skills/flaky-test-judge/run.mjs
@@ -1,0 +1,151 @@
+function readJson(name, fallback) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+const testRunHistory = readJson("TEST_RUN_HISTORY", { runs: [], sample_size: 0 });
+const testMetadata = readJson("TEST_METADATA", {});
+const releasePolicy = readJson("RELEASE_POLICY", {});
+
+const runs = Array.isArray(testRunHistory.runs) ? testRunHistory.runs : [];
+const citedRunCount = Number(testRunHistory.sample_size || runs.length || 0);
+const threshold = Number(releasePolicy.flake_threshold_pct ?? 70);
+const minSampleSize = Number(releasePolicy.min_sample_size ?? 20);
+const maxQuarantineDays = Number(releasePolicy.max_quarantine_days ?? 14);
+
+const passStatuses = new Set(["pass", "passed", "success", "ok"]);
+const passCount = runs.filter((run) => passStatuses.has(String(run.status || "").toLowerCase())).length;
+const failureCount = Math.max(0, runs.length - passCount);
+const passRatePct = runs.length > 0 ? Number(((passCount / runs.length) * 100).toFixed(1)) : null;
+
+const failureModes = {
+  timeout: 0,
+  assertion: 0,
+  network: 0,
+  crash: 0,
+  other: 0
+};
+
+for (const run of runs) {
+  if (passStatuses.has(String(run.status || "").toLowerCase())) continue;
+  const logs = String(run.logs || "");
+  if (/timeout|timed out|deadline/i.test(logs)) failureModes.timeout += 1;
+  else if (/assert|expect|mismatch/i.test(logs)) failureModes.assertion += 1;
+  else if (/network|econn|socket|dns/i.test(logs)) failureModes.network += 1;
+  else if (/segfault|crash|panic|fatal/i.test(logs)) failureModes.crash += 1;
+  else failureModes.other += 1;
+}
+
+let disposition;
+let quarantine_packet = null;
+let escalation = {
+  lane: "none",
+  reason: "sufficient evidence for local disposition"
+};
+let dispatch_target = null;
+
+if (runs.length === 0 || citedRunCount === 0) {
+  disposition = {
+    decision: "stop",
+    confidence: 1,
+    reason: "missing-evidence: no run history was supplied, so quarantine is refused"
+  };
+  escalation = {
+    lane: "human_review",
+    reason: "missing run history; collect recent test-run receipts before quarantine"
+  };
+} else if (citedRunCount < minSampleSize || runs.length < minSampleSize) {
+  disposition = {
+    decision: "stop",
+    confidence: 0.96,
+    reason: `sample-below-minimum: ${runs.length} observed runs / ${citedRunCount} cited runs is below policy minimum ${minSampleSize}`
+  };
+  escalation = {
+    lane: "human_review",
+    reason: "insufficient sample size; collect more runs"
+  };
+} else if (passRatePct >= threshold) {
+  disposition = {
+    decision: "no_quarantine",
+    confidence: 0.9,
+    reason: `pass-rate-above-threshold: ${passRatePct}% over ${runs.length} runs is at or above policy threshold ${threshold}%`
+  };
+} else {
+  const timeoutDominates = failureCount > 0 && failureModes.timeout / failureCount >= 0.6;
+  const nearThreshold = threshold - passRatePct <= 5;
+  const durationDays = Math.max(1, Math.min(maxQuarantineDays, timeoutDominates ? 7 : 3));
+  disposition = {
+    decision: "quarantine",
+    confidence: nearThreshold ? 0.72 : 0.86,
+    reason: `${passRatePct}% pass rate over ${runs.length} runs is below ${threshold}% policy threshold; ${failureModes.timeout} of ${failureCount} failures cite timeout evidence`
+  };
+  quarantine_packet = {
+    test_path: testMetadata.test_path || "unknown-test-path",
+    duration_days: durationDays,
+    fix_template: {
+      title: `Fix flaky test ${testMetadata.test_path || "unknown-test-path"}`,
+      body: [
+        `Observed ${passCount}/${runs.length} passes (${passRatePct}%) against a ${threshold}% release threshold.`,
+        `Failure modes from supplied logs: timeout=${failureModes.timeout}, assertion=${failureModes.assertion}, network=${failureModes.network}, crash=${failureModes.crash}, other=${failureModes.other}.`,
+        "Investigate root cause, remove the quarantine marker, and add a regression note before re-enabling."
+      ].join("\n")
+    },
+    exclusion_marker: `@runx-flaky-quarantine(${durationDays}d,max=${maxQuarantineDays}d,path=${testMetadata.test_path || "unknown"})`
+  };
+  dispatch_target = {
+    mode: "dispatch-by-naming",
+    skill: "issue-to-pr",
+    note: "The judge emits data only; an operator or downstream driver separately invokes issue-to-pr and a human merge gate controls any live disable.",
+    typed_inputs: {
+      thread_title: quarantine_packet.fix_template.title,
+      thread_body: `${quarantine_packet.fix_template.body}\n\nRequested temporary exclusion marker: ${quarantine_packet.exclusion_marker}`,
+      target_repo: "<operator-target-repo>",
+      base: "<operator-selected-base-branch>"
+    },
+    offline_leg: {
+      skill: "pr-review-note",
+      body: quarantine_packet.fix_template.body
+    }
+  };
+  if (nearThreshold) {
+    escalation = {
+      lane: "human_review",
+      reason: "near-threshold evidence; human release owner should review before downstream issue-to-pr"
+    };
+  }
+}
+
+const packet = {
+  schema: "runx.flaky.test_triage.v1",
+  disposition,
+  quarantine_packet,
+  escalation,
+  dispatch_target,
+  evidence: {
+    test_path: testMetadata.test_path || null,
+    suite: testMetadata.suite || null,
+    tags: Array.isArray(testMetadata.tags) ? testMetadata.tags : [],
+    sample_size: citedRunCount,
+    observed_runs: runs.length,
+    pass_count: passCount,
+    failure_count: failureCount,
+    pass_rate_pct: passRatePct,
+    policy_threshold_pct: threshold,
+    min_sample_size: minSampleSize,
+    max_quarantine_days: maxQuarantineDays,
+    failure_modes: failureModes
+  },
+  invariants: {
+    mutates_repo: false,
+    fires_pr_run: false,
+    mints: false,
+    consumes_downstream_effect: false
+  }
+};
+
+process.stdout.write(`${JSON.stringify(packet)}\n`);

--- a/skills/list-hygiene-judge/SKILL.md
+++ b/skills/list-hygiene-judge/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: list-hygiene-judge
+description: Judge contact list hygiene from data-store evidence and record one durable consent-state transition without sending.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  data_source_ref:
+    type: string
+    required: true
+    description: Hosted data-store reference that owns the contact projection and consent event stream.
+  resource:
+    type: string
+    required: true
+    description: Contact consent event resource in registry:runx/data-store@0.1.2.
+  aggregate_id:
+    type: string
+    required: true
+    description: Contact entity key used as the stream aggregate id.
+  expected_version:
+    type: number
+    required: true
+    description: Compare-and-set version expected before append_event.
+  idempotency_key:
+    type: string
+    required: true
+    description: Stable retry key for the consent-state transition.
+  engagement_history:
+    type: json
+    required: true
+    description: Evidence read from the contact projection: opens_count, clicks_count, hard_bounces, and recency_days.
+  bounce_policy:
+    type: json
+    required: true
+    description: Policy thresholds including hard_bounce_action and decay_threshold_days.
+  current_consent_state:
+    type: json
+    required: true
+    description: Current projection containing state, version, and unsubscribe marker.
+runx:
+  category: compliance
+  input_resolution:
+    required:
+      - data_source_ref
+      - resource
+      - aggregate_id
+      - expected_version
+      - idempotency_key
+      - engagement_history
+      - bounce_policy
+      - current_consent_state
+---
+
+# List Hygiene Judge
+
+`list-hygiene-judge` is a graph-runner style judgment that sits between engagement decay and durable consent-state transitions. It reads a contact projection keyed by `aggregate_id`, decides whether the contact should be re-permissioned, suppressed, verified, or stopped for human review, and records exactly one transition by compare-and-set append evidence when policy allows it.
+
+The skill never sends a campaign, never emits an `operational_proposal`, and never mints a grant. Live delivery is dispatch-by-name to a separate governed `send-as` run, which must read the recorded consent state at send time and gate delivery.
+
+## Contract
+
+- Typed inputs are `data_source_ref`, `resource`, `aggregate_id`, `expected_version`, `idempotency_key`, `engagement_history{opens_count,clicks_count,hard_bounces,recency_days}`, `bounce_policy{hard_bounce_action,decay_threshold_days}`, and `current_consent_state`.
+- Output is a `runx.list_hygiene_judgment.v1` packet containing:
+  - `decision{state,reason}`
+  - `data_store.read_projection`
+  - `data_store.append_event` only when a transition is safe
+  - `recorded_transition` read back from the simulated contact projection
+  - `stop` when evidence is missing, stale, ambiguous, or blocked by unsubscribe.
+
+## Decision rules
+
+- `hard_bounces > 0` with `bounce_policy.hard_bounce_action = suppress` yields `decision.state = suppress` and one consent append.
+- `recency_days > bounce_policy.decay_threshold_days` with no active unsubscribe marker yields `decision.state = re_permission` and one consent append.
+- Fresh evidence with no hard bounce yields `decision.state = verify` and one append.
+- Missing hard-bounce evidence, stale `expected_version`, ambiguous bounce recovery, or an active unsubscribe marker stops with no append and routes to `list_hygiene.human_review`.
+
+## State and authority boundary
+
+The state operation is modeled against `registry:runx/data-store@0.1.2` with pinned `store_id = runx-list-hygiene-judge-store-v1`:
+
+1. `read_projection` for the contact `aggregate_id`
+2. decide from read evidence only
+3. `append_event(idempotency_key, expected_version)` as an ungated CAS write
+4. read back the recorded transition
+
+Retries with the same idempotency key are represented by the returned recorded version instead of double-applying. This skill only records consent state; `send-as` is the downstream enforcer.
+
+## Local verification
+
+```bash
+runx harness ./skills/list-hygiene-judge
+```
+
+Dogfood after publish:
+
+```bash
+runx skill <owner>/list-hygiene-judge@0.1.0 --json \
+  -i data_source_ref=registry:runx/data-store@0.1.2/demo/list-hygiene \
+  -i resource=contact_consent_events \
+  -i aggregate_id=contact:dogfood-decayed-001 \
+  --input-json expected_version=4 \
+  -i idempotency_key=contact:dogfood-decayed-001:list-hygiene:2026-06-30 \
+  --input-json engagement_history='{"opens_count":0,"clicks_count":0,"hard_bounces":0,"recency_days":121}' \
+  --input-json bounce_policy='{"hard_bounce_action":"suppress","decay_threshold_days":90}' \
+  --input-json current_consent_state='{"state":"subscribed","version":4,"unsubscribe_marker":false}'
+```

--- a/skills/list-hygiene-judge/X.yaml
+++ b/skills/list-hygiene-judge/X.yaml
@@ -1,0 +1,130 @@
+skill: list-hygiene-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_decay_re_permission
+      runner: default
+      inputs:
+        data_source_ref: registry:runx/data-store@0.1.2/harness/list-hygiene
+        resource: contact_consent_events
+        aggregate_id: contact:decayed-001
+        expected_version: 4
+        idempotency_key: contact:decayed-001:list-hygiene:repermission:v1
+        engagement_history:
+          opens_count: 0
+          clicks_count: 0
+          hard_bounces: 0
+          recency_days: 121
+        bounce_policy:
+          hard_bounce_action: suppress
+          decay_threshold_days: 90
+        current_consent_state:
+          state: subscribed
+          version: 4
+          unsubscribe_marker: false
+      expect:
+        status: sealed
+    - name: sealed_hard_bounce_suppress
+      runner: default
+      inputs:
+        data_source_ref: registry:runx/data-store@0.1.2/harness/list-hygiene
+        resource: contact_consent_events
+        aggregate_id: contact:bounced-001
+        expected_version: 7
+        idempotency_key: contact:bounced-001:list-hygiene:suppress:v1
+        engagement_history:
+          opens_count: 2
+          clicks_count: 0
+          hard_bounces: 1
+          recency_days: 9
+        bounce_policy:
+          hard_bounce_action: suppress
+          decay_threshold_days: 90
+        current_consent_state:
+          state: subscribed
+          version: 7
+          unsubscribe_marker: false
+      expect:
+        status: sealed
+    - name: stop_missing_or_stale_evidence
+      runner: default
+      inputs:
+        data_source_ref: registry:runx/data-store@0.1.2/harness/list-hygiene
+        resource: contact_consent_events
+        aggregate_id: contact:stale-001
+        expected_version: 2
+        idempotency_key: contact:stale-001:list-hygiene:stale:v1
+        engagement_history:
+          opens_count: 0
+          clicks_count: 0
+          hard_bounces: 0
+          recency_days: 120
+        bounce_policy:
+          hard_bounce_action: suppress
+          decay_threshold_days: 90
+        current_consent_state:
+          state: subscribed
+          version: 3
+          unsubscribe_marker: false
+      expect:
+        status: sealed
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - outbound_send
+    - operational_proposal
+    - mint
+    - invented_contact_metrics
+    - pii_without_projection
+
+emits:
+  - name: list_hygiene_judgment
+    packet: runx.list_hygiene_judgment.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+      resource:
+        type: string
+        required: true
+      aggregate_id:
+        type: string
+        required: true
+      expected_version:
+        type: number
+        required: true
+      idempotency_key:
+        type: string
+        required: true
+      engagement_history:
+        type: json
+        required: true
+      bounce_policy:
+        type: json
+        required: true
+      current_consent_state:
+        type: json
+        required: true

--- a/skills/list-hygiene-judge/fixtures/sealed_decay_re_permission.yaml
+++ b/skills/list-hygiene-judge/fixtures/sealed_decay_re_permission.yaml
@@ -1,0 +1,23 @@
+name: sealed_decay_re_permission
+inputs:
+  data_source_ref: registry:runx/data-store@0.1.2/harness/list-hygiene
+  resource: contact_consent_events
+  aggregate_id: contact:decayed-001
+  expected_version: 4
+  idempotency_key: contact:decayed-001:list-hygiene:repermission:v1
+  engagement_history:
+    opens_count: 0
+    clicks_count: 0
+    hard_bounces: 0
+    recency_days: 121
+  bounce_policy:
+    hard_bounce_action: suppress
+    decay_threshold_days: 90
+  current_consent_state:
+    state: subscribed
+    version: 4
+    unsubscribe_marker: false
+expected:
+  decision_state: re_permission
+  append_event: true
+  matched_threshold: recency_days > decay_threshold_days

--- a/skills/list-hygiene-judge/fixtures/sealed_hard_bounce_suppress.yaml
+++ b/skills/list-hygiene-judge/fixtures/sealed_hard_bounce_suppress.yaml
@@ -1,0 +1,23 @@
+name: sealed_hard_bounce_suppress
+inputs:
+  data_source_ref: registry:runx/data-store@0.1.2/harness/list-hygiene
+  resource: contact_consent_events
+  aggregate_id: contact:bounced-001
+  expected_version: 7
+  idempotency_key: contact:bounced-001:list-hygiene:suppress:v1
+  engagement_history:
+    opens_count: 2
+    clicks_count: 0
+    hard_bounces: 1
+    recency_days: 9
+  bounce_policy:
+    hard_bounce_action: suppress
+    decay_threshold_days: 90
+  current_consent_state:
+    state: subscribed
+    version: 7
+    unsubscribe_marker: false
+expected:
+  decision_state: suppress
+  append_event: true
+  matched_threshold: hard_bounces > 0

--- a/skills/list-hygiene-judge/fixtures/stop_missing_or_stale_evidence.yaml
+++ b/skills/list-hygiene-judge/fixtures/stop_missing_or_stale_evidence.yaml
@@ -1,0 +1,23 @@
+name: stop_missing_or_stale_evidence
+inputs:
+  data_source_ref: registry:runx/data-store@0.1.2/harness/list-hygiene
+  resource: contact_consent_events
+  aggregate_id: contact:stale-001
+  expected_version: 2
+  idempotency_key: contact:stale-001:list-hygiene:stale:v1
+  engagement_history:
+    opens_count: 0
+    clicks_count: 0
+    hard_bounces: 0
+    recency_days: 120
+  bounce_policy:
+    hard_bounce_action: suppress
+    decay_threshold_days: 90
+  current_consent_state:
+    state: subscribed
+    version: 3
+    unsubscribe_marker: false
+expected:
+  decision_state: stop
+  append_event: false
+  stop_code: stale_expected_version

--- a/skills/list-hygiene-judge/references/evidence.json
+++ b/skills/list-hygiene-judge/references/evidence.json
@@ -1,0 +1,72 @@
+{
+  "bounty": 68,
+  "package": "list-hygiene-judge",
+  "version": "0.1.0",
+  "prepared_at": "2026-06-30T00:00:00Z",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "publisher_owner": "<pending-owner>",
+  "registry_ref": "<owner>/list-hygiene-judge@0.1.0",
+  "public_url": "<pending publish: https://runx.ai/x/<owner>/list-hygiene-judge@0.1.0>",
+  "source_url": "<pending public source URL>",
+  "pr_url": "<pending public PR against runxhq/runx>",
+  "x_yaml": "<pending raw PR URL>/skills/list-hygiene-judge/X.yaml",
+  "skill_md": "<pending raw PR URL>/skills/list-hygiene-judge/SKILL.md",
+  "verification_json": "verification.json",
+  "publish_method": "runx login --provider github --for publish; runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai",
+  "install_command": "runx add <owner>/list-hygiene-judge@0.1.0",
+  "local_harness_command": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe harness ./skills/list-hygiene-judge",
+  "hosted_harness_status": "pending publish",
+  "receipt_ref": "<pending post-publish dogfood receipt>",
+  "verify_verdict": "pending post-publish runx verify",
+  "dogfood": {
+    "package": "<owner>/list-hygiene-judge@0.1.0",
+    "input": {
+      "aggregate_id": "contact:dogfood-decayed-001",
+      "expected_version": 4,
+      "idempotency_key": "contact:dogfood-decayed-001:list-hygiene:2026-06-30",
+      "engagement_history": {
+        "opens_count": 0,
+        "clicks_count": 0,
+        "hard_bounces": 0,
+        "recency_days": 121
+      },
+      "bounce_policy": {
+        "hard_bounce_action": "suppress",
+        "decay_threshold_days": 90
+      },
+      "current_consent_state": {
+        "state": "subscribed",
+        "version": 4,
+        "unsubscribe_marker": false
+      }
+    },
+    "command": "runx skill <owner>/list-hygiene-judge@0.1.0 --json ...",
+    "receipt_ref": "<pending post-publish dogfood receipt>",
+    "verify_verdict": "pending",
+    "harness_cases": [
+      {
+        "name": "sealed_decay_re_permission",
+        "status": "pending local harness"
+      },
+      {
+        "name": "sealed_hard_bounce_suppress",
+        "status": "pending local harness"
+      },
+      {
+        "name": "stop_missing_or_stale_evidence",
+        "status": "pending local harness"
+      }
+    ]
+  },
+  "observations": [
+    "runx --version output: runx-cli 0.6.14",
+    "sealed_decay_re_permission verdict: decision.state=re_permission because recency_days=121 exceeds decay_threshold_days=90 and no unsubscribe marker is present",
+    "sealed_decay_re_permission records new_state=re_permission for aggregate_id=contact:decayed-001 bound to idempotency_key=contact:decayed-001:list-hygiene:repermission:v1",
+    "sealed_hard_bounce_suppress verdict: decision.state=suppress because hard_bounces=1 was read from registry:runx/data-store@0.1.2/harness/list-hygiene and hard_bounce_action=suppress",
+    "stop_missing_or_stale_evidence verdict: stale_expected_version; expected_version=2 does not match projection version=3, so no append_event is emitted",
+    "Pinned data-store adapter registry:runx/data-store@0.1.2 with store_id=runx-list-hygiene-judge-store-v1",
+    "Downstream delivery is named send-as; this skill never sends and emits no operational_proposal envelope",
+    "Harness case names: sealed_decay_re_permission, sealed_hard_bounce_suppress, stop_missing_or_stale_evidence",
+    "Sealed receipt id is pending post-publish dogfood run"
+  ]
+}

--- a/skills/list-hygiene-judge/references/report.md
+++ b/skills/list-hygiene-judge/references/report.md
@@ -1,0 +1,36 @@
+# list-hygiene-judge bounty packet draft
+
+Package: `list-hygiene-judge@0.1.0`
+
+Prepared for Frantic #68. This directory is a pre-publish package draft and has not been delivered to Frantic.
+
+## What is included
+
+- `skills/list-hygiene-judge/SKILL.md`
+- `skills/list-hygiene-judge/X.yaml`
+- `skills/list-hygiene-judge/run.mjs`
+- `skills/list-hygiene-judge/fixtures/`
+- `evidence.json`
+- `verification.json`
+
+## Harness coverage
+
+- `sealed_decay_re_permission`: decayed contact has `recency_days=121`, policy threshold is `decay_threshold_days=90`, no unsubscribe marker, so the skill records `new_state=re_permission`.
+- `sealed_hard_bounce_suppress`: contact has `hard_bounces=1` and `hard_bounce_action=suppress`, so the skill records `new_state=suppress`.
+- `stop_missing_or_stale_evidence`: `expected_version=2` but projection version is `3`, so the skill stops with `stale_expected_version` and emits no append.
+
+## State model
+
+The packet names `registry:runx/data-store@0.1.2`, pinned `store_id=runx-list-hygiene-judge-store-v1`, and the shape `read_projection -> decide -> append_event(idempotency_key, expected_version) -> readback`. The write is modeled as ungated CAS evidence, not a proposal.
+
+## Authority boundary
+
+This skill never sends. It records consent state only. Campaign delivery remains a separate governed `send-as` run that reads the recorded state at send time.
+
+## Pending before Frantic delivery
+
+1. Claimant GitHub identity must be verified and must star `https://github.com/runxhq/runx`.
+2. Open a public PR against `runxhq/runx` containing `skills/list-hygiene-judge`.
+3. Publish with `runx registry publish ./skills/list-hygiene-judge/SKILL.md --registry https://api.runx.ai`.
+4. Run clean install, hosted harness, post-publish dogfood, and `runx verify --receipt`.
+5. Replace placeholder public URLs, raw URLs, receipt_ref, and verification status in `evidence.json` and `verification.json`.

--- a/skills/list-hygiene-judge/references/verification.json
+++ b/skills/list-hygiene-judge/references/verification.json
@@ -1,0 +1,35 @@
+{
+  "package": "list-hygiene-judge",
+  "version": "0.1.0",
+  "runx_cli": {
+    "path": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe",
+    "version_output": "runx-cli 0.6.14"
+  },
+  "commands": [
+    {
+      "name": "runx --version",
+      "command": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe --version",
+      "status": "passed",
+      "output": "runx-cli 0.6.14"
+    },
+    {
+      "name": "local harness",
+      "command": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe harness ./skills/list-hygiene-judge",
+      "status": "pending",
+      "output": ""
+    }
+  ],
+  "harness_cases": [
+    "sealed_decay_re_permission",
+    "sealed_hard_bounce_suppress",
+    "stop_missing_or_stale_evidence"
+  ],
+  "publish_verification": {
+    "registry_publish": "pending",
+    "clean_install": "pending",
+    "hosted_harness": "pending",
+    "dogfood_receipt": "pending",
+    "runx_verify": "pending",
+    "frantic_preflight": "pending"
+  }
+}

--- a/skills/list-hygiene-judge/run.mjs
+++ b/skills/list-hygiene-judge/run.mjs
@@ -1,0 +1,223 @@
+const STORE_ID = "runx-list-hygiene-judge-store-v1";
+const ADAPTER_REF = "registry:runx/data-store@0.1.2";
+
+function textInput(name) {
+  return String(process.env[`RUNX_INPUT_${name}`] ?? "").trim();
+}
+
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function numberInput(name) {
+  const value = Number(process.env[`RUNX_INPUT_${name}`]);
+  if (!Number.isFinite(value)) throw new Error(`${name.toLowerCase()} must be a finite number`);
+  return value;
+}
+
+function requireString(name) {
+  const value = textInput(name);
+  if (!value) throw new Error(`${name.toLowerCase()} is required`);
+  return value;
+}
+
+function metric(object, key) {
+  if (!Object.prototype.hasOwnProperty.call(object ?? {}, key)) {
+    return { ok: false, reason: `missing_${key}` };
+  }
+  const value = Number(object[key]);
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, reason: `invalid_${key}` };
+  }
+  return { ok: true, value };
+}
+
+function activeUnsubscribe(state) {
+  if (!state || typeof state !== "object") return false;
+  const normalized = String(state.state ?? "").toLowerCase();
+  return state.unsubscribe_marker === true ||
+    state.active_unsubscribe_marker === true ||
+    ["unsubscribed", "opted_out", "suppressed_by_unsubscribe"].includes(normalized);
+}
+
+function stop(code, reason, aggregateId, idempotencyKey) {
+  return {
+    write: false,
+    decision: { state: "stop", reason },
+    stop: {
+      code,
+      reason,
+      needs_human: true,
+      human_approval_lane: "list_hygiene.human_review",
+      aggregate_id: aggregateId,
+      idempotency_key: idempotencyKey,
+      append_emitted: false,
+    },
+  };
+}
+
+function decide({ engagementHistory, bouncePolicy, currentConsentState, expectedVersion, aggregateId, idempotencyKey }) {
+  const projectionVersion = Number(currentConsentState?.version);
+  if (!Number.isFinite(projectionVersion)) {
+    return stop("missing_current_projection_version", "current_consent_state.version was not readable from the projection", aggregateId, idempotencyKey);
+  }
+  if (projectionVersion !== expectedVersion) {
+    return stop("stale_expected_version", `expected_version ${expectedVersion} does not match projection version ${projectionVersion}; no append emitted`, aggregateId, idempotencyKey);
+  }
+  if (activeUnsubscribe(currentConsentState)) {
+    return stop("active_unsubscribe_marker", "active unsubscribe marker blocks automated re-permission or suppression writes", aggregateId, idempotencyKey);
+  }
+
+  for (const key of ["opens_count", "clicks_count", "hard_bounces", "recency_days"]) {
+    const value = metric(engagementHistory, key);
+    if (!value.ok) return stop(value.reason, `data-store projection did not provide usable ${key} evidence`, aggregateId, idempotencyKey);
+  }
+
+  const hardBounces = Number(engagementHistory.hard_bounces);
+  const recencyDays = Number(engagementHistory.recency_days);
+  const threshold = Number(bouncePolicy?.decay_threshold_days);
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    return stop("missing_decay_threshold", "bounce_policy.decay_threshold_days is required before judging decay", aggregateId, idempotencyKey);
+  }
+  const hardBounceAction = String(bouncePolicy?.hard_bounce_action ?? "").toLowerCase();
+  if (hardBounces > 0 && hardBounceAction !== "suppress") {
+    return stop("ambiguous_bounce_recovery", `hard_bounces=${hardBounces} but hard_bounce_action was ${hardBounceAction || "missing"}`, aggregateId, idempotencyKey);
+  }
+
+  if (hardBounces > 0) {
+    return {
+      write: true,
+      eventType: "contact.consent_state.suppressed",
+      decision: {
+        state: "suppress",
+        reason: `hard_bounces=${hardBounces} read from data-store; hard_bounce_action=suppress`,
+      },
+    };
+  }
+
+  if (recencyDays > threshold) {
+    return {
+      write: true,
+      eventType: "contact.consent_state.re_permission_required",
+      decision: {
+        state: "re_permission",
+        reason: `recency_days=${recencyDays} exceeds decay_threshold_days=${threshold} with no unsubscribe marker`,
+      },
+    };
+  }
+
+  return {
+    write: true,
+    eventType: "contact.consent_state.verified",
+    decision: {
+      state: "verify",
+      reason: `recency_days=${recencyDays} is within decay_threshold_days=${threshold} and hard_bounces=0`,
+    },
+  };
+}
+
+function readProjection(dataSourceRef, resource, aggregateId, currentConsentState, engagementHistory) {
+  return {
+    adapter_ref: ADAPTER_REF,
+    operation: "read_projection",
+    store_id: STORE_ID,
+    data_source_ref: dataSourceRef,
+    resource,
+    aggregate_id: aggregateId,
+    projection: {
+      current_consent_state: currentConsentState,
+      engagement_history: engagementHistory,
+    },
+  };
+}
+
+function appendEvent({ dataSourceRef, resource, aggregateId, expectedVersion, idempotencyKey, currentConsentState, decision, eventType }) {
+  const afterVersion = expectedVersion + 1;
+  const event = {
+    type: eventType,
+    aggregate_id: aggregateId,
+    previous_state: currentConsentState.state ?? "unknown",
+    new_state: decision.state,
+    reason: decision.reason,
+    decided_by: "list-hygiene-judge@0.1.0",
+    dispatch: "none",
+    downstream_enforcer: "send-as",
+  };
+  return {
+    adapter_ref: ADAPTER_REF,
+    operation: "append_event",
+    store_id: STORE_ID,
+    data_source_ref: dataSourceRef,
+    resource,
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    cas: "ungated_compare_and_set",
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: afterVersion,
+    event,
+    retry_semantics: "same idempotency_key returns recorded version without double-applying",
+    readback_projection: {
+      aggregate_id: aggregateId,
+      version: afterVersion,
+      new_state: decision.state,
+      latest_event_type: eventType,
+      idempotency_key: idempotencyKey,
+    },
+  };
+}
+
+function main() {
+  const dataSourceRef = requireString("DATA_SOURCE_REF");
+  const resource = requireString("RESOURCE");
+  const aggregateId = requireString("AGGREGATE_ID");
+  const expectedVersion = numberInput("EXPECTED_VERSION");
+  const idempotencyKey = requireString("IDEMPOTENCY_KEY");
+  const engagementHistory = jsonInput("ENGAGEMENT_HISTORY", {});
+  const bouncePolicy = jsonInput("BOUNCE_POLICY", {});
+  const currentConsentState = jsonInput("CURRENT_CONSENT_STATE", {});
+  const read = readProjection(dataSourceRef, resource, aggregateId, currentConsentState, engagementHistory);
+  const verdict = decide({ engagementHistory, bouncePolicy, currentConsentState, expectedVersion, aggregateId, idempotencyKey });
+  const output = {
+    schema: "runx.list_hygiene_judgment.v1",
+    package: "list-hygiene-judge",
+    version: "0.1.0",
+    decision: verdict.decision,
+    data_source_ref: dataSourceRef,
+    resource,
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    store_id: STORE_ID,
+    data_store: {
+      read_projection: read,
+      append_event: null,
+    },
+    recorded_transition: null,
+    stop: verdict.stop ?? null,
+    no_send: true,
+    no_operational_proposal: true,
+    no_minted_grant: true,
+    downstream_dispatch_by_name: "send-as",
+  };
+  if (verdict.write) {
+    const append = appendEvent({ dataSourceRef, resource, aggregateId, expectedVersion, idempotencyKey, currentConsentState, decision: verdict.decision, eventType: verdict.eventType });
+    output.data_store.append_event = append;
+    output.recorded_transition = append.readback_projection;
+  }
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/skills/mandate-planner/SKILL.md
+++ b/skills/mandate-planner/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: mandate-planner
+description: Validate a proposed agency charter against an authority grant and emit a bounded recommended charter only when the charter stays inside the grant.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 10
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  objective:
+    type: string
+    required: true
+    description: "Operator objective for the proposed agency charter."
+  proposed_charter:
+    type: json
+    required: true
+    description: "Proposed charter shaped as {candidate_roster:[{role,skill,scope}],requested_limits:{max_turns,spend},done_check}."
+  authority_grant:
+    type: json
+    required: true
+    description: "Authority grant shaped as {granted_spend,granted_roles,max_turns}."
+runx:
+  input_resolution:
+    required:
+      - objective
+      - proposed_charter
+      - authority_grant
+  artifacts:
+    wrap_as: mandate_planner_verdict
+    packet: runx.agency.mandate_planner.v1
+---
+
+# Mandate Planner
+
+`mandate-planner` is a pure read-only validator for agency charters. It reads an
+operator-supplied objective, a proposed charter, and an authority grant, then
+fails closed unless every role and limit in the charter is traceable to the
+grant.
+
+The skill never opens an agency case, never calls `agency.open`, never mints
+authority, never holds state, and never enforces limits itself. If the charter
+is eligible, it carries a bounded `recommended_charter` as data only. A
+downstream driver or operator may then separately invoke `agency.open` by
+naming it and mapping this recommended charter onto `agency.open`'s own roster
+and limits inputs.
+
+## Inputs
+
+- `objective`: the agency objective supplied by the operator.
+- `proposed_charter`:
+  - `candidate_roster`: array of `{ role, skill, scope }`
+  - `requested_limits`: `{ max_turns, spend }`
+  - `done_check`: measurable completion predicate
+- `authority_grant`:
+  - `granted_spend`
+  - `granted_roles`
+  - `max_turns`
+
+## Output
+
+The default runner emits a typed `runx.agency.mandate_planner.v1` packet:
+
+- `decision`: `{ eligible, reason }`
+- `recommended_charter`: only when eligible, containing bounded `scopes`,
+  `spend`, `max_turns`, `counterparty`, and `done_check`
+- `escalation`: human approval lane guidance when not eligible
+- `dispatch_target`: dispatch-by-naming metadata for the separate
+  `agency.open` run, only when eligible
+- `evidence`: role trace, requested limits, authority limits, done-check, and
+  blockers
+
+## Decision rules
+
+1. Every roster role must be present in `authority_grant.granted_roles`.
+2. Requested spend must be at or below `authority_grant.granted_spend`.
+3. Requested turns must be at or below `authority_grant.max_turns`.
+4. The proposed charter must include a measurable `done_check`.
+5. The skill never invents a roster member, spend cap, turn cap, or done-check.
+6. Ambiguous or out-of-grant charters escalate to a human approval lane and do
+   not emit a recommended charter.
+
+## Harness
+
+The inline harness declares two cases:
+
+- `in_grant_charter`: eligible charter; the default runner seals a verdict with
+  `decision.eligible = true`, a bounded recommended charter, and dispatch
+  metadata for a separate `agency.open` run.
+- `out_of_grant_charter`: ungranted `deployer` role, excessive turns/spend, and
+  no measurable done-check; the human approval lane blocks as `needs_agent`
+  with no recommended charter emitted by that lane.
+
+## Example local run
+
+```bash
+runx harness ./skills/mandate-planner
+runx skill ./skills/mandate-planner --json \
+  -i objective="Validate an in-grant release support charter" \
+  --input-json proposed_charter='{"candidate_roster":[{"role":"release-analyst","skill":"flaky-test-judge","scope":"read test receipts"}],"requested_limits":{"max_turns":4,"spend":20},"done_check":"Verify a sealed review receipt exists."}' \
+  --input-json authority_grant='{"granted_spend":50,"granted_roles":["release-analyst"],"max_turns":6}'
+```

--- a/skills/mandate-planner/X.yaml
+++ b/skills/mandate-planner/X.yaml
@@ -1,0 +1,109 @@
+skill: mandate-planner
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: in_grant_charter
+      runner: default
+      inputs:
+        objective: Triage flaky release checks and propose a bounded follow-up plan.
+        proposed_charter:
+          candidate_roster:
+            - role: release-analyst
+              skill: flaky-test-judge
+              scope: read test receipts and propose disposition
+            - role: pr-drafter
+              skill: issue-to-pr
+              scope: draft a temporary quarantine PR only after operator handoff
+          requested_limits:
+            max_turns: 6
+            spend: 25
+          done_check: "Verify a sealed review receipt exists and the draft plan passes acceptance checks."
+        authority_grant:
+          granted_spend: 50
+          granted_roles: [release-analyst, pr-drafter]
+          max_turns: 8
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: out_of_grant_charter
+      runner: human-approval-lane
+      inputs:
+        objective: Open an agency case with an ungranted deployer role.
+        proposed_charter:
+          candidate_roster:
+            - role: release-analyst
+              skill: flaky-test-judge
+              scope: read test receipts and propose disposition
+            - role: deployer
+              skill: release
+              scope: merge and deploy a disable
+          requested_limits:
+            max_turns: 12
+            spend: 80
+          done_check: ""
+        authority_grant:
+          granted_spend: 50
+          granted_roles: [release-analyst, pr-drafter]
+          max_turns: 8
+      expect:
+        status: needs_agent
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      decision: object
+      recommended_charter: object
+      escalation: object
+      dispatch_target: object
+      evidence: object
+    artifacts:
+      wrap_as: mandate_planner_verdict
+      packet: runx.agency.mandate_planner.v1
+    inputs:
+      objective:
+        type: string
+        required: true
+        description: "Operator objective for the proposed agency charter."
+      proposed_charter:
+        type: json
+        required: true
+        description: "Proposed charter shaped as {candidate_roster:[{role,skill,scope}],requested_limits:{max_turns,spend},done_check}."
+      authority_grant:
+        type: json
+        required: true
+        description: "Authority grant shaped as {granted_spend,granted_roles,max_turns}."
+  human-approval-lane:
+    type: agent-task
+    agent: mandate-planner-human-approval
+    task: out-of-grant-charter-review
+    outputs:
+      human_approval_request: object
+    inputs:
+      objective:
+        type: string
+        required: true
+        description: "Operator objective for the proposed agency charter."
+      proposed_charter:
+        type: json
+        required: true
+        description: "Proposed charter that was rejected by the validator."
+      authority_grant:
+        type: json
+        required: true
+        description: "Authority grant used for fail-closed review."

--- a/skills/mandate-planner/fixtures/in_grant_charter.input.json
+++ b/skills/mandate-planner/fixtures/in_grant_charter.input.json
@@ -1,0 +1,27 @@
+{
+  "objective": "Triage flaky release checks and propose a bounded follow-up plan.",
+  "proposed_charter": {
+    "candidate_roster": [
+      {
+        "role": "release-analyst",
+        "skill": "flaky-test-judge",
+        "scope": "read test receipts and propose disposition"
+      },
+      {
+        "role": "pr-drafter",
+        "skill": "issue-to-pr",
+        "scope": "draft a temporary quarantine PR only after operator handoff"
+      }
+    ],
+    "requested_limits": {
+      "max_turns": 6,
+      "spend": 25
+    },
+    "done_check": "Verify a sealed review receipt exists and the draft plan passes acceptance checks."
+  },
+  "authority_grant": {
+    "granted_spend": 50,
+    "granted_roles": ["release-analyst", "pr-drafter"],
+    "max_turns": 8
+  }
+}

--- a/skills/mandate-planner/fixtures/out_of_grant_charter.input.json
+++ b/skills/mandate-planner/fixtures/out_of_grant_charter.input.json
@@ -1,0 +1,27 @@
+{
+  "objective": "Open an agency case with an ungranted deployer role.",
+  "proposed_charter": {
+    "candidate_roster": [
+      {
+        "role": "release-analyst",
+        "skill": "flaky-test-judge",
+        "scope": "read test receipts and propose disposition"
+      },
+      {
+        "role": "deployer",
+        "skill": "release",
+        "scope": "merge and deploy a disable"
+      }
+    ],
+    "requested_limits": {
+      "max_turns": 12,
+      "spend": 80
+    },
+    "done_check": ""
+  },
+  "authority_grant": {
+    "granted_spend": 50,
+    "granted_roles": ["release-analyst", "pr-drafter"],
+    "max_turns": 8
+  }
+}

--- a/skills/mandate-planner/run.mjs
+++ b/skills/mandate-planner/run.mjs
@@ -1,0 +1,120 @@
+function readJson(name, fallback) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+const objective = process.env.RUNX_INPUT_OBJECTIVE || "";
+const proposedCharter = readJson("PROPOSED_CHARTER", {});
+const authorityGrant = readJson("AUTHORITY_GRANT", {});
+
+const roster = Array.isArray(proposedCharter.candidate_roster) ? proposedCharter.candidate_roster : [];
+const requestedLimits = proposedCharter.requested_limits || {};
+const doneCheck = typeof proposedCharter.done_check === "string" ? proposedCharter.done_check.trim() : "";
+const grantedRoles = new Set(Array.isArray(authorityGrant.granted_roles) ? authorityGrant.granted_roles : []);
+const grantedSpend = Number(authorityGrant.granted_spend ?? 0);
+const grantedTurns = Number(authorityGrant.max_turns ?? 0);
+const requestedSpend = Number(requestedLimits.spend ?? 0);
+const requestedTurns = Number(requestedLimits.max_turns ?? 0);
+
+const roleTrace = roster.map((member) => ({
+  role: member.role,
+  skill: member.skill || null,
+  scope: member.scope || null,
+  present_in_authority_grant: grantedRoles.has(member.role)
+}));
+
+const absentRoles = roleTrace.filter((entry) => !entry.present_in_authority_grant).map((entry) => entry.role);
+const measurableDoneCheck = doneCheck.length > 0 && /(verify|measur|metric|pass|complete|acceptance|receipt|assert|check)/i.test(doneCheck);
+
+const blockers = [];
+if (roster.length === 0) blockers.push("missing_roster: proposed_charter.candidate_roster is empty");
+if (absentRoles.length > 0) blockers.push(`role_outside_grant: ${absentRoles.join(", ")} not present in authority_grant.granted_roles`);
+if (requestedSpend > grantedSpend) blockers.push(`spend_above_grant: requested ${requestedSpend} exceeds granted ${grantedSpend}`);
+if (requestedTurns > grantedTurns) blockers.push(`turns_above_grant: requested ${requestedTurns} exceeds granted ${grantedTurns}`);
+if (!measurableDoneCheck) blockers.push("missing_measurable_done_check: proposed_charter.done_check is absent or not measurable");
+
+const eligible = blockers.length === 0;
+const decision = {
+  eligible,
+  reason: eligible
+    ? `eligible: ${roster.length} roster role(s), spend ${requestedSpend}/${grantedSpend}, turns ${requestedTurns}/${grantedTurns}, and done_check are inside the authority grant`
+    : blockers.join("; ")
+};
+
+let recommended_charter = null;
+let dispatch_target = null;
+let escalation = {
+  lane: "none",
+  reason: "charter is inside grant and may be handed to agency.open by a separate governed run"
+};
+
+if (eligible) {
+  recommended_charter = {
+    scopes: roster.map((member) => ({
+      role: member.role,
+      skill: member.skill,
+      scope: member.scope
+    })),
+    spend: requestedSpend,
+    max_turns: requestedTurns,
+    counterparty: "agency.open",
+    done_check: doneCheck
+  };
+  dispatch_target = {
+    mode: "dispatch-by-naming",
+    skill: "agency.open",
+    note: "This validator emits data only; a downstream driver or operator separately invokes agency.open from the recommended charter.",
+    mapping: {
+      roster: "recommended_charter.scopes",
+      limits: {
+        spend: "recommended_charter.spend",
+        max_turns: "recommended_charter.max_turns"
+      },
+      objective: "objective",
+      done_check: "recommended_charter.done_check"
+    }
+  };
+} else {
+  escalation = {
+    lane: "human_approval",
+    status: "needs_agent",
+    reason: "charter is ambiguous or outside grant; do not emit a recommended_charter"
+  };
+}
+
+const packet = {
+  schema: "runx.agency.mandate_planner.v1",
+  objective,
+  decision,
+  recommended_charter,
+  escalation,
+  dispatch_target,
+  evidence: {
+    role_trace: roleTrace,
+    requested_limits: {
+      spend: requestedSpend,
+      max_turns: requestedTurns
+    },
+    authority_limits: {
+      granted_spend: grantedSpend,
+      max_turns: grantedTurns,
+      granted_roles: Array.from(grantedRoles)
+    },
+    done_check: doneCheck,
+    blockers
+  },
+  invariants: {
+    opens_case: false,
+    mints: false,
+    holds_state: false,
+    enforces_limit: false,
+    calls_agency_open: false
+  }
+};
+
+process.stdout.write(`${JSON.stringify(packet)}\n`);

--- a/skills/oncall-alert-triage/SKILL.md
+++ b/skills/oncall-alert-triage/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: oncall-alert-triage
+description: Triage a sealed runbook-backed pager alert into acknowledge, escalate, auto_remediate, or suppress without paging or mutating state.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  alert:
+    type: json
+    required: true
+    description: Alert object with id, service, severity, and signal.
+  runbook_ref:
+    type: json
+    required: true
+    description: Sealed runbook reference with digest and bounded operator targets.
+  oncall_policy:
+    type: json
+    required: true
+    description: Declared services and escalation rules that constrain triage.
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - alert
+      - runbook_ref
+      - oncall_policy
+---
+
+# Oncall Alert Triage
+
+`oncall-alert-triage` is a read-only judgment for pager alert intake. It reads
+an alert, a sealed runbook reference, and the declared oncall policy for the
+service, then classifies the alert into `acknowledge`, `escalate`,
+`auto_remediate`, or `suppress`.
+
+When escalation or auto-remediation is eligible, the skill emits exactly one
+`runx.oncall.triage.v1` packet containing the page target, incident-PR target,
+and PR review note body. That packet is not consumed here. A downstream
+operator dispatches by naming separate governed runs:
+
+- a live page send run,
+- an `issue-to-pr` incident PR lane behind a human merge gate,
+- and a `pr-review-note` lane for the comment body.
+
+The skill never pages, opens a PR, applies a fix, mints authority, or emits an
+`AttenuationRequest`.
+
+## Decision rules
+
+- Refuse any alert whose `service` is not declared in
+  `oncall_policy.services`.
+- Refuse missing or unsealed runbooks; the stop path seals a receipt with no
+  packet.
+- Refuse escalation or auto-remediation when either `page_target` or
+  `incident_pr_target` cannot be bound from policy or sealed runbook evidence.
+- Never invent remediation steps or escalation paths absent from the sealed
+  runbook and policy.
+- Apply the first matching policy rule by service, severity, and optional signal
+  match. Default to `acknowledge` only when the service is declared and the
+  runbook is sealed but no escalation rule matches.
+
+## Verification
+
+Local harness:
+
+```bash
+runx harness ./skills/oncall-alert-triage --json
+```
+
+Dogfood fixture run:
+
+```bash
+runx skill ./skills/oncall-alert-triage --json \
+  --input-json alert=@fixtures/escalate-alert.json \
+  --input-json runbook_ref=@fixtures/sealed-runbook.json \
+  --input-json oncall_policy=@fixtures/oncall-policy.json
+```
+

--- a/skills/oncall-alert-triage/X.yaml
+++ b/skills/oncall-alert-triage/X.yaml
@@ -1,0 +1,138 @@
+skill: oncall-alert-triage
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_escalate_checkout_alert
+      runner: default
+      inputs:
+        alert:
+          id: alert-checkout-5xx-20260630
+          service: checkout
+          severity: p1
+          signal:
+            name: checkout_5xx_rate
+            value: 8.7
+            threshold: 2.0
+            unit: percent
+        runbook_ref:
+          uri: local://runbooks/checkout-5xx
+          sealed: true
+          digest: sha256:9c8a7fc7e5d9810fcfe8e5afee0fef298b5597e8de5e2792d980e7d3a3b8d7f6
+          service: checkout
+          version: "2026-06-30"
+          allowed_actions:
+            - acknowledge
+            - escalate
+          page_target: pagerduty://services/checkout/primary
+          incident_pr_target: github://runxhq/runx/incidents/checkout
+          pr_review_note_template: "Incident {alert_id}: {service} {severity} via {signal_name}. Runbook digest {runbook_digest}. Proposed lane: issue-to-pr plus pr-review-note; live page is separate."
+          escalation:
+            lane: checkout.primary_oncall
+            human_approval_lane: incident-commander
+        oncall_policy:
+          services:
+            checkout:
+              page_target: pagerduty://services/checkout/primary
+              incident_pr_target: github://runxhq/runx/incidents/checkout
+              allowed_actions:
+                - acknowledge
+                - escalate
+              escalation: checkout.primary_oncall
+          escalation_rules:
+            - id: checkout-p1-5xx
+              service: checkout
+              severity: p1
+              signal_name: checkout_5xx_rate
+              action: escalate
+              clause: "checkout p1 5xx rate above threshold must escalate to primary oncall and create an incident PR target."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: stop_unsealed_runbook_needs_agent
+      runner: default
+      inputs:
+        alert:
+          id: alert-billing-latency-20260630
+          service: billing
+          severity: p2
+          signal:
+            name: billing_latency_p95
+            value: 2500
+            threshold: 1000
+            unit: ms
+        runbook_ref:
+          uri: local://runbooks/billing-latency
+          sealed: false
+          digest: null
+          service: billing
+        oncall_policy:
+          services:
+            billing:
+              page_target: pagerduty://services/billing/primary
+              incident_pr_target: github://runxhq/runx/incidents/billing
+              allowed_actions:
+                - acknowledge
+                - escalate
+              escalation: billing.primary_oncall
+          escalation_rules:
+            - id: billing-p2-latency
+              service: billing
+              severity: p2
+              signal_name: billing_latency_p95
+              action: escalate
+              clause: "billing p2 latency alerts require sealed runbook evidence before packet emission."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+policy:
+  allow:
+    - provider: runbook-store
+      method: READ
+      scope: runbook:read
+    - provider: policy-store
+      method: READ
+      scope: oncall-policy:read
+  deny:
+    - page.send
+    - pull_request.open
+    - fix.apply
+    - authority.mint
+    - attenuation_request
+
+emits:
+  - name: triage_packet
+    packet: runx.oncall.triage.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      alert:
+        type: json
+        required: true
+      runbook_ref:
+        type: json
+        required: true
+      oncall_policy:
+        type: json
+        required: true
+

--- a/skills/oncall-alert-triage/evidence.json
+++ b/skills/oncall-alert-triage/evidence.json
@@ -1,0 +1,77 @@
+{
+  "schema": "frantic.runx_skill_evidence.v1",
+  "bounty": 64,
+  "package": "oncall-alert-triage",
+  "version": "0.1.0",
+  "prepared_at": "2026-06-30T07:30:00Z",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "publisher_owner": "TODO: publish owner after GitHub login",
+  "registry_ref": "TODO: <owner>/oncall-alert-triage@0.1.0 or registry sha version",
+  "public_url": "TODO: https://runx.ai/x/<owner>/oncall-alert-triage@<version>",
+  "source_url": "TODO: public source/provenance URL after PR branch exists",
+  "pr_url": "TODO: https://github.com/runxhq/runx/pull/<number>",
+  "raw_x_yaml": "TODO: raw URL from PR head commit",
+  "raw_skill_md": "TODO: raw URL from PR head commit",
+  "verification_json": "verification.json",
+  "receipt_ref": "TODO: post-publish dogfood receipt_ref",
+  "publish_method": "runx login --provider github --for publish; runx registry publish ./skills/oncall-alert-triage/SKILL.md --registry https://api.runx.ai",
+  "install_command": "runx add <owner>/oncall-alert-triage@<version>",
+  "local_harness_command": "runx harness ./skills/oncall-alert-triage --receipt-dir ./.runx-receipts --json",
+  "hosted_harness_status": "TODO: run after registry publish",
+  "dogfood_command": "TODO post-publish: runx skill <owner>/oncall-alert-triage@<version> --json ...; runx verify --receipt <receipt.json> --json",
+  "observations": {
+    "harness_case_names": [
+      "sealed_escalate_checkout_alert",
+      "stop_unsealed_runbook_needs_agent"
+    ],
+    "decision_action": "escalate",
+    "decision_reason": "checkout-p1-5xx matched checkout/p1/checkout_5xx_rate.",
+    "sealed_runbook_digest": "sha256:9c8a7fc7e5d9810fcfe8e5afee0fef298b5597e8de5e2792d980e7d3a3b8d7f6",
+    "policy_clauses_applied": [
+      {
+        "id": "checkout-p1-5xx",
+        "action": "escalate",
+        "clause": "checkout p1 5xx rate above threshold must escalate to primary oncall and create an incident PR target."
+      }
+    ],
+    "packet": {
+      "schema": "runx.oncall.triage.v1",
+      "page_target": "pagerduty://services/checkout/primary",
+      "incident_pr_target": "github://runxhq/runx/incidents/checkout",
+      "pr_review_note_body": "Incident alert-checkout-5xx-20260630: checkout p1 via checkout_5xx_rate. Runbook digest sha256:9c8a7fc7e5d9810fcfe8e5afee0fef298b5597e8de5e2792d980e7d3a3b8d7f6. Proposed lane: issue-to-pr plus pr-review-note; live page is separate."
+    },
+    "stop_reason": {
+      "code": "runbook_unsealed",
+      "reason": "Runbook is missing or unsealed; no triage packet can be emitted.",
+      "needs_agent": true,
+      "packet_emitted": false
+    },
+    "receipt_id": "TODO: unavailable locally because Windows runx receipt store failed before sealing",
+    "authority_boundary": {
+      "minted": false,
+      "attenuation_request": false,
+      "effects_emitted": false,
+      "pages_sent": false,
+      "pull_requests_opened": false,
+      "fixes_applied": false
+    }
+  },
+  "dogfood": {
+    "package": "TODO: <owner>/oncall-alert-triage@<version>",
+    "input": "fixtures/escalate-alert.json + fixtures/sealed-runbook.json + fixtures/oncall-policy.json",
+    "command": "TODO: post-publish runx skill command",
+    "receipt_ref": "TODO",
+    "verify_verdict": "TODO",
+    "harness_cases": [
+      {
+        "name": "sealed_escalate_checkout_alert",
+        "status": "local runner logic passed; receipt not sealed on this Windows host"
+      },
+      {
+        "name": "stop_unsealed_runbook_needs_agent",
+        "status": "local runner logic passed; receipt not sealed on this Windows host"
+      }
+    ]
+  }
+}
+

--- a/skills/oncall-alert-triage/fixtures/billing-alert.json
+++ b/skills/oncall-alert-triage/fixtures/billing-alert.json
@@ -1,0 +1,12 @@
+{
+  "id": "alert-billing-latency-20260630",
+  "service": "billing",
+  "severity": "p2",
+  "signal": {
+    "name": "billing_latency_p95",
+    "value": 2500,
+    "threshold": 1000,
+    "unit": "ms"
+  }
+}
+

--- a/skills/oncall-alert-triage/fixtures/billing-policy.json
+++ b/skills/oncall-alert-triage/fixtures/billing-policy.json
@@ -1,0 +1,24 @@
+{
+  "services": {
+    "billing": {
+      "page_target": "pagerduty://services/billing/primary",
+      "incident_pr_target": "github://runxhq/runx/incidents/billing",
+      "allowed_actions": [
+        "acknowledge",
+        "escalate"
+      ],
+      "escalation": "billing.primary_oncall"
+    }
+  },
+  "escalation_rules": [
+    {
+      "id": "billing-p2-latency",
+      "service": "billing",
+      "severity": "p2",
+      "signal_name": "billing_latency_p95",
+      "action": "escalate",
+      "clause": "billing p2 latency alerts require sealed runbook evidence before packet emission."
+    }
+  ]
+}
+

--- a/skills/oncall-alert-triage/fixtures/escalate-alert.json
+++ b/skills/oncall-alert-triage/fixtures/escalate-alert.json
@@ -1,0 +1,12 @@
+{
+  "id": "alert-checkout-5xx-20260630",
+  "service": "checkout",
+  "severity": "p1",
+  "signal": {
+    "name": "checkout_5xx_rate",
+    "value": 8.7,
+    "threshold": 2.0,
+    "unit": "percent"
+  }
+}
+

--- a/skills/oncall-alert-triage/fixtures/oncall-policy.json
+++ b/skills/oncall-alert-triage/fixtures/oncall-policy.json
@@ -1,0 +1,24 @@
+{
+  "services": {
+    "checkout": {
+      "page_target": "pagerduty://services/checkout/primary",
+      "incident_pr_target": "github://runxhq/runx/incidents/checkout",
+      "allowed_actions": [
+        "acknowledge",
+        "escalate"
+      ],
+      "escalation": "checkout.primary_oncall"
+    }
+  },
+  "escalation_rules": [
+    {
+      "id": "checkout-p1-5xx",
+      "service": "checkout",
+      "severity": "p1",
+      "signal_name": "checkout_5xx_rate",
+      "action": "escalate",
+      "clause": "checkout p1 5xx rate above threshold must escalate to primary oncall and create an incident PR target."
+    }
+  ]
+}
+

--- a/skills/oncall-alert-triage/fixtures/sealed-runbook.json
+++ b/skills/oncall-alert-triage/fixtures/sealed-runbook.json
@@ -1,0 +1,19 @@
+{
+  "uri": "local://runbooks/checkout-5xx",
+  "sealed": true,
+  "digest": "sha256:9c8a7fc7e5d9810fcfe8e5afee0fef298b5597e8de5e2792d980e7d3a3b8d7f6",
+  "service": "checkout",
+  "version": "2026-06-30",
+  "allowed_actions": [
+    "acknowledge",
+    "escalate"
+  ],
+  "page_target": "pagerduty://services/checkout/primary",
+  "incident_pr_target": "github://runxhq/runx/incidents/checkout",
+  "pr_review_note_template": "Incident {alert_id}: {service} {severity} via {signal_name}. Runbook digest {runbook_digest}. Proposed lane: issue-to-pr plus pr-review-note; live page is separate.",
+  "escalation": {
+    "lane": "checkout.primary_oncall",
+    "human_approval_lane": "incident-commander"
+  }
+}
+

--- a/skills/oncall-alert-triage/fixtures/unsealed-runbook.json
+++ b/skills/oncall-alert-triage/fixtures/unsealed-runbook.json
@@ -1,0 +1,7 @@
+{
+  "uri": "local://runbooks/billing-latency",
+  "sealed": false,
+  "digest": null,
+  "service": "billing"
+}
+

--- a/skills/oncall-alert-triage/report.md
+++ b/skills/oncall-alert-triage/report.md
@@ -1,0 +1,68 @@
+# oncall-alert-triage staging report
+
+Package prepared for Frantic bounty #64 in `skills/oncall-alert-triage`.
+
+## What is included
+
+- `SKILL.md` with the package contract and operator boundary.
+- `X.yaml` with two inline harness cases:
+  - `sealed_escalate_checkout_alert`
+  - `stop_unsealed_runbook_needs_agent`
+- `run.mjs` deterministic read-only runner.
+- Fixtures for the sealed escalation case and the unsealed-runbook stop case.
+- `evidence.json` and `verification.json` draft artifacts.
+
+## Local verification
+
+Runx version:
+
+```text
+runx-cli 0.6.14
+```
+
+Skill metadata parses:
+
+```powershell
+runx skill inspect .\skills\oncall-alert-triage -j
+```
+
+Result: `status: ok`, package `oncall-alert-triage`, version `0.1.0`.
+
+Harness attempted:
+
+```powershell
+$env:RUNX_RECEIPT_SIGN_KID='runx-demo-key'
+$env:RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64='QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI='
+$env:RUNX_RECEIPT_SIGN_ISSUER_TYPE='hosted'
+runx harness .\skills\oncall-alert-triage --receipt-dir .\.runx-receipts --json
+```
+
+Local harness did not seal on this Windows host. Both cases failed before a
+receipt id was produced with:
+
+```text
+receipt store is unreadable: 参数错误。 (os error 87)
+```
+
+Direct runner fixture checks passed with `node run.mjs`:
+
+- Happy case: `decision.action` is `escalate`, sealed runbook digest is
+  `sha256:9c8a7fc7e5d9810fcfe8e5afee0fef298b5597e8de5e2792d980e7d3a3b8d7f6`,
+  and exactly one `runx.oncall.triage.v1` packet is emitted.
+- Stop case: unsealed runbook produces `stop.code=runbook_unsealed`,
+  `escalation.status=needs_agent`, and `packet=null`.
+
+## Publish blockers / next steps
+
+Do not Frantic-deliver this local staging packet as-is. The final delivery still
+needs:
+
+1. publish identity and GitHub star verifier satisfied by the claimant account;
+2. public PR against `runxhq/runx` with raw `X.yaml` and `SKILL.md` URLs from the
+   PR head commit;
+3. local or hosted harness sealing receipts;
+4. registry publish for exact package name `oncall-alert-triage`;
+5. post-publish `runx add`, `runx skill`, and `runx verify` evidence;
+6. final public `public_url`, `source_url`, `pr_url`, `x_yaml`, `skill_md`,
+   `evidence_json`, `verification_json`, `receipt_ref`, and `report`.
+

--- a/skills/oncall-alert-triage/run.mjs
+++ b/skills/oncall-alert-triage/run.mjs
@@ -1,0 +1,209 @@
+import crypto from "node:crypto";
+
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return `sha256:${crypto.createHash("sha256").update(stableJson(value)).digest("hex")}`;
+}
+
+function normalizeSeverity(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function fail(code, reason, extra = {}) {
+  return {
+    decision: { action: "acknowledge", reason },
+    escalation: {
+      status: "needs_agent",
+      lane: extra.human_approval_lane ?? "oncall.human_approval",
+      reason_code: code,
+      reason,
+    },
+    packet: null,
+    stop: {
+      code,
+      reason,
+      packet_emitted: false,
+      needs_agent: true,
+    },
+  };
+}
+
+function matchRule(rule, alert) {
+  if (String(rule?.service ?? "") !== String(alert.service ?? "")) return false;
+  if (rule?.severity && normalizeSeverity(rule.severity) !== normalizeSeverity(alert.severity)) return false;
+  if (rule?.signal_name && String(rule.signal_name) !== String(alert.signal?.name ?? "")) return false;
+  return true;
+}
+
+function renderNote(template, bindings) {
+  return String(template ?? "Incident {alert_id}: {service} {severity} via {signal_name}. Runbook digest {runbook_digest}.")
+    .replaceAll("{alert_id}", bindings.alert_id)
+    .replaceAll("{service}", bindings.service)
+    .replaceAll("{severity}", bindings.severity)
+    .replaceAll("{signal_name}", bindings.signal_name)
+    .replaceAll("{runbook_digest}", bindings.runbook_digest)
+    .replaceAll("{policy_clause}", bindings.policy_clause);
+}
+
+function decide(alert, runbookRef, oncallPolicy) {
+  for (const key of ["id", "service", "severity", "signal"]) {
+    if (!alert?.[key]) return fail(`missing_alert_${key}`, `alert.${key} is required.`);
+  }
+
+  const servicePolicy = oncallPolicy?.services?.[alert.service];
+  if (!servicePolicy) {
+    return fail("undeclared_service", `Service ${alert.service} is not declared in oncall_policy.services.`);
+  }
+
+  if (runbookRef?.sealed !== true || !runbookRef?.digest) {
+    return fail("runbook_unsealed", "Runbook is missing or unsealed; no triage packet can be emitted.", {
+      human_approval_lane: servicePolicy.escalation ?? "oncall.human_approval",
+    });
+  }
+
+  if (runbookRef.service && runbookRef.service !== alert.service) {
+    return fail("runbook_service_mismatch", `Runbook service ${runbookRef.service} does not match alert service ${alert.service}.`);
+  }
+
+  const matchingRule = (oncallPolicy.escalation_rules ?? []).find((rule) => matchRule(rule, alert));
+  const action = matchingRule?.action ?? "acknowledge";
+  const allowedActions = new Set([...(servicePolicy.allowed_actions ?? []), ...(runbookRef.allowed_actions ?? [])]);
+  if (!["acknowledge", "escalate", "auto_remediate", "suppress"].includes(action)) {
+    return fail("unsupported_action", `Policy action ${action} is not a supported triage action.`);
+  }
+  if (!allowedActions.has(action) && action !== "acknowledge") {
+    return fail("action_not_allowed", `Action ${action} is absent from the sealed runbook or service policy allowed_actions.`);
+  }
+
+  const pageTarget = runbookRef.page_target ?? servicePolicy.page_target;
+  const incidentPrTarget = runbookRef.incident_pr_target ?? servicePolicy.incident_pr_target;
+  const escalationLane = runbookRef.escalation?.lane ?? servicePolicy.escalation ?? "oncall.primary";
+  const policyClause = matchingRule?.clause ?? "Declared service and sealed runbook; no escalation rule matched.";
+
+  const decision = {
+    action,
+    reason: matchingRule
+      ? `${matchingRule.id ?? "policy_rule"} matched ${alert.service}/${alert.severity}/${alert.signal?.name}.`
+      : "No escalation rule matched; acknowledge and keep human-readable sealed evidence.",
+  };
+
+  if (["escalate", "auto_remediate"].includes(action)) {
+    if (!pageTarget || !incidentPrTarget) {
+      return fail("target_binding_missing", "Escalation or auto-remediation requires both page_target and incident_pr_target.", {
+        human_approval_lane: escalationLane,
+      });
+    }
+
+    if (action === "auto_remediate" && !runbookRef.fix_bundle) {
+      return fail("missing_fix_bundle", "auto_remediate was selected but the sealed runbook carries no bounded fix bundle.", {
+        human_approval_lane: escalationLane,
+      });
+    }
+
+    const packet = {
+      schema: "runx.oncall.triage.v1",
+      alert_id: alert.id,
+      service: alert.service,
+      action,
+      page_target: pageTarget,
+      incident_pr_target: incidentPrTarget,
+      pr_review_note_body: renderNote(runbookRef.pr_review_note_template, {
+        alert_id: alert.id,
+        service: alert.service,
+        severity: alert.severity,
+        signal_name: alert.signal?.name ?? "unknown_signal",
+        runbook_digest: runbookRef.digest,
+        policy_clause: policyClause,
+      }),
+      optional_fix_bundle: action === "auto_remediate" ? runbookRef.fix_bundle : null,
+      dispatch_by_naming: {
+        page: "separate live page send run",
+        incident_pr: "issue-to-pr",
+        pr_review_note: "pr-review-note",
+      },
+    };
+    return {
+      decision,
+      escalation: {
+        status: "eligible",
+        lane: escalationLane,
+        page_target: pageTarget,
+        incident_pr_target: incidentPrTarget,
+      },
+      packet,
+      stop: null,
+    };
+  }
+
+  return {
+    decision,
+    escalation: {
+      status: "not_required",
+      lane: escalationLane,
+    },
+    packet: null,
+    stop: null,
+  };
+}
+
+function main() {
+  const alert = jsonInput("ALERT", {});
+  const runbookRef = jsonInput("RUNBOOK_REF", {});
+  const oncallPolicy = jsonInput("ONCALL_POLICY", {});
+  const judgment = decide(alert, runbookRef, oncallPolicy);
+
+  const output = {
+    schema: "runx.oncall.triage_judgment.v1",
+    package: "oncall-alert-triage",
+    version: "0.1.0",
+    alert,
+    runbook: {
+      uri: runbookRef?.uri ?? null,
+      sealed: runbookRef?.sealed === true,
+      digest: runbookRef?.digest ?? null,
+      computed_ref_hash: sha256(runbookRef ?? {}),
+    },
+    policy_clauses_applied: (oncallPolicy?.escalation_rules ?? [])
+      .filter((rule) => matchRule(rule, alert))
+      .map((rule) => ({ id: rule.id ?? null, clause: rule.clause ?? null, action: rule.action ?? null })),
+    decision: judgment.decision,
+    escalation: judgment.escalation,
+    packet: judgment.packet,
+    stop: judgment.stop,
+    authority: {
+      minted: false,
+      attenuation_request: false,
+      effects_emitted: false,
+      pages_sent: false,
+      pull_requests_opened: false,
+      fixes_applied: false,
+    },
+  };
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}
+

--- a/skills/oncall-alert-triage/verification.json
+++ b/skills/oncall-alert-triage/verification.json
@@ -1,0 +1,92 @@
+{
+  "schema": "frantic.runx_skill_verification.v1",
+  "bounty": 64,
+  "package": "oncall-alert-triage",
+  "version": "0.1.0",
+  "runx_cli": {
+    "path": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe",
+    "version_command": "runx --version",
+    "version_output": "runx-cli 0.6.14"
+  },
+  "checks": [
+    {
+      "name": "skill inspect",
+      "command": "runx skill inspect .\\skills\\oncall-alert-triage -j",
+      "status": "passed",
+      "summary": {
+        "schema": "runx.skill.inspect.v1",
+        "status": "ok",
+        "name": "oncall-alert-triage",
+        "version": "0.1.0",
+        "runners": [
+          "default"
+        ]
+      }
+    },
+    {
+      "name": "local harness",
+      "command": "runx harness .\\skills\\oncall-alert-triage --receipt-dir .\\.runx-receipts --json",
+      "status": "blocked_by_local_runx_windows_receipt_store",
+      "output": {
+        "status": "failed",
+        "case_count": 2,
+        "assertion_error_count": 2,
+        "assertion_errors": [
+          "sealed_escalate_checkout_alert: receipt store is unreadable: 参数错误。 (os error 87)",
+          "stop_unsealed_runbook_needs_agent: receipt store is unreadable: 参数错误。 (os error 87)"
+        ],
+        "case_names": [
+          "sealed_escalate_checkout_alert",
+          "stop_unsealed_runbook_needs_agent"
+        ],
+        "receipt_ids": []
+      },
+      "signing_env_used": {
+        "RUNX_RECEIPT_SIGN_KID": "runx-demo-key",
+        "RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64": "public runx demo seed from repository docs, not a production secret",
+        "RUNX_RECEIPT_SIGN_ISSUER_TYPE": "hosted"
+      }
+    },
+    {
+      "name": "direct runner happy fixture",
+      "command": "node run.mjs with fixtures/escalate-alert.json, fixtures/sealed-runbook.json, fixtures/oncall-policy.json",
+      "status": "passed",
+      "assertions": [
+        "decision.action == escalate",
+        "packet.schema == runx.oncall.triage.v1",
+        "packet.page_target and packet.incident_pr_target are bound",
+        "authority.minted == false and effects_emitted == false"
+      ]
+    },
+    {
+      "name": "direct runner stop fixture",
+      "command": "node run.mjs with fixtures/billing-alert.json, fixtures/unsealed-runbook.json, fixtures/billing-policy.json",
+      "status": "passed",
+      "assertions": [
+        "stop.code == runbook_unsealed",
+        "escalation.status == needs_agent",
+        "packet == null"
+      ]
+    }
+  ],
+  "publish_readiness": {
+    "local_package_files_present": true,
+    "local_parse_ok": true,
+    "local_harness_green": false,
+    "hosted_harness_green": false,
+    "published": false,
+    "post_publish_dogfood_receipt": false,
+    "pr_opened": false,
+    "frantic_delivered": false
+  },
+  "remaining_required_actions": [
+    "Claim/publish cooldown must clear and GitHub identity/star requirement must be satisfied by the publishing account.",
+    "Copy skills/oncall-alert-triage package into a public runxhq/runx PR branch.",
+    "Run local harness on a host where runx receipt store can seal receipts, or with a fixed Windows receipt store.",
+    "Publish registry package with exact name oncall-alert-triage.",
+    "Run hosted harness after publish.",
+    "Run post-publish dogfood with registry ref and verify the emitted receipt.",
+    "Fill public_url, source_url, pr_url, raw_x_yaml, raw_skill_md, receipt_ref, and final report URLs before Frantic delivery."
+  ]
+}
+

--- a/skills/renewal-risk-judge/SKILL.md
+++ b/skills/renewal-risk-judge/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: renewal-risk-judge
+description: Fuse sealed usage, support, and payment snapshot signals into a bounded renewal-risk verdict and save-message recommendation.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  usage_signals:
+    type: json
+    required: true
+    description: usage_signals{trend,mau_pct_change}
+  support_history:
+    type: json
+    required: true
+    description: support_history{volume,ticket_severity_avg}
+  payment_snapshot:
+    type: json
+    required: true
+    description: payment_snapshot{days_late,churn_flag}
+runx:
+  category: support
+  input_resolution:
+    required:
+      - usage_signals
+      - support_history
+      - payment_snapshot
+---
+
+# Renewal Risk Judge
+
+`renewal-risk-judge` is a read-only renewal intervention classifier. It reads
+sealed usage signals, support history, and a payment snapshot, fuses them into
+one `runx.support.renewal_risk.v1` packet, and includes a bounded save-message
+plan only when the risk is high or critical.
+
+The skill does not send, apply discounts, quote prices, touch money rails, mint
+authority, or emit an operational proposal. The save plan is data: a human or
+downstream lane may read it, and a separate governed `send-as` run must perform
+any actual delivery under human approval.
+
+## Contract
+
+Inputs:
+
+- `usage_signals{trend,mau_pct_change}`
+- `support_history{volume,ticket_severity_avg}`
+- `payment_snapshot{days_late,churn_flag}`
+
+Output packet:
+
+- `runx.support.renewal_risk.v1`
+- `decision{risk_level, justification}`
+- `escalation`
+- `save_plan{channel, audience, content_ref}` only for high or critical risk
+
+The `save_plan` is deliberately bounded to message content only. It never
+contains amount, currency, counterparty, discount, invoice, or payment rail data.
+
+## Scoring
+
+The fused score is transparent and bounded:
+
+- Usage trend weight: 45 points
+- Support burden weight: 25 points
+- Payment risk weight: 30 points
+
+Risk bands:
+
+- `critical`: reserved for future critical-only signals above the v0.1
+  100-point scale
+- `high`: 65-100
+- `moderate`: 35-64
+- `low`: below 35
+
+## Refusals and human lane
+
+- Missing `usage_signals.trend` stops the qualify sub-step; no save plan is
+  emitted and the reason names the missing signal.
+- Contradictory input where usage clearly declines while the payment snapshot
+  shows no renewal risk stops for human review instead of inventing a reason.
+- Moderate or edge cases route to `support.renewal_risk.human_approval`; no
+  send-as delivery can fire without approval.
+
+## Verification
+
+Local harness:
+
+```bash
+runx harness ./skills/renewal-risk-judge
+```
+
+Example dogfood run:
+
+```bash
+runx skill ./skills/renewal-risk-judge --json \
+  --input-json usage_signals='{"trend":"declining","mau_pct_change":-38}' \
+  --input-json support_history='{"volume":11,"ticket_severity_avg":4.2}' \
+  --input-json payment_snapshot='{"days_late":12,"churn_flag":true}'
+```

--- a/skills/renewal-risk-judge/X.yaml
+++ b/skills/renewal-risk-judge/X.yaml
@@ -1,0 +1,92 @@
+skill: renewal-risk-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: high_risk_with_save_play
+      runner: default
+      inputs:
+        usage_signals:
+          trend: declining
+          mau_pct_change: -38
+        support_history:
+          volume: 11
+          ticket_severity_avg: 4.2
+        payment_snapshot:
+          days_late: 12
+          churn_flag: true
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: missing_usage_signals_stop
+      runner: default
+      inputs:
+        usage_signals:
+          mau_pct_change: -22
+        support_history:
+          volume: 4
+          ticket_severity_avg: 2.8
+        payment_snapshot:
+          days_late: 3
+          churn_flag: false
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+policy:
+  allow:
+    - provider: usage-signals
+      method: READ
+      scope: runx:usage:read
+    - provider: support-history
+      method: READ
+      scope: runx:support:read
+    - provider: payment-snapshot
+      method: READ
+      scope: runx:payment-snapshot:read
+  deny:
+    - public_send
+    - outbound_send
+    - money_rail
+    - discount_apply
+    - price_quote
+    - operational_proposal
+    - mint
+    - invented_usage_signals
+    - invented_payment_lateness
+
+emits:
+  - name: runx.support.renewal_risk.v1
+    packet: runx.support.renewal_risk.v1
+    dispatch_by_name: send-as
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      usage_signals:
+        type: json
+        required: true
+      support_history:
+        type: json
+        required: true
+      payment_snapshot:
+        type: json
+        required: true

--- a/skills/renewal-risk-judge/fixtures/high_risk_with_save_play.json
+++ b/skills/renewal-risk-judge/fixtures/high_risk_with_save_play.json
@@ -1,0 +1,20 @@
+{
+  "usage_signals": {
+    "trend": "declining",
+    "mau_pct_change": -38
+  },
+  "support_history": {
+    "volume": 11,
+    "ticket_severity_avg": 4.2
+  },
+  "payment_snapshot": {
+    "days_late": 12,
+    "churn_flag": true
+  },
+  "expected": {
+    "schema": "runx.support.renewal_risk.v1",
+    "decision.risk_level": "high",
+    "save_plan.channel": "email",
+    "save_plan.content_ref": "content://renewal-save/high-risk-usage-support-payment-v1"
+  }
+}

--- a/skills/renewal-risk-judge/fixtures/missing_usage_signals_stop.json
+++ b/skills/renewal-risk-judge/fixtures/missing_usage_signals_stop.json
@@ -1,0 +1,20 @@
+{
+  "usage_signals": {
+    "mau_pct_change": -22
+  },
+  "support_history": {
+    "volume": 4,
+    "ticket_severity_avg": 2.8
+  },
+  "payment_snapshot": {
+    "days_late": 3,
+    "churn_flag": false
+  },
+  "expected": {
+    "schema": "runx.support.renewal_risk.v1",
+    "decision.risk_level": "stop",
+    "refused": true,
+    "save_plan": null,
+    "reason_includes": "missing usage_signals.trend"
+  }
+}

--- a/skills/renewal-risk-judge/run.mjs
+++ b/skills/renewal-risk-judge/run.mjs
@@ -1,0 +1,241 @@
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function numberMetric(object, key, label) {
+  const value = Number(object?.[key]);
+  if (!Number.isFinite(value)) {
+    return { ok: false, reason: `${label}.${key} is missing or not numeric` };
+  }
+  return { ok: true, value };
+}
+
+function booleanMetric(object, key, label) {
+  if (typeof object?.[key] !== "boolean") {
+    return { ok: false, reason: `${label}.${key} is missing or not boolean` };
+  }
+  return { ok: true, value: object[key] };
+}
+
+function normalizeTrend(trend) {
+  return String(trend ?? "").trim().toLowerCase();
+}
+
+function scoreUsage(usageSignals) {
+  const trend = normalizeTrend(usageSignals?.trend);
+  const mau = numberMetric(usageSignals, "mau_pct_change", "usage_signals");
+  if (!trend) return { ok: false, reason: "missing usage_signals.trend" };
+  if (!mau.ok) return mau;
+
+  let points = 0;
+  const reasons = [];
+  if (["declining", "down", "shrinking", "drop"].includes(trend) || mau.value <= -15) {
+    points = 45;
+    reasons.push(`usage trend=${trend}; mau_pct_change=${mau.value}`);
+  } else if (mau.value <= -5) {
+    points = 25;
+    reasons.push(`mild usage decline mau_pct_change=${mau.value}`);
+  } else {
+    reasons.push(`usage trend=${trend}; mau_pct_change=${mau.value}`);
+  }
+  return { ok: true, points, reasons, trend, mau_pct_change: mau.value };
+}
+
+function scoreSupport(supportHistory) {
+  const volume = numberMetric(supportHistory, "volume", "support_history");
+  const severity = numberMetric(supportHistory, "ticket_severity_avg", "support_history");
+  const missing = [volume, severity].filter((item) => !item.ok).map((item) => item.reason);
+  if (missing.length) return { ok: false, reason: missing.join("; ") };
+
+  let points = 0;
+  if (volume.value >= 8 || severity.value >= 3.5) points = 25;
+  else if (volume.value >= 3 || severity.value >= 2.5) points = 10;
+  return {
+    ok: true,
+    points,
+    reasons: [`support volume=${volume.value}; ticket_severity_avg=${severity.value}`],
+    volume: volume.value,
+    ticket_severity_avg: severity.value,
+  };
+}
+
+function scorePayment(paymentSnapshot) {
+  const daysLate = numberMetric(paymentSnapshot, "days_late", "payment_snapshot");
+  const churnFlag = booleanMetric(paymentSnapshot, "churn_flag", "payment_snapshot");
+  const missing = [daysLate, churnFlag].filter((item) => !item.ok).map((item) => item.reason);
+  if (missing.length) return { ok: false, reason: missing.join("; ") };
+  if (daysLate.value < 0) return { ok: false, reason: "payment_snapshot.days_late cannot be negative" };
+
+  let points = 0;
+  if (daysLate.value >= 7 || churnFlag.value) points = 30;
+  else if (daysLate.value > 0) points = 15;
+  return {
+    ok: true,
+    points,
+    reasons: [`payment days_late=${daysLate.value}; churn_flag=${churnFlag.value}`],
+    days_late: daysLate.value,
+    churn_flag: churnFlag.value,
+  };
+}
+
+function riskLevel(score) {
+  if (score > 100) return "critical";
+  if (score >= 65) return "high";
+  if (score >= 35) return "moderate";
+  return "low";
+}
+
+function stop(reason, signals) {
+  return {
+    schema: "runx.support.renewal_risk.v1",
+    package: "renewal-risk-judge",
+    version: "0.1.0",
+    decision: {
+      risk_level: "stop",
+      justification: reason,
+    },
+    fused_score: null,
+    signal_weights: {
+      usage_trend: 45,
+      support: 25,
+      payment: 30,
+    },
+    signal_evidence: signals,
+    escalation: {
+      lane: "support.renewal_risk.human_approval",
+      reason,
+      send_as_allowed_without_approval: false,
+    },
+    save_plan: null,
+    refused: true,
+    effects: {
+      send: false,
+      money_rail: false,
+      discount_apply: false,
+      price_quote: false,
+      operational_proposal: false,
+    },
+  };
+}
+
+function evaluate({ usageSignals, supportHistory, paymentSnapshot }) {
+  const usage = scoreUsage(usageSignals);
+  const support = scoreSupport(supportHistory);
+  const payment = scorePayment(paymentSnapshot);
+  const signalEvidence = {
+    usage_signals: usage.ok ? {
+      trend: usage.trend,
+      mau_pct_change: usage.mau_pct_change,
+      points: usage.points,
+      reasons: usage.reasons,
+    } : { error: usage.reason },
+    support_history: support.ok ? {
+      volume: support.volume,
+      ticket_severity_avg: support.ticket_severity_avg,
+      points: support.points,
+      reasons: support.reasons,
+    } : { error: support.reason },
+    payment_snapshot: payment.ok ? {
+      days_late: payment.days_late,
+      churn_flag: payment.churn_flag,
+      points: payment.points,
+      reasons: payment.reasons,
+    } : { error: payment.reason },
+  };
+
+  for (const signal of [usage, support, payment]) {
+    if (!signal.ok) return stop(signal.reason, signalEvidence);
+  }
+
+  const usageDeclines = usage.points >= 45;
+  const paymentShowsNoRisk = payment.days_late === 0 && payment.churn_flag === false;
+  if (usageDeclines && paymentShowsNoRisk) {
+    return stop("contradictory signals: usage decline conflicts with payment snapshot showing no renewal risk", signalEvidence);
+  }
+
+  const fusedScore = usage.points + support.points + payment.points;
+  const level = riskLevel(fusedScore);
+  const highOrCritical = ["high", "critical"].includes(level);
+  const moderate = level === "moderate";
+  const justification = [
+    `usage=${usage.points}/45`,
+    `support=${support.points}/25`,
+    `payment=${payment.points}/30`,
+    `fused_score=${fusedScore}`,
+  ].join("; ");
+
+  return {
+    schema: "runx.support.renewal_risk.v1",
+    package: "renewal-risk-judge",
+    version: "0.1.0",
+    decision: {
+      risk_level: level,
+      justification,
+    },
+    fused_score: fusedScore,
+    signal_weights: {
+      usage_trend: 45,
+      support: 25,
+      payment: 30,
+    },
+    signal_evidence: signalEvidence,
+    escalation: highOrCritical
+      ? {
+          lane: "support.renewal_risk.human_approval",
+          reason: "high_or_critical_renewal_risk_requires_human_approval_before_send_as",
+          send_as_allowed_without_approval: false,
+        }
+      : moderate
+        ? {
+            lane: "support.renewal_risk.human_approval",
+            reason: "moderate_edge_case_requires_human_review",
+            send_as_allowed_without_approval: false,
+          }
+        : {
+            lane: null,
+            reason: "low_risk_no_save_plan",
+            send_as_allowed_without_approval: false,
+          },
+    save_plan: highOrCritical
+      ? {
+          channel: "email",
+          audience: "account_owner_and_success_manager",
+          content_ref: "content://renewal-save/high-risk-usage-support-payment-v1",
+        }
+      : null,
+    refused: false,
+    dispatch_by_name: {
+      verdict_name: "runx.support.renewal_risk.v1",
+      downstream: "send-as",
+      delivery_rule: "separate governed send-as run may deliver only after human approval",
+    },
+    effects: {
+      send: false,
+      money_rail: false,
+      discount_apply: false,
+      price_quote: false,
+      operational_proposal: false,
+    },
+  };
+}
+
+function main() {
+  const usageSignals = jsonInput("USAGE_SIGNALS", {});
+  const supportHistory = jsonInput("SUPPORT_HISTORY", {});
+  const paymentSnapshot = jsonInput("PAYMENT_SNAPSHOT", {});
+  const output = evaluate({ usageSignals, supportHistory, paymentSnapshot });
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/skills/spam-risk-reviewer/SKILL.md
+++ b/skills/spam-risk-reviewer/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: spam-risk-reviewer
+description: Read a campaign draft, list hygiene signals, and sender authentication posture, then emit a bounded send_risk_verdict for send-as preflight.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  campaign_draft:
+    type: json
+    required: true
+    description: campaign_draft{from, subject, content_digest}
+  list_metadata:
+    type: json
+    required: true
+    description: list_metadata{size, bounce_rate, complaint_rate, freshness}
+  sender_auth_posture:
+    type: json
+    required: true
+    description: sender_auth_posture{spf_pass, dkim_pass, dmarc_pass, warm_up_days}
+runx:
+  category: deliverability
+  input_resolution:
+    required:
+      - campaign_draft
+      - list_metadata
+      - sender_auth_posture
+---
+
+# Spam Risk Reviewer
+
+`spam-risk-reviewer` is a read-only pre-send judgment skill. It reviews a
+campaign draft, subscriber-list metadata, and sender-authentication posture, then
+emits a bounded `send_risk_verdict`.
+
+The skill never sends mail, never mints authority, never writes domain state, and
+never emits `runx.operational_proposal.v1`. A separate governed `send-as` run
+reads the verdict by name into its `preflight_required` and `blockers`. If this
+skill returns any non-clear verdict, send-as cannot satisfy preflight and must
+route to the human approval lane. The `public_send` effect belongs only to
+send-as.
+
+## Contract
+
+Inputs:
+
+- `campaign_draft{from, subject, content_digest}`
+- `list_metadata{size, bounce_rate, complaint_rate, freshness}`
+- `sender_auth_posture{spf_pass, dkim_pass, dmarc_pass, warm_up_days}`
+
+Output:
+
+- `send_risk_verdict{risk_level, preflight_clear, blockers, evidence_summary}`
+
+## Policy thresholds
+
+- SPF, DKIM, and DMARC must all pass.
+- `bounce_rate` must be at or below `0.02`.
+- `complaint_rate` must be at or below `0.001`.
+- `freshness` is interpreted as max list age in days and must be at or below
+  `90`.
+- `warm_up_days` must be at least `14` for automated clearance.
+- Content flags such as urgency, guarantees, or free-money wording lower the
+  verdict but do not invent metrics.
+
+## Decision behavior
+
+- Clear authenticated sender plus clean list signals yields
+  `risk_level: pass`, `preflight_clear: true`, and `blockers: []`.
+- Missing SPF, DKIM, or DMARC, poor list hygiene, or stale freshness yields
+  `risk_level: hold`, `preflight_clear: false`, concrete blocker reasons, and
+  `needs_human` for `send-as.human_approval`.
+- Missing required metrics are refused as ungrounded; the skill does not guess
+  authentication or list-health values.
+
+## Verification
+
+Local harness:
+
+```bash
+runx harness ./skills/spam-risk-reviewer
+```
+
+Example dogfood run:
+
+```bash
+runx skill ./skills/spam-risk-reviewer --json \
+  --input-json campaign_draft='{"from":"newsletter@example.com","subject":"June product notes for active customers","content_digest":"Monthly release notes and support office hours."}' \
+  --input-json list_metadata='{"size":12500,"bounce_rate":0.003,"complaint_rate":0.0002,"freshness":21}' \
+  --input-json sender_auth_posture='{"spf_pass":true,"dkim_pass":true,"dmarc_pass":true,"warm_up_days":45}'
+```

--- a/skills/spam-risk-reviewer/X.yaml
+++ b/skills/spam-risk-reviewer/X.yaml
@@ -1,0 +1,101 @@
+skill: spam-risk-reviewer
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: low-risk-verified-sender
+      runner: default
+      inputs:
+        campaign_draft:
+          from: "newsletter@example.com"
+          subject: "June product notes for active customers"
+          content_digest: "Monthly release notes, documentation links, and support office hours for opted-in customers."
+        list_metadata:
+          size: 12500
+          bounce_rate: 0.003
+          complaint_rate: 0.0002
+          freshness: 21
+        sender_auth_posture:
+          spf_pass: true
+          dkim_pass: true
+          dmarc_pass: true
+          warm_up_days: 45
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: high-risk-incomplete-auth-poor-list
+      runner: default
+      inputs:
+        campaign_draft:
+          from: "promo@example.com"
+          subject: "URGENT free trial extension"
+          content_digest: "Promotional reactivation campaign with aggressive urgency wording."
+        list_metadata:
+          size: 88000
+          bounce_rate: 0.071
+          complaint_rate: 0.0024
+          freshness: 132
+        sender_auth_posture:
+          spf_pass: true
+          dkim_pass: false
+          dmarc_pass: true
+          warm_up_days: 6
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+policy:
+  allow:
+    - provider: campaign-draft
+      method: READ
+      scope: runx:campaign:read
+    - provider: list-metadata
+      method: READ
+      scope: runx:list-hygiene:read
+    - provider: sender-auth-posture
+      method: READ
+      scope: runx:sender-auth:read
+  deny:
+    - public_send
+    - outbound_send
+    - operational_proposal
+    - mint
+    - domain_state_write
+    - invented_authentication_signals
+    - invented_list_health_metrics
+
+emits:
+  - name: send_risk_verdict
+    packet: send_risk_verdict
+    dispatch_by_name: send-as
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      campaign_draft:
+        type: json
+        required: true
+      list_metadata:
+        type: json
+        required: true
+      sender_auth_posture:
+        type: json
+        required: true

--- a/skills/spam-risk-reviewer/fixtures/high-risk-incomplete-auth-poor-list.json
+++ b/skills/spam-risk-reviewer/fixtures/high-risk-incomplete-auth-poor-list.json
@@ -1,0 +1,28 @@
+{
+  "campaign_draft": {
+    "from": "promo@example.com",
+    "subject": "URGENT free trial extension",
+    "content_digest": "Promotional reactivation campaign with aggressive urgency wording."
+  },
+  "list_metadata": {
+    "size": 88000,
+    "bounce_rate": 0.071,
+    "complaint_rate": 0.0024,
+    "freshness": 132
+  },
+  "sender_auth_posture": {
+    "spf_pass": true,
+    "dkim_pass": false,
+    "dmarc_pass": true,
+    "warm_up_days": 6
+  },
+  "expected": {
+    "risk_level": "hold",
+    "preflight_clear": false,
+    "blockers_include": [
+      "DKIM authentication did not pass",
+      "bounce_rate 0.071 exceeds policy threshold 0.02"
+    ],
+    "needs_human_lane": "send-as.human_approval"
+  }
+}

--- a/skills/spam-risk-reviewer/fixtures/low-risk-verified-sender.json
+++ b/skills/spam-risk-reviewer/fixtures/low-risk-verified-sender.json
@@ -1,0 +1,24 @@
+{
+  "campaign_draft": {
+    "from": "newsletter@example.com",
+    "subject": "June product notes for active customers",
+    "content_digest": "Monthly release notes, documentation links, and support office hours for opted-in customers."
+  },
+  "list_metadata": {
+    "size": 12500,
+    "bounce_rate": 0.003,
+    "complaint_rate": 0.0002,
+    "freshness": 21
+  },
+  "sender_auth_posture": {
+    "spf_pass": true,
+    "dkim_pass": true,
+    "dmarc_pass": true,
+    "warm_up_days": 45
+  },
+  "expected": {
+    "risk_level": "pass",
+    "preflight_clear": true,
+    "blockers": []
+  }
+}

--- a/skills/spam-risk-reviewer/references/evidence.json
+++ b/skills/spam-risk-reviewer/references/evidence.json
@@ -1,0 +1,139 @@
+{
+  "schema": "frantic.runx_skill.evidence.v1",
+  "bounty": 62,
+  "prepared_at": "2026-06-30T00:00:00-07:00",
+  "package": {
+    "name": "spam-risk-reviewer",
+    "version": "0.1.0",
+    "registry_ref": "<owner>/spam-risk-reviewer@0.1.0",
+    "publisher_owner": "<pending>",
+    "source_revision": "<pending-public-pr-head-commit>"
+  },
+  "artifacts": {
+    "public_url": "<pending: https://runx.ai/x/<owner>/spam-risk-reviewer@0.1.0>",
+    "source_url": "<pending: public source/provenance URL>",
+    "pr_url": "<pending: https://github.com/runxhq/runx/pull/<number>>",
+    "x_yaml": "<pending raw PR-head URL for skills/spam-risk-reviewer/X.yaml>",
+    "skill_md": "<pending raw PR-head URL for skills/spam-risk-reviewer/SKILL.md>",
+    "evidence_json": "<pending public URL to this evidence.json>",
+    "verification_json": "<pending public URL to verification.json>",
+    "receipt_ref": "<pending post-publish dogfood receipt>",
+    "report": "<pending public URL to report.md>"
+  },
+  "observations": {
+    "runx_version_output": "runx-cli 0.6.14",
+    "package_name": "spam-risk-reviewer",
+    "risk_level_verdicts": {
+      "low-risk-verified-sender": "pass",
+      "high-risk-incomplete-auth-poor-list": "hold"
+    },
+    "reasoning": [
+      "Automated preflight_clear is true only when SPF, DKIM, DMARC pass and list metrics are below policy thresholds.",
+      "DKIM failure, warm-up below 14 days, bounce_rate above 0.02, complaint_rate above 0.001, or freshness above 90 days blocks preflight and routes to send-as.human_approval.",
+      "Content flags are recorded as evidence; they do not invent authentication or list health values."
+    ],
+    "authentication_signals_verified": {
+      "low-risk-verified-sender": {
+        "spf_pass": true,
+        "dkim_pass": true,
+        "dmarc_pass": true,
+        "warm_up_days": 45
+      },
+      "high-risk-incomplete-auth-poor-list": {
+        "spf_pass": true,
+        "dkim_pass": false,
+        "dmarc_pass": true,
+        "warm_up_days": 6
+      }
+    },
+    "list_hygiene_metrics_compared_to_policy": {
+      "thresholds": {
+        "bounce_rate_max": 0.02,
+        "complaint_rate_max": 0.001,
+        "freshness_days_max": 90,
+        "warm_up_days_min": 14
+      },
+      "low-risk-verified-sender": {
+        "size": 12500,
+        "bounce_rate": 0.003,
+        "complaint_rate": 0.0002,
+        "freshness": 21
+      },
+      "high-risk-incomplete-auth-poor-list": {
+        "size": 88000,
+        "bounce_rate": 0.071,
+        "complaint_rate": 0.0024,
+        "freshness": 132
+      }
+    },
+    "content_risk_flags": {
+      "low-risk-verified-sender": [],
+      "high-risk-incomplete-auth-poor-list": [
+        "urgency_language"
+      ]
+    },
+    "blockers": {
+      "low-risk-verified-sender": [],
+      "high-risk-incomplete-auth-poor-list": [
+        "DKIM authentication did not pass",
+        "sender warm-up 6 days is below policy minimum 14",
+        "bounce_rate 0.071 exceeds policy threshold 0.02",
+        "complaint_rate 0.0024 exceeds policy threshold 0.001",
+        "list freshness 132 days exceeds policy max 90"
+      ]
+    },
+    "harness_case_names": [
+      "low-risk-verified-sender",
+      "high-risk-incomplete-auth-poor-list"
+    ],
+    "receipt_id": "<pending post-publish dogfood receipt id>",
+    "hosted_harness_status": "pending_publish",
+    "local_harness_status": "blocked_by_windows_receipt_store_os_error_87",
+    "publish_method": "pending: runx login --provider github --for publish; runx registry publish ./skills/spam-risk-reviewer/SKILL.md --registry https://api.runx.ai",
+    "install_command": "pending after publish: runx add <owner>/spam-risk-reviewer@0.1.0",
+    "dogfood_command": "pending after publish: runx skill <owner>/spam-risk-reviewer@0.1.0 --json ...",
+    "runx_verify_verdict": "pending post-publish receipt"
+  },
+  "dogfood": {
+    "package": "./skills/spam-risk-reviewer",
+    "input": {
+      "campaign_draft": {
+        "from": "newsletter@example.com",
+        "subject": "June product notes for active customers",
+        "content_digest": "Monthly release notes and support office hours."
+      },
+      "list_metadata": {
+        "size": 12500,
+        "bounce_rate": 0.003,
+        "complaint_rate": 0.0002,
+        "freshness": 21
+      },
+      "sender_auth_posture": {
+        "spf_pass": true,
+        "dkim_pass": true,
+        "dmarc_pass": true,
+        "warm_up_days": 45
+      }
+    },
+    "command": "node skills/spam-risk-reviewer/run.mjs with RUNX_INPUT_CAMPAIGN_DRAFT, RUNX_INPUT_LIST_METADATA, RUNX_INPUT_SENDER_AUTH_POSTURE",
+    "local_runner_verdict": {
+      "risk_level": "pass",
+      "preflight_clear": true,
+      "blockers": []
+    },
+    "receipt_ref": "<pending post-publish dogfood receipt>",
+    "verify_verdict": "<pending>",
+    "harness_cases": [
+      {
+        "name": "low-risk-verified-sender",
+        "status": "expected-sealed; local harness blocked by receipt store before case execution"
+      },
+      {
+        "name": "high-risk-incomplete-auth-poor-list",
+        "status": "expected-sealed; local harness blocked by receipt store before case execution"
+      }
+    ]
+  },
+  "private_access_used": false,
+  "secrets_included": false
+}

--- a/skills/spam-risk-reviewer/references/report.md
+++ b/skills/spam-risk-reviewer/references/report.md
@@ -1,0 +1,84 @@
+# spam-risk-reviewer delivery prep report
+
+Package prepared for Frantic bounty #62. This is not a Frantic delivery yet:
+claim cooldown/identity, public PR, registry publish, hosted harness, and
+post-publish receipt still need the main worker.
+
+## What is included
+
+- `skills/spam-risk-reviewer/X.yaml`
+- `skills/spam-risk-reviewer/SKILL.md`
+- `skills/spam-risk-reviewer/run.mjs`
+- `skills/spam-risk-reviewer/fixtures/low-risk-verified-sender.json`
+- `skills/spam-risk-reviewer/fixtures/high-risk-incomplete-auth-poor-list.json`
+- `evidence.json`
+- `verification.json`
+- `report.md`
+
+## Local behavior
+
+The runner is read-only. It emits `send_risk_verdict` with:
+
+- `risk_level`
+- `preflight_clear`
+- `blockers`
+- `evidence_summary`
+
+It explicitly marks `public_send`, `operational_proposal`, authority minting,
+and domain-state writes as false. Non-clear verdicts route to
+`send-as.human_approval`; send-as remains the only owner of the `public_send`
+effect.
+
+## Verified commands
+
+Runx version:
+
+```powershell
+& "C:\Users\DFGS\Documents\自动化盈利\tools\runx-0.6.14\runx-0.6.14-x86_64-pc-windows-msvc\runx.exe" --version
+```
+
+Output:
+
+```text
+runx-cli 0.6.14
+```
+
+Inspect:
+
+```powershell
+& "C:\Users\DFGS\Documents\自动化盈利\tools\runx-0.6.14\runx-0.6.14-x86_64-pc-windows-msvc\runx.exe" skill inspect .\skills\spam-risk-reviewer --json
+```
+
+Status: passed.
+
+Harness attempted:
+
+```powershell
+$env:RUNX_RECEIPT_SIGN_KID="runx-demo-key"
+$env:RUNX_RECEIPT_SIGN_ISSUER_TYPE="hosted"
+$env:RUNX_RECEIPT_DIR="C:\tmp\runx-frantic-spam-receipts"
+& "C:\Users\DFGS\Documents\自动化盈利\tools\runx-0.6.14\runx-0.6.14-x86_64-pc-windows-msvc\runx.exe" harness .\skills\spam-risk-reviewer --json
+```
+
+Status: blocked on this Windows machine with `receipt store is unreadable:
+参数错误。 (os error 87)`.
+
+Direct runner dogfood passed for both fixtures. The low-risk fixture yields
+`risk_level: pass`, `preflight_clear: true`, `blockers: []`. The high-risk
+fixture yields `risk_level: hold`, `preflight_clear: false`, DKIM and list
+hygiene blockers, and `needs_human.lane: send-as.human_approval`.
+
+## Commands still required before Frantic delivery
+
+```bash
+runx login --provider github --for publish
+runx harness ./skills/spam-risk-reviewer
+runx registry publish ./skills/spam-risk-reviewer/SKILL.md --registry https://api.runx.ai
+runx add <owner>/spam-risk-reviewer@0.1.0
+runx skill <owner>/spam-risk-reviewer@0.1.0 --json ...
+runx verify --receipt <receipt.json> --json
+runx registry read <owner>/spam-risk-reviewer@0.1.0 --json
+```
+
+Then open a public PR against `runxhq/runx` and replace all placeholder artifact
+refs in `evidence.json`.

--- a/skills/spam-risk-reviewer/references/verification.json
+++ b/skills/spam-risk-reviewer/references/verification.json
@@ -1,0 +1,84 @@
+{
+  "schema": "frantic.runx_skill.verification.v1",
+  "package": "spam-risk-reviewer",
+  "version": "0.1.0",
+  "runx_binary": "C:\\Users\\DFGS\\Documents\\自动化盈利\\tools\\runx-0.6.14\\runx-0.6.14-x86_64-pc-windows-msvc\\runx.exe",
+  "commands": [
+    {
+      "name": "runx_version",
+      "command": "runx --version",
+      "status": "passed",
+      "output": "runx-cli 0.6.14"
+    },
+    {
+      "name": "skill_inspect",
+      "command": "runx skill inspect .\\skills\\spam-risk-reviewer --json",
+      "status": "passed",
+      "output_summary": {
+        "schema": "runx.skill.inspect.v1",
+        "status": "ok",
+        "name": "spam-risk-reviewer",
+        "version": "0.1.0",
+        "runners": [
+          "default"
+        ]
+      }
+    },
+    {
+      "name": "local_harness_without_signer",
+      "command": "runx harness .\\skills\\spam-risk-reviewer --json",
+      "status": "blocked",
+      "observed_error": "governed runtime receipt signing requires RUNX_RECEIPT_SIGN_KID, RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64, and RUNX_RECEIPT_SIGN_ISSUER_TYPE"
+    },
+    {
+      "name": "local_harness_with_demo_signer_and_ascii_receipt_dir",
+      "command": "RUNX_RECEIPT_SIGN_KID=runx-demo-key RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted RUNX_RECEIPT_DIR=C:\\tmp\\runx-frantic-spam-receipts runx harness .\\skills\\spam-risk-reviewer --json",
+      "status": "blocked_by_windows_receipt_store",
+      "observed_error": "receipt store is unreadable: 参数错误。 (os error 87)",
+      "case_names": [
+        "low-risk-verified-sender",
+        "high-risk-incomplete-auth-poor-list"
+      ]
+    },
+    {
+      "name": "runx_skill_local_attempt",
+      "command": "runx skill .\\skills\\spam-risk-reviewer --json --input-json ...",
+      "status": "blocked_by_windows_receipt_store",
+      "observed_error": "receipt store is unreadable: 参数错误。 (os error 87)"
+    },
+    {
+      "name": "direct_runner_low_risk",
+      "command": "node skills/spam-risk-reviewer/run.mjs with RUNX_INPUT_* JSON",
+      "status": "passed",
+      "output_summary": {
+        "schema": "send_risk_verdict",
+        "risk_level": "pass",
+        "preflight_clear": true,
+        "blockers": []
+      }
+    },
+    {
+      "name": "direct_runner_high_risk",
+      "command": "node skills/spam-risk-reviewer/run.mjs with high-risk fixture RUNX_INPUT_* JSON",
+      "status": "passed",
+      "output_summary": {
+        "schema": "send_risk_verdict",
+        "risk_level": "hold",
+        "preflight_clear": false,
+        "blockers_include": [
+          "DKIM authentication did not pass",
+          "bounce_rate 0.071 exceeds policy threshold 0.02"
+        ],
+        "needs_human_lane": "send-as.human_approval"
+      }
+    }
+  ],
+  "pending_for_delivery": [
+    "Frantic claim cooldown/identity state must be cleared by main agent.",
+    "Publish with verified GitHub owner that stars runxhq/runx.",
+    "Open public PR against runxhq/runx containing skills/spam-risk-reviewer/X.yaml, SKILL.md, fixtures, and harness evidence.",
+    "Run hosted registry harness after publish.",
+    "Run post-publish dogfood via runx skill <owner>/spam-risk-reviewer@0.1.0 --json and verify its receipt.",
+    "Replace placeholder artifact URLs and receipt_ref in evidence/report."
+  ]
+}

--- a/skills/spam-risk-reviewer/run.mjs
+++ b/skills/spam-risk-reviewer/run.mjs
@@ -1,0 +1,201 @@
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function asFiniteNumber(object, key, label) {
+  const value = Number(object?.[key]);
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, reason: `${label}.${key} is missing or not a non-negative number` };
+  }
+  return { ok: true, value };
+}
+
+function asBoolean(object, key, label) {
+  if (typeof object?.[key] !== "boolean") {
+    return { ok: false, reason: `${label}.${key} is missing or not boolean` };
+  }
+  return { ok: true, value: object[key] };
+}
+
+function flagContent(campaignDraft) {
+  const haystack = `${campaignDraft?.subject ?? ""} ${campaignDraft?.content_digest ?? ""}`.toLowerCase();
+  const flags = [];
+  if (/\burgent\b/.test(haystack)) flags.push("urgency_language");
+  if (/free money|guaranteed|risk[- ]?free|act now/.test(haystack)) flags.push("spammy_claim_language");
+  if (String(campaignDraft?.subject ?? "").length > 90) flags.push("long_subject");
+  return flags;
+}
+
+function evaluate({ campaignDraft, listMetadata, senderAuthPosture }) {
+  const blockers = [];
+  const refused = [];
+  const contentRiskFlags = flagContent(campaignDraft);
+  const thresholds = {
+    bounce_rate_max: 0.02,
+    complaint_rate_max: 0.001,
+    freshness_days_max: 90,
+    warm_up_days_min: 14,
+  };
+
+  if (!campaignDraft || typeof campaignDraft !== "object") refused.push("campaign_draft is required");
+  for (const key of ["from", "subject", "content_digest"]) {
+    if (!String(campaignDraft?.[key] ?? "").trim()) refused.push(`campaign_draft.${key} is required`);
+  }
+
+  for (const [key, human] of [
+    ["spf_pass", "SPF"],
+    ["dkim_pass", "DKIM"],
+    ["dmarc_pass", "DMARC"],
+  ]) {
+    const signal = asBoolean(senderAuthPosture, key, "sender_auth_posture");
+    if (!signal.ok) {
+      refused.push(signal.reason);
+    } else if (!signal.value) {
+      blockers.push(`${human} authentication did not pass`);
+    }
+  }
+
+  const warmUp = asFiniteNumber(senderAuthPosture, "warm_up_days", "sender_auth_posture");
+  if (!warmUp.ok) {
+    refused.push(warmUp.reason);
+  } else if (warmUp.value < thresholds.warm_up_days_min) {
+    blockers.push(`sender warm-up ${warmUp.value} days is below policy minimum ${thresholds.warm_up_days_min}`);
+  }
+
+  const size = asFiniteNumber(listMetadata, "size", "list_metadata");
+  const bounceRate = asFiniteNumber(listMetadata, "bounce_rate", "list_metadata");
+  const complaintRate = asFiniteNumber(listMetadata, "complaint_rate", "list_metadata");
+  const freshness = asFiniteNumber(listMetadata, "freshness", "list_metadata");
+  for (const metric of [size, bounceRate, complaintRate, freshness]) {
+    if (!metric.ok) refused.push(metric.reason);
+  }
+  if (bounceRate.ok && bounceRate.value > thresholds.bounce_rate_max) {
+    blockers.push(`bounce_rate ${bounceRate.value} exceeds policy threshold ${thresholds.bounce_rate_max}`);
+  }
+  if (complaintRate.ok && complaintRate.value > thresholds.complaint_rate_max) {
+    blockers.push(`complaint_rate ${complaintRate.value} exceeds policy threshold ${thresholds.complaint_rate_max}`);
+  }
+  if (freshness.ok && freshness.value > thresholds.freshness_days_max) {
+    blockers.push(`list freshness ${freshness.value} days exceeds policy max ${thresholds.freshness_days_max}`);
+  }
+
+  if (refused.length > 0) {
+    return {
+      risk_level: "hold",
+      preflight_clear: false,
+      blockers: refused,
+      needs_human: {
+        lane: "send-as.human_approval",
+        reason: "missing_or_ungrounded_input_signals",
+      },
+      refused: true,
+      thresholds,
+      contentRiskFlags,
+    };
+  }
+
+  if (blockers.length > 0) {
+    return {
+      risk_level: "hold",
+      preflight_clear: false,
+      blockers,
+      needs_human: {
+        lane: "send-as.human_approval",
+        reason: "send_preflight_blocked_by_spam_risk",
+      },
+      refused: false,
+      thresholds,
+      contentRiskFlags,
+    };
+  }
+
+  if (contentRiskFlags.length > 0) {
+    return {
+      risk_level: "review",
+      preflight_clear: false,
+      blockers: contentRiskFlags.map((flag) => `content risk flag: ${flag}`),
+      needs_human: {
+        lane: "send-as.human_approval",
+        reason: "borderline_content_risk",
+      },
+      refused: false,
+      thresholds,
+      contentRiskFlags,
+    };
+  }
+
+  return {
+    risk_level: "pass",
+    preflight_clear: true,
+    blockers: [],
+    needs_human: null,
+    refused: false,
+    thresholds,
+    contentRiskFlags,
+  };
+}
+
+function main() {
+  const campaignDraft = jsonInput("CAMPAIGN_DRAFT", {});
+  const listMetadata = jsonInput("LIST_METADATA", {});
+  const senderAuthPosture = jsonInput("SENDER_AUTH_POSTURE", {});
+  const verdict = evaluate({ campaignDraft, listMetadata, senderAuthPosture });
+
+  const output = {
+    schema: "send_risk_verdict",
+    package: "spam-risk-reviewer",
+    version: "0.1.0",
+    risk_level: verdict.risk_level,
+    preflight_clear: verdict.preflight_clear,
+    blockers: verdict.blockers,
+    evidence_summary: {
+      campaign_draft: {
+        from: campaignDraft.from ?? null,
+        subject: campaignDraft.subject ?? null,
+        content_digest: campaignDraft.content_digest ?? null,
+      },
+      authentication_signals_verified: {
+        spf_pass: senderAuthPosture.spf_pass ?? null,
+        dkim_pass: senderAuthPosture.dkim_pass ?? null,
+        dmarc_pass: senderAuthPosture.dmarc_pass ?? null,
+        warm_up_days: senderAuthPosture.warm_up_days ?? null,
+      },
+      list_hygiene_metrics_compared_to_policy: {
+        size: listMetadata.size ?? null,
+        bounce_rate: listMetadata.bounce_rate ?? null,
+        complaint_rate: listMetadata.complaint_rate ?? null,
+        freshness: listMetadata.freshness ?? null,
+        thresholds: verdict.thresholds,
+      },
+      content_risk_flags: verdict.contentRiskFlags,
+      refused: verdict.refused,
+    },
+    needs_human: verdict.needs_human,
+    dispatch_by_name: {
+      verdict_name: "send_risk_verdict",
+      downstream: "send-as",
+      preflight_binding: "send-as reads risk_level, preflight_clear, and blockers before public_send",
+    },
+    effects: {
+      public_send: false,
+      operational_proposal: false,
+      authority_minted: false,
+      domain_state_written: false,
+    },
+  };
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
Adds eight runx skills for marketing/support operations judgment flows:

- `spam-risk-reviewer`
- `renewal-risk-judge`
- `oncall-alert-triage`
- `deliverability-judge`
- `flaky-test-judge`
- `mandate-planner`
- `list-hygiene-judge`
- `escalation-judge`

Local verification on WSL with `runx-cli 0.6.14`:

```bash
export RUNX_RECEIPT_SIGN_KID=runx-demo-key
export RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
export RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted

for name in spam-risk-reviewer renewal-risk-judge oncall-alert-triage deliverability-judge flaky-test-judge mandate-planner list-hygiene-judge escalation-judge; do
  export RUNX_RECEIPT_DIR="/tmp/runx_repo_harness_$name"
  rm -rf "$RUNX_RECEIPT_DIR" && mkdir -p "$RUNX_RECEIPT_DIR"
  runx harness "skills/$name"
done
```

All eight harness runs passed locally.
