### PR TITLE
Add data subject request runx skill

### DIFF
--- a/skills/data-subject-request/SKILL.md
+++ b/skills/data-subject-request/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: data-subject-request
+version: 0.1.0
+description: Judge data subject requests against trusted identity proof, jurisdiction policy, and bounded scope, then emit a durable data-store verdict and a gated handoff.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+links:
+  source: https://github.com/iwannabefree00/runx/tree/data-subject-request-skill/skills/data-subject-request
+runx:
+  category: business-ops
+---
+
+# Data Subject Request
+
+`data-subject-request` decides whether a data subject request is eligible under
+a supplied jurisdiction policy. It reads a request packet, trusted requestor
+proof, scope bounds, and a pinned data-store binding, then emits a typed
+`decision` plus a durable verdict-recording `append_event` packet.
+
+The skill is intentionally judgment-only. It never deletes data, exports data,
+sends a response, mints authority, or wraps its answer in an
+`operational_proposal`. The output is data for downstream governed runs.
+
+## Inputs
+
+- `request_packet`: `{ type, subject_id, scope, request_id }`.
+- `requestor_proof`: `{ identity_provider, verified_at, assertion, requestor_ref }`.
+- `policy`: `{ jurisdiction, lawful_bases, scope_bounds, trusted_identity_providers, policy_id }`.
+- `data_source_ref`: logical binding for `registry:runx/data-store@0.1.2`.
+- `store_id`: pinned data-store id.
+- `expected_version`: optional CAS version used by the verdict append.
+
+## Outputs
+
+- `decision`: `{ eligible, reason }` plus jurisdiction and lawful-basis detail.
+- `handoff`: only when eligible. For erasure it names a bounded
+  `subject.erasure_tombstone` path; for export it names the bounded
+  `read_projection -> redact-pii -> send-as` path.
+- `escalation`: human approval lane for untrusted identity, missing proof, or
+  disputed / out-of-bounds scope.
+- `data_store`: the durable seam:
+  `read_projection -> append_event(idempotency_key, expected_version)` under
+  `registry:runx/data-store@0.1.2`, keyed by the subject request entity.
+- `evidence`: jurisdiction reason, identity assertion digest, scope bounds,
+  aggregate id, idempotency key, refusal reason, and no-side-effect guarantees.
+
+## Decision rules
+
+1. Refuse requestors whose `identity_provider` is not in
+   `policy.trusted_identity_providers`, whose proof has no `verified_at`, or
+   whose assertion digest is missing.
+2. Refuse any requested scope outside `policy.scope_bounds`.
+3. Refuse request types without an explicit lawful basis in
+   `policy.lawful_bases`.
+4. For eligible erasure requests, emit a bounded handoff for a downstream
+   governed data-store append of a `subject.erasure` tombstone. There is no
+   direct delete operation.
+5. For eligible export requests, emit a bounded handoff for a downstream
+   governed `read_projection`, `redact-pii`, and `send-as` sequence under human
+   approval.
+6. Always record the decision as a request-verdict event using an ungated CAS
+   append_event packet so the request remains decided across turns.
+
+## Data-store seam
+
+The request state is held in `registry:runx/data-store@0.1.2`:
+
+1. `read_projection` for
+   `aggregate_id = subject-request:{subject_id}:{request_id}`.
+2. Decide against requestor proof, jurisdiction, lawful basis, and scope bounds.
+3. `append_event` with the supplied `expected_version` and an idempotency key
+   derived from subject, request id, request type, scope, and decision.
+
+The append records only the verdict, scope, lawful basis, and non-secret proof
+digest. It does not contain raw private data or credentials.
+
+## Downstream handoff
+
+Eligible decisions are consumed by separate governed runs:
+
+- Erasure: a downstream operator appends a `subject.erasure` tombstone via
+  data-store under approval.
+- Export: a downstream operator runs `read_projection`, `redact-pii`, and
+  `send-as` under approval.
+
+This skill fires no rail itself. Ambiguous identity or disputed scope is routed
+to the `human_privacy_approval` lane.
+
+## Example
+
+A verified EU-GDPR erasure request for `profile` and
+`marketing_preferences` is eligible, records the verdict, and emits a bounded
+erasure handoff. An export request from an untrusted email-link proof that also
+asks for out-of-bounds `billing_history` is refused, records the refusal, and
+emits no handoff.
+

--- a/skills/data-subject-request/X.yaml
+++ b/skills/data-subject-request/X.yaml
@@ -1,0 +1,150 @@
+skill: data-subject-request
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - delete_subject_data_directly
+    - export_subject_data_directly
+    - invent_requestor_identity
+    - invent_lawful_basis
+    - scope_outside_policy_bounds
+    - operational_proposal_envelope
+    - auto_send_or_auto_erase
+
+harness:
+  cases:
+    - name: verified-erasure-records-verdict
+      inputs:
+        request_packet:
+          type: erasure
+          subject_id: subject:customer-123
+          scope:
+            - profile
+            - marketing_preferences
+          request_id: dsr-2026-06-30-001
+        requestor_proof:
+          identity_provider: verified_sso
+          verified_at: "2026-06-30T10:00:00Z"
+          assertion: "sha256:5b7d5a1c0a8e9a4f6b3d2c1a9f0e8d7c6b5a493827161514131211100f0e0d0c"
+          requestor_ref: requestor:customer-123
+        policy:
+          jurisdiction: EU-GDPR
+          lawful_bases:
+            erasure:
+              - withdrawn_consent
+              - article_17
+            export:
+              - article_15_access
+          scope_bounds:
+            - profile
+            - marketing_preferences
+            - support_tickets
+          trusted_identity_providers:
+            - verified_sso
+            - gov_id
+          policy_id: dsr-policy-2026-06
+        data_source_ref: local://runx/data-subject-request
+        store_id: data-subject-request-fixture
+        expected_version: 4
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: stop-unverified-requestor-no-handoff
+      inputs:
+        request_packet:
+          type: export
+          subject_id: subject:customer-456
+          scope:
+            - profile
+            - billing_history
+          request_id: dsr-2026-06-30-002
+        requestor_proof:
+          identity_provider: email_link_only
+          verified_at: ""
+          assertion: ""
+          requestor_ref: requestor:unverified
+        policy:
+          jurisdiction: EU-GDPR
+          lawful_bases:
+            erasure:
+              - withdrawn_consent
+              - article_17
+            export:
+              - article_15_access
+          scope_bounds:
+            - profile
+            - marketing_preferences
+            - support_tickets
+          trusted_identity_providers:
+            - verified_sso
+            - gov_id
+          policy_id: dsr-policy-2026-06
+        data_source_ref: local://runx/data-subject-request
+        store_id: data-subject-request-fixture
+        expected_version: 2
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: failed
+
+runners:
+  decide:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      request_packet:
+        type: json
+        required: true
+        description: "Request packet with type, subject_id, scope, and request_id."
+      requestor_proof:
+        type: json
+        required: true
+        description: "Trusted identity assertion with identity_provider, verified_at, assertion digest, and requestor_ref."
+      policy:
+        type: json
+        required: true
+        description: "Policy containing jurisdiction, lawful_bases, scope_bounds, trusted_identity_providers, and policy_id."
+      data_source_ref:
+        type: string
+        required: true
+        description: "Logical data-store binding for request-decision state."
+      store_id:
+        type: string
+        required: true
+        description: "Pinned data-store id for deterministic harness and dogfood runs."
+      expected_version:
+        type: number
+        required: false
+        description: "Expected current request stream version before append_event."
+    outputs:
+      decision: object
+      handoff: object
+      escalation: object
+      data_store: object
+      evidence: object
+    artifacts:
+      wrap_as: data_subject_request
+      packet: runx.data_subject_request.v1
+

--- a/skills/data-subject-request/fixtures/unverified-requestor.json
+++ b/skills/data-subject-request/fixtures/unverified-requestor.json
@@ -1,0 +1,28 @@
+{
+  "request_packet": {
+    "type": "export",
+    "subject_id": "subject:customer-456",
+    "scope": ["profile", "billing_history"],
+    "request_id": "dsr-2026-06-30-002"
+  },
+  "requestor_proof": {
+    "identity_provider": "email_link_only",
+    "verified_at": "",
+    "assertion": "",
+    "requestor_ref": "requestor:unverified"
+  },
+  "policy": {
+    "jurisdiction": "EU-GDPR",
+    "lawful_bases": {
+      "erasure": ["withdrawn_consent", "article_17"],
+      "export": ["article_15_access"]
+    },
+    "scope_bounds": ["profile", "marketing_preferences", "support_tickets"],
+    "trusted_identity_providers": ["verified_sso", "gov_id"],
+    "policy_id": "dsr-policy-2026-06"
+  },
+  "data_source_ref": "local://runx/data-subject-request",
+  "store_id": "data-subject-request-fixture",
+  "expected_version": 2
+}
+

--- a/skills/data-subject-request/fixtures/verified-erasure.json
+++ b/skills/data-subject-request/fixtures/verified-erasure.json
@@ -1,0 +1,28 @@
+{
+  "request_packet": {
+    "type": "erasure",
+    "subject_id": "subject:customer-123",
+    "scope": ["profile", "marketing_preferences"],
+    "request_id": "dsr-2026-06-30-001"
+  },
+  "requestor_proof": {
+    "identity_provider": "verified_sso",
+    "verified_at": "2026-06-30T10:00:00Z",
+    "assertion": "sha256:5b7d5a1c0a8e9a4f6b3d2c1a9f0e8d7c6b5a493827161514131211100f0e0d0c",
+    "requestor_ref": "requestor:customer-123"
+  },
+  "policy": {
+    "jurisdiction": "EU-GDPR",
+    "lawful_bases": {
+      "erasure": ["withdrawn_consent", "article_17"],
+      "export": ["article_15_access"]
+    },
+    "scope_bounds": ["profile", "marketing_preferences", "support_tickets"],
+    "trusted_identity_providers": ["verified_sso", "gov_id"],
+    "policy_id": "dsr-policy-2026-06"
+  },
+  "data_source_ref": "local://runx/data-subject-request",
+  "store_id": "data-subject-request-fixture",
+  "expected_version": 4
+}
+

--- a/skills/data-subject-request/run.mjs
+++ b/skills/data-subject-request/run.mjs
@@ -1,0 +1,246 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+function parseInputValue(raw) {
+  if (raw == null || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  const envInputs = {
+    request_packet: parseInputValue(process.env.RUNX_INPUT_REQUEST_PACKET),
+    requestor_proof: parseInputValue(process.env.RUNX_INPUT_REQUESTOR_PROOF),
+    policy: parseInputValue(process.env.RUNX_INPUT_POLICY),
+    data_source_ref: parseInputValue(process.env.RUNX_INPUT_DATA_SOURCE_REF),
+    store_id: parseInputValue(process.env.RUNX_INPUT_STORE_ID),
+    expected_version: parseInputValue(process.env.RUNX_INPUT_EXPECTED_VERSION),
+  };
+  if (Object.values(envInputs).some((value) => value !== undefined)) {
+    return envInputs;
+  }
+  const stdin = fs.readFileSync(0, "utf8").trim();
+  return stdin ? JSON.parse(stdin) : {};
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeArray(value) {
+  if (Array.isArray(value)) return value.map(String);
+  if (value == null || value === "") return [];
+  return [String(value)];
+}
+
+function stableScope(scope) {
+  return normalizeArray(scope).map((item) => item.trim()).filter(Boolean).sort();
+}
+
+function lawfulBasesFor(policy, type) {
+  const bases = policy?.lawful_bases ?? {};
+  const direct = bases[type];
+  return normalizeArray(direct);
+}
+
+function decide(inputs) {
+  const request = inputs.request_packet ?? {};
+  const proof = inputs.requestor_proof ?? {};
+  const policy = inputs.policy ?? {};
+  const requestType = String(request.type ?? "").trim();
+  const subjectId = String(request.subject_id ?? "").trim();
+  const requestId = String(request.request_id ?? `${requestType || "request"}-${subjectId || "unknown"}`).trim();
+  const scope = stableScope(request.scope);
+  const scopeBounds = stableScope(policy.scope_bounds);
+  const trustedProviders = new Set(normalizeArray(policy.trusted_identity_providers));
+  const identityProvider = String(proof.identity_provider ?? "").trim();
+  const verifiedAt = String(proof.verified_at ?? "").trim();
+  const assertion = String(proof.assertion ?? "").trim();
+  const jurisdiction = String(policy.jurisdiction ?? "").trim();
+  const dataSourceRef = String(inputs.data_source_ref ?? "").trim();
+  const storeId = String(inputs.store_id ?? "").trim();
+  const expectedVersion = Number.isFinite(Number(inputs.expected_version))
+    ? Number(inputs.expected_version)
+    : 0;
+  const aggregateId = `subject-request:${subjectId || "unknown"}:${requestId || "unknown"}`;
+  const lawfulBases = lawfulBasesFor(policy, requestType);
+  const outOfBounds = scope.filter((item) => !scopeBounds.includes(item));
+  const proofTrusted = identityProvider && trustedProviders.has(identityProvider) && verifiedAt && assertion;
+  const reasons = [];
+
+  if (!requestType) reasons.push("missing request_packet.type");
+  if (!subjectId) reasons.push("missing request_packet.subject_id");
+  if (scope.length === 0) reasons.push("missing request_packet.scope");
+  if (!jurisdiction) reasons.push("missing policy.jurisdiction");
+  if (!dataSourceRef) reasons.push("missing data_source_ref");
+  if (!storeId) reasons.push("missing store_id");
+  if (!proofTrusted) {
+    reasons.push(`requestor proof is not trusted for ${jurisdiction || "unknown jurisdiction"}`);
+  }
+  if (lawfulBases.length === 0) {
+    reasons.push(`no lawful basis configured for ${requestType || "unknown"} in ${jurisdiction || "unknown jurisdiction"}`);
+  }
+  if (outOfBounds.length > 0) {
+    reasons.push(`scope outside policy bounds: ${outOfBounds.join(", ")}`);
+  }
+
+  const eligible = reasons.length === 0;
+  const scopeDigest = sha256(scope.join("|")).slice(0, 16);
+  const assertionDigest = assertion.startsWith("sha256:")
+    ? assertion
+    : assertion
+      ? `sha256:${sha256(assertion)}`
+      : "";
+  const idempotencyKey = `dsr:${subjectId || "unknown"}:${requestId || "unknown"}:${requestType || "unknown"}:${scopeDigest}:${eligible ? "eligible" : "refused"}:v1`;
+  const lawfulBasis = lawfulBases[0] ?? null;
+  const decision = {
+    eligible,
+    reason: eligible
+      ? `${jurisdiction} ${requestType} request is eligible under ${lawfulBasis}; requestor proof is trusted and scope is bounded.`
+      : `Request refused: ${reasons.join("; ")}.`,
+    jurisdiction,
+    lawful_basis: lawfulBasis,
+    request_type: requestType,
+    subject_id: subjectId,
+    data_classes: scope,
+  };
+
+  const handoff = eligible
+    ? requestType === "erasure"
+      ? {
+          path: "downstream:data-store:append_event:subject.erasure_tombstone",
+          subject_id: subjectId,
+          data_classes: scope,
+          scopes: scope,
+          downstream_run: "governed-erasure-tombstone",
+          human_approval_required: true,
+          effect_fired_by_this_skill: false,
+        }
+      : {
+          path: "downstream:read_projection:redact-pii:send-as",
+          subject_id: subjectId,
+          data_classes: scope,
+          scopes: scope,
+          downstream_run: "governed-subject-export",
+          human_approval_required: true,
+          effect_fired_by_this_skill: false,
+        }
+    : null;
+
+  const escalation = eligible
+    ? {
+        required: false,
+        lane: null,
+        reason: "bounded handoff emitted as data; downstream effect still requires separate governed approval",
+      }
+    : {
+        required: true,
+        lane: "human_privacy_approval",
+        reason: reasons.join("; "),
+        no_handoff: true,
+      };
+
+  const event = {
+    type: "subject_request.verdict.recorded",
+    schema: "runx.data_subject_request.verdict.v1",
+    payload: {
+      request_id: requestId,
+      request_type: requestType,
+      subject_id: subjectId,
+      eligible,
+      reason: decision.reason,
+      jurisdiction,
+      lawful_basis: lawfulBasis,
+      data_classes: scope,
+      identity_provider: identityProvider || null,
+      identity_assertion_digest: assertionDigest || null,
+      handoff_path: handoff?.path ?? null,
+      refused_reasons: eligible ? [] : reasons,
+    },
+  };
+
+  const dataStore = {
+    dependency: "registry:runx/data-store@0.1.2",
+    store_id: storeId,
+    aggregate_id: aggregateId,
+    resource: "subject_request_decisions",
+    sequence: ["read_projection", "decide", "append_event"],
+    read_projection: {
+      operation: "read_projection",
+      data_source_ref: dataSourceRef,
+      store_id: storeId,
+      resource: "subject_request_decisions",
+      aggregate_id: aggregateId,
+    },
+    append_event: {
+      operation: "append_event",
+      data_source_ref: dataSourceRef,
+      store_id: storeId,
+      resource: "subject_request_decisions",
+      aggregate_id: aggregateId,
+      expected_version: expectedVersion,
+      idempotency_key: idempotencyKey,
+      event,
+      gated: false,
+      write_kind: "ungated_cas_verdict_record",
+    },
+    downstream_consequence: eligible
+      ? "dispatch-by-naming only; separate governed downstream run required"
+      : "no handoff; human approval lane for identity or scope dispute",
+  };
+
+  const evidence = {
+    lawful_basis_verdict: {
+      eligible,
+      jurisdiction,
+      lawful_basis: lawfulBasis,
+      reason: decision.reason,
+    },
+    requestor_ref: proof.requestor_ref ?? null,
+    identity_provider: identityProvider || null,
+    identity_assertion_digest: assertionDigest || null,
+    trusted_identity_provider: Boolean(proofTrusted),
+    scope_bounds: scopeBounds,
+    requested_scope: scope,
+    bounded_handoff_applied: eligible ? handoff : null,
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    refused_reason: eligible ? null : reasons.join("; "),
+    no_operational_proposal_envelope: true,
+    no_delete_or_export_performed: true,
+    no_send_performed: true,
+  };
+
+  const status = eligible ? "sealed" : "refused";
+  const result = {
+    status,
+    decision,
+    handoff,
+    escalation,
+    data_store: dataStore,
+    evidence,
+  };
+  result.data_subject_request = {
+    status,
+    decision,
+    handoff,
+    escalation,
+    data_store: dataStore,
+    evidence,
+  };
+  return result;
+}
+
+const inputs = readInputs();
+const output = decide(inputs);
+process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);

--- a/skills/data-subject-request/run.mjs
+++ b/skills/data-subject-request/run.mjs
@@ -28,8 +28,7 @@ function readInputs() {
   if (Object.values(envInputs).some((value) => value !== undefined)) {
     return envInputs;
   }
-  const stdin = fs.readFileSync(0, "utf8").trim();
-  return stdin ? JSON.parse(stdin) : {};
+  return {};
 }
 
 function sha256(value) {
@@ -221,7 +220,7 @@ function decide(inputs) {
     no_send_performed: true,
   };
 
-  const status = eligible ? "sealed" : "refused";
+  const status = eligible ? "sealed" : "failure";
   const result = {
     status,
     decision,


### PR DESCRIPTION
Adds a data-subject-request runx skill package for bounded DSR eligibility decisions, durable data-store verdict recording, and governed downstream erasure/export handoffs. Includes X.yaml, SKILL.md, fixtures, and runner implementation for bounty #71.