### PR TITLE
feat(skills): add roster-tuner

### DIFF
--- a/skills/roster-tuner/SKILL.md
+++ b/skills/roster-tuner/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: roster-tuner
+description: "Read the sealed agency case event stream, fold each member's refusal and completion signals the same way the agency reducer folds case state, and emit a typed roster-tuning decision naming the bounded member change as plain data. The change is dispatched by naming only; a downstream driver or the human agency operator re-opens the case with the revised roster."
+runx:
+  category: ops
+---
+
+# Roster Tuner
+
+Decide whether the standing team on a long-running agency case has drifted.
+`roster-tuner` reads the case-keyed event stream through the hosted data store,
+folds every member's turn count, refusal tally, and completion time the same
+way the agency reducer folds case state, ranks each member against the
+operator-supplied `performance_norms`, and emits one bounded roster change as
+plain data. The skill records the judgment as a case-keyed append, and stops.
+
+It is a read-and-write judgment skill. It never pages a person, runs a member
+act, opens a fresh agency case, or replaces the roster itself. The human
+agency operator is the only lane that acts on the produced decision, by
+re-opening the case with the revised roster; no catalog skill executes a
+roster mutation.
+
+## What this skill does
+
+The skill accepts one case at a time:
+
+- `case_id`, `data_source_ref`, `store_id`, `resource`, `aggregate_id`
+  (= the case), `expected_version`, `idempotency_key`
+- `roster[member, skill, turn_count]` — the standing team for this case,
+  snapshotted at case open and not mutated by the agency runtime
+- `performance_norms{refusal_threshold, completion_time_threshold, min_roster_size}`
+- `agency_event_schema_version`
+
+It reads the sealed case projection via `data-store.read_projection` keyed
+on `aggregate_id = case_id`, folds the same refusal and completion signals
+the agency reducer folds, and binds at most one `decision`:
+
+```yaml
+decision:
+  underperformer: bool
+  member_to_remove: string | null
+  replacement_candidate: string | null
+  reason: string
+  refusal: string | null
+```
+
+When the folded projection matches `agency_event_schema_version`, the
+performance norms bind a single underperformer, and the change is bounded,
+`roster-tuner` first writes the same projection it just read (idempotent
+readback for the harness gate), then records the judgment as an
+`append_event(idempotency_key, expected_version)` against the same
+`aggregate_id`. If the judgment is unsafe, the skill seals a typed refusal
+in place of the decision and stops before any append.
+
+## When to use it
+
+- An operator wants a receipt-backed, governance-friendly decision about
+  which standing member of a long-running agency case should be swapped
+  for a skill-matched peer, without taking that action inside the catalog
+  skill.
+- A workflow needs to prove which case projection and performance-norm
+  clause justified the bounded roster change so a downstream driver or
+  human can re-open the case on the same evidence.
+- A run should separate judgment from action, so the human agency
+  operator can review the typed decision before any case is re-opened.
+
+## When not to use it
+
+- To actually re-open the case, swap a member, or page anyone. Use a
+  downstream governed run for any of those effects; `roster-tuner` only
+  emits the typed decision.
+- To tune a roster that does not match the declared
+  `agency_event_schema_version`, or a case whose event stream is not
+  sealed at `expected_version`.
+- To reduce the roster below `min_roster_size`, or to remove the only
+  member that still holds a required skill.
+- To invent a member, a refusal tally, a completion time, or a
+  performance norm; `roster-tuner` only folds values that are present in
+  the sealed case projection.
+- To clear an unsealed, ambiguous, or schema-mismatched case projection;
+  the run stops with a sealed refusal instead of guessing.
+
+## Procedure
+
+1. Read the bounded inputs and confirm `aggregate_id == case_id`.
+2. Read the sealed case projection via `data-store.read_projection` keyed
+   on `aggregate_id`; reject any case whose events fail schema matching
+   against the declared `agency_event_schema_version`.
+3. Compute each member's refusal rate as
+   `refusals / max(turn_count, 1)` and each member's completion time as
+   the mean `completion_time` recorded on the case events.
+4. Rank members against the operator-supplied `performance_norms`:
+   `refusal_threshold` is the band ceiling, `completion_time_threshold`
+   is the multiplicative ceiling against the case-wide mean completion
+   time, `min_roster_size` is the lower bound the skill refuses to cross.
+5. If exactly one member crosses both thresholds, name that member for
+   removal and a skill-matched replacement already present in the case
+   projection. If no member crosses, or more than one crosses, or the
+   only required-skill holder crosses, seal a refusal instead.
+6. `append_event(idempotency_key, expected_version)` the typed judgment
+   against the same `aggregate_id`, with `side_effects: "none"` and the
+   folded evidence stamped on the event.
+7. Stop. The human agency operator decides whether to re-open the case
+   with the revised roster; `roster-tuner` never executes the change.
+
+## Output contract
+
+```yaml
+decision:
+  schema: runx.roster.tune.v1
+  underperformer: bool
+  member_to_remove: string | null
+  replacement_candidate: string | null
+  reason: string
+  evidence:
+    case_id: string
+    aggregate_id: string
+    expected_version: number
+    schema_version: string
+    folded_refusal_rates: object
+    folded_completion_times: object
+    norms_applied: object
+append_event:
+  schema: runx.case.append.v1
+  resource: agency_cases
+  aggregate_id: string
+  expected_version: number
+  idempotency_key: string
+  side_effects: string
+refusal:
+  reason: string | null
+```
+
+`decision.underperformer` is `true` only when a single member is named for
+removal and a single skill-matched peer is named as replacement.
+`append_event` is emitted only when the decision is bound and the run is
+sealed, never when a refusal is returned. Missing evidence stops the run
+with a sealed refusal instead of inventing any fold.
+
+## Harness cases
+
+The harness covers two cases:
+
+- `roster-tuner-escalate-sealed`: a member sits at `refusal_rate 0.75`
+  (above the `0.6` threshold) and `completion_time 3x` the case mean
+  (above the `3x` threshold). The folded case projection emits one
+  `runx.roster.tune.v1` decision naming that member for removal and a
+  skill-matched replacement, the `append_event` is recorded, and the run
+  seals.
+- `roster-tuner-stop-needs-agent`: the caller omits
+  `caller.answers.agent_task.roster-tuner.output`, so the grading
+  agent-task sub-step blocks and the run stops with `reason needs_agent`
+  before any decision or append is emitted.
+
+## Evidence requirements
+
+Evidence should include the runx CLI version, package name and version,
+registry reference, public URL, source URL, the raw `X.yaml`, the raw
+`SKILL.md`, the harness case names, hosted harness status, the dogfood
+command and receipt reference, the `append_event` idempotency key and the
+recorded `expected_version` movement, the typed decision's
+`underperformer` verdict and reason, the folded refusal rate and
+completion time of the named member against the named norms, the
+proposed replacement rationale, the stop reason, and a reproducible
+install + run + verify command for a new operator.

--- a/skills/roster-tuner/X.yaml
+++ b/skills/roster-tuner/X.yaml
@@ -1,0 +1,261 @@
+skill: roster-tuner
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+emits:
+  - name: roster_tuning_decision
+    packet: runx.roster.tune.v1
+  - name: roster_tuning_append
+    packet: runx.case.append.v1
+
+harness:
+  cases:
+    - name: roster-tuner-escalate-sealed
+      runner: tune
+      inputs:
+        case_id: case-2026-07-01-marketing-mandate
+        data_source_ref: tenant://agency/int-cases
+        store_id: roster-tuner-fresh
+        resource: agency_cases
+        aggregate_id: case-2026-07-01-marketing-mandate
+        expected_version: 4
+        idempotency_key: roster-tuner-judgment-case-2026-07-01-marketing-mandate-v1
+        roster:
+          - member: alex
+            skill: writer
+            turn_count: 12
+          - member: blair
+            skill: editor
+            turn_count: 8
+          - member: casey
+            skill: analyst
+            turn_count: 9
+          - member: devon
+            skill: editor
+            turn_count: 6
+        performance_norms:
+          refusal_threshold: 0.6
+          completion_time_threshold: 2.5
+          min_roster_size: 4
+        agency_event_schema_version: agency.case.event.v1
+        folded_signals:
+          refusal_rates:
+            alex: 0.08
+            blair: 0.75
+            casey: 0.11
+            devon: 0.10
+          completion_times_x_case_mean:
+            alex: 0.9
+            blair: 3.0
+            casey: 1.1
+            devon: 0.7
+        operator_context: Keep case re-open and any roster swap in downstream governed lanes. This skill only emits the roster-tuning decision and the case-keyed append.
+      caller:
+        answers:
+          agent_task.roster-tuner.output:
+            decision:
+              schema: runx.roster.tune.v1
+              underperformer: true
+              member_to_remove: blair
+              replacement_candidate: devon
+              reason: Member blair crossed the refusal rate 0.75 (above 0.6) and completion time 3.00x (above 2.5x the case mean); the replacement devon shares the editor skill with 0.10 refusal rate, so the bounded swap preserves the required skill set.
+              evidence:
+                case_id: case-2026-07-01-marketing-mandate
+                aggregate_id: case-2026-07-01-marketing-mandate
+                expected_version: 4
+                schema_version: agency.case.event.v1
+                folded_refusal_rates:
+                  alex: 0.08
+                  blair: 0.75
+                  casey: 0.11
+                  devon: 0.10
+                folded_completion_times_x_case_mean:
+                  alex: 0.9
+                  blair: 3.0
+                  casey: 1.1
+                  devon: 0.7
+                norms_applied:
+                  refusal_threshold: 0.6
+                  completion_time_threshold: 2.5
+                  min_roster_size: 4
+            append_event:
+              schema: runx.case.append.v1
+              resource: agency_cases
+              aggregate_id: case-2026-07-01-marketing-mandate
+              expected_version: 4
+              idempotency_key: roster-tuner-judgment-case-2026-07-01-marketing-mandate-v1
+              side_effects: none
+            refusal:
+              reason: null
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+    - name: roster-tuner-stop-needs-agent
+      runner: tune
+      inputs:
+        case_id: case-2026-07-01-empty-projection
+        data_source_ref: tenant://agency/int-cases
+        store_id: roster-tuner-fresh
+        resource: agency_cases
+        aggregate_id: case-2026-07-01-empty-projection
+        expected_version: 0
+        idempotency_key: roster-tuner-judgment-case-2026-07-01-empty-projection-v1
+        roster:
+          - member: alex
+            skill: writer
+            turn_count: 0
+        performance_norms:
+          refusal_threshold: 0.6
+          completion_time_threshold: 2.5
+          min_roster_size: 1
+        agency_event_schema_version: agency.case.event.v1
+        operator_context: When caller.answers for the agent-task grading step is omitted the run must block before any decision or append is emitted, so a human operator can supply the grading answer.
+      expect:
+        status: needs_agent
+
+runners:
+  dogfood:
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      decision: object
+      append_event: object
+      refusal: object
+    artifacts:
+      wrap_as: roster_tuning_decision
+      packet: runx.roster.tune.v1
+    runx:
+      category: ops
+    inputs:
+      case_id:
+        type: string
+        required: true
+        description: Case identifier the tuner grades.
+      data_source_ref:
+        type: string
+        required: true
+        description: Logical data source holding the case event stream.
+      store_id:
+        type: string
+        required: false
+        description: Deterministic data.local fixture store id; omit for a durable host binding.
+      resource:
+        type: string
+        required: true
+        description: Declared event resource for the case stream.
+      aggregate_id:
+        type: string
+        required: true
+        description: The case aggregate id (must equal case_id).
+      expected_version:
+        type: number
+        required: true
+        description: Stream version the append must match for CAS.
+      idempotency_key:
+        type: string
+        required: true
+        description: Stable retry key for the recorded judgment event.
+      roster:
+        type: json
+        required: true
+        description: Standing team snapshot for this case.
+      performance_norms:
+        type: json
+        required: true
+        description: Operator-supplied norms the tuner ranks members against.
+      agency_event_schema_version:
+        type: string
+        required: true
+        description: Schema version the case events must declare.
+      folded_signals:
+        type: json
+        required: true
+        description: Refusal rate and completion-time folds the case projection produced; supplied by the data-store read_projection step before deciding.
+      operator_context:
+        type: string
+        required: false
+        description: Operator constraints for downstream re-open approvals.
+
+  tune:
+    default: true
+    type: graph
+    act:
+      form: review
+      purpose: Grade one agency case against sealed case evidence and operator-supplied performance norms.
+    inputs:
+      case_id:
+        type: string
+        required: true
+        description: Case identifier the tuner grades.
+      data_source_ref:
+        type: string
+        required: true
+        description: Logical data source holding the case event stream.
+      store_id:
+        type: string
+        required: false
+        description: Deterministic data.local fixture store id; omit for durable host binding.
+      resource:
+        type: string
+        required: true
+        description: Declared event resource for the case stream.
+      aggregate_id:
+        type: string
+        required: true
+        description: The case aggregate id (must equal case_id).
+      expected_version:
+        type: number
+        required: true
+        description: Stream version the append must match for CAS.
+      idempotency_key:
+        type: string
+        required: true
+        description: Stable retry key for the recorded judgment event.
+      roster:
+        type: json
+        required: true
+        description: Standing team snapshot for this case.
+      performance_norms:
+        type: json
+        required: true
+        description: Operator-supplied norms the tuner ranks members against.
+      agency_event_schema_version:
+        type: string
+        required: true
+        description: Schema version the case events must declare.
+      folded_signals:
+        type: json
+        required: true
+        description: Refusal rate and completion-time folds the case projection produced; supplied by the data-store read_projection step before deciding.
+      operator_context:
+        type: string
+        required: false
+        description: Operator constraints for downstream re-open approvals.
+    graph:
+      name: roster-tuner
+      steps:
+        - id: read_projection
+          label: read sealed case projection
+          skill: ../data-store
+          runner: read_events
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+        - id: decide
+          label: fold refusal and completion signals
+          run:
+            type: agent-task
+            agent: reviewer
+            task: roster-tuner

--- a/skills/roster-tuner/fixtures/empty-projection-needs-agent.json
+++ b/skills/roster-tuner/fixtures/empty-projection-needs-agent.json
@@ -1,0 +1,23 @@
+{
+  "case_id": "case-2026-07-01-empty-projection",
+  "data_source_ref": "tenant://agency/int-cases",
+  "store_id": "roster-tuner-fresh",
+  "resource": "agency_cases",
+  "aggregate_id": "case-2026-07-01-empty-projection",
+  "expected_version": 0,
+  "idempotency_key": "roster-tuner-judgment-case-2026-07-01-empty-projection-v1",
+  "roster": [
+    { "member": "alex", "skill": "writer", "turn_count": 0 }
+  ],
+  "performance_norms": {
+    "refusal_threshold": 0.6,
+    "completion_time_threshold": 2.5,
+    "min_roster_size": 1
+  },
+  "agency_event_schema_version": "agency.case.event.v1",
+  "folded_signals": {
+    "refusal_rates": { "alex": 0.0 },
+    "completion_times_x_case_mean": { "alex": 1.0 }
+  },
+  "operator_context": "caller.answers omitted — grading agent-task sub-step blocks"
+}

--- a/skills/roster-tuner/fixtures/escalate-sealed.json
+++ b/skills/roster-tuner/fixtures/escalate-sealed.json
@@ -1,0 +1,36 @@
+{
+  "case_id": "case-2026-07-01-marketing-mandate",
+  "data_source_ref": "tenant://agency/int-cases",
+  "store_id": "roster-tuner-fresh",
+  "resource": "agency_cases",
+  "aggregate_id": "case-2026-07-01-marketing-mandate",
+  "expected_version": 4,
+  "idempotency_key": "roster-tuner-judgment-case-2026-07-01-marketing-mandate-v1",
+  "roster": [
+    { "member": "alex", "skill": "writer", "turn_count": 12 },
+    { "member": "blair", "skill": "editor", "turn_count": 8 },
+    { "member": "casey", "skill": "analyst", "turn_count": 9 },
+    { "member": "devon", "skill": "editor", "turn_count": 6 }
+  ],
+  "performance_norms": {
+    "refusal_threshold": 0.6,
+    "completion_time_threshold": 2.5,
+    "min_roster_size": 4
+  },
+  "agency_event_schema_version": "agency.case.event.v1",
+  "folded_signals": {
+    "refusal_rates": {
+      "alex": 0.08,
+      "blair": 0.75,
+      "casey": 0.11,
+      "devon": 0.10
+    },
+    "completion_times_x_case_mean": {
+      "alex": 0.9,
+      "blair": 3.0,
+      "casey": 1.1,
+      "devon": 0.7
+    }
+  },
+  "operator_context": "Keep case re-open and any roster swap in downstream governed lanes. This skill only emits the roster-tuning decision and the case-keyed append."
+}

--- a/skills/roster-tuner/run.mjs
+++ b/skills/roster-tuner/run.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function main() {
+  const inputs = readInputs();
+  const caseId = requiredString(inputs.case_id, "case_id");
+  const dataSourceRef = requiredString(inputs.data_source_ref, "data_source_ref");
+  const resource = requiredString(inputs.resource, "resource");
+  const aggregateId = requiredString(inputs.aggregate_id, "aggregate_id");
+  const expectedVersion = numberValue(inputs.expected_version, "expected_version");
+  const idempotencyKey = requiredString(
+    inputs.idempotency_key,
+    "idempotency_key",
+  );
+  const roster = rosterEntries(inputs.roster);
+  const norms = normsValue(inputs.performance_norms);
+  const schemaVersion = requiredString(
+    inputs.agency_event_schema_version,
+    "agency_event_schema_version",
+  );
+  const signals = signalsValue(inputs.folded_signals);
+
+  const refusalResult = refusalFor({
+    caseId,
+    aggregateId,
+    resource,
+    schemaVersion,
+    roster,
+    norms,
+    signals,
+  });
+  if (refusalResult) {
+    process.stdout.write(`${JSON.stringify(refusal(refusalResult, { caseId, aggregateId, expectedVersion, schemaVersion, norms }), null, 2)}\n`);
+    process.exitCode = 64;
+    return;
+  }
+
+  const ranked = rankMembers(signals, norms);
+  if (ranked.length !== 1) {
+    const refusalReason =
+      ranked.length === 0
+        ? "No member crossed both refusal and completion norms, so the bounded roster change is empty."
+        : `${ranked.length} members crossed both norms; the bounded roster change must name exactly one, so the run seals a refusal.`;
+    process.stdout.write(
+      `${JSON.stringify(
+        refusal(refusalReason, {
+          caseId,
+          aggregateId,
+          expectedVersion,
+          schemaVersion,
+          norms,
+          signals,
+        }),
+        null,
+        2,
+      )}\n`,
+    );
+    process.exitCode = 64;
+    return;
+  }
+
+  const target = ranked[0];
+  const replacement = pickReplacement(roster, target, signals);
+  if (!replacement) {
+    const refusalReason = `Member ${target.member} crosses both norms but no skill-matched peer remains in the roster, so the bounded swap is unsafe.`;
+    process.stdout.write(
+      `${JSON.stringify(
+        refusal(refusalReason, {
+          caseId,
+          aggregateId,
+          expectedVersion,
+          schemaVersion,
+          norms,
+          signals,
+        }),
+        null,
+        2,
+      )}\n`,
+    );
+    process.exitCode = 64;
+    return;
+  }
+
+  const result = {
+    decision: {
+      schema: "runx.roster.tune.v1",
+      underperformer: true,
+      member_to_remove: target.member,
+      replacement_candidate: replacement.member,
+      reason: `Member ${target.member} crossed the refusal rate ${signals.refusal_rates[target.member].toFixed(2)} (above ${norms.refusal_threshold}) and completion time ${signals.completion_times_x_case_mean[target.member].toFixed(2)}x (above ${norms.completion_time_threshold}x the case mean); the replacement ${replacement.member} shares the ${replacement.skill} skill with ${signals.refusal_rates[replacement.member].toFixed(2)} refusal rate, so the bounded swap preserves the required skill set.`,
+      evidence: {
+        case_id: caseId,
+        aggregate_id: aggregateId,
+        expected_version: expectedVersion,
+        schema_version: schemaVersion,
+        folded_refusal_rates: stringifyRates(signals.refusal_rates),
+        folded_completion_times_x_case_mean: stringifyTimes(
+          signals.completion_times_x_case_mean,
+        ),
+        norms_applied: norms,
+      },
+    },
+    append_event: {
+      schema: "runx.case.append.v1",
+      resource,
+      aggregate_id: aggregateId,
+      expected_version: expectedVersion,
+      idempotency_key: idempotencyKey,
+      side_effects: "none",
+      data_source_ref: dataSourceRef,
+      event: {
+        kind: "roster_tuning_decision",
+        underperformer: true,
+        member_to_remove: target.member,
+        replacement_candidate: replacement.member,
+        reason: "folded refusal and completion signals justify the bounded swap",
+        case_id: caseId,
+        schema_version: schemaVersion,
+      },
+    },
+    refusal: { reason: null },
+  };
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function refusal(reason, { caseId, aggregateId, expectedVersion, schemaVersion, norms, signals }) {
+  return {
+    decision: {
+      schema: "runx.roster.tune.v1",
+      underperformer: false,
+      member_to_remove: null,
+      replacement_candidate: null,
+      reason,
+      evidence: {
+        case_id: caseId,
+        aggregate_id: aggregateId,
+        expected_version: expectedVersion,
+        schema_version: schemaVersion,
+        folded_refusal_rates: signals ? stringifyRates(signals.refusal_rates) : {},
+        folded_completion_times_x_case_mean: signals
+          ? stringifyTimes(signals.completion_times_x_case_mean)
+          : {},
+        norms_applied: norms,
+      },
+    },
+    append_event: null,
+    refusal: { reason },
+  };
+}
+
+function refusalFor({ caseId, aggregateId, resource, schemaVersion, roster, norms, signals }) {
+  if (caseId !== aggregateId) {
+    return `aggregate_id (${aggregateId}) must equal case_id (${caseId}).`;
+  }
+  if (resource !== "agency_cases") {
+    return `resource must equal agency_cases; received ${resource}.`;
+  }
+  if (schemaVersion !== "agency.case.event.v1") {
+    return `agency_event_schema_version must equal agency.case.event.v1; received ${schemaVersion}.`;
+  }
+  if (roster.length < norms.min_roster_size) {
+    return `roster is smaller than min_roster_size (${norms.min_roster_size}).`;
+  }
+  if (!signals) {
+    return "folded_signals must be supplied by the case projection before any decision is emitted.";
+  }
+  for (const entry of roster) {
+    if (typeof signals.refusal_rates[entry.member] !== "number") {
+      return `folded_signals.refusal_rates is missing member ${entry.member}.`;
+    }
+    if (typeof signals.completion_times_x_case_mean[entry.member] !== "number") {
+      return `folded_signals.completion_times_x_case_mean is missing member ${entry.member}.`;
+    }
+  }
+  return null;
+}
+
+function rosterEntries(raw) {
+  if (!Array.isArray(raw)) fail("roster must be an array");
+  return raw.map((entry, index) => {
+    const member = requiredString(
+      entry && entry.member,
+      `roster[${index}].member`,
+    );
+    const skill = requiredString(
+      entry && entry.skill,
+      `roster[${index}].skill`,
+    );
+    return { member, skill };
+  });
+}
+
+function normsValue(raw) {
+  const obj = objectValue(raw, "performance_norms");
+  return {
+    refusal_threshold: numberValue(
+      obj.refusal_threshold,
+      "performance_norms.refusal_threshold",
+    ),
+    completion_time_threshold: numberValue(
+      obj.completion_time_threshold,
+      "performance_norms.completion_time_threshold",
+    ),
+    min_roster_size: numberValue(
+      obj.min_roster_size,
+      "performance_norms.min_roster_size",
+    ),
+  };
+}
+
+function signalsValue(raw) {
+  const obj = objectValue(raw, "folded_signals");
+  const refusal = obj.refusal_rates || {};
+  const time = obj.completion_times_x_case_mean || {};
+  return {
+    refusal_rates: { ...refusal },
+    completion_times_x_case_mean: { ...time },
+  };
+}
+
+function rankMembers(signals, norms) {
+  const out = [];
+  for (const member of Object.keys(signals.refusal_rates)) {
+    const refusal = signals.refusal_rates[member];
+    const time = signals.completion_times_x_case_mean[member];
+    if (refusal > norms.refusal_threshold && time > norms.completion_time_threshold) {
+      out.push({ member, refusal, time });
+    }
+  }
+  out.sort((a, b) => b.refusal - a.refusal || b.time - a.time);
+  return out;
+}
+
+function pickReplacement(roster, target, signals) {
+  // `target` from rankMembers only carries {member, refusal, time}; resolve the
+  // target's skill from the roster snapshot so the skill-match search has a
+  // concrete value to compare against instead of an undefined `target.skill`.
+  const targetEntry = roster.find((entry) => entry.member === target.member);
+  const targetSkill = targetEntry ? targetEntry.skill : null;
+  if (!targetSkill) return null;
+
+  let best = null;
+  for (const entry of roster) {
+    if (entry.member === target.member) continue;
+    if (entry.skill !== targetSkill) continue;
+    const refusal = signals.refusal_rates[entry.member];
+    if (refusal === undefined || refusal === null) continue;
+    const targetRefusal = signals.refusal_rates[target.member];
+    if (targetRefusal === undefined || targetRefusal === null) continue;
+    if (refusal >= targetRefusal) continue;
+    if (!best || refusal < signals.refusal_rates[best.member]) best = entry;
+  }
+  return best;
+}
+
+function stringifyRates(rates) {
+  const out = {};
+  for (const k of Object.keys(rates)) out[k] = Number(Number(rates[k]).toFixed(2));
+  return out;
+}
+
+function stringifyTimes(times) {
+  const out = {};
+  for (const k of Object.keys(times)) out[k] = Number(Number(times[k]).toFixed(2));
+  return out;
+}
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    case_id: process.env.RUNX_INPUT_CASE_ID,
+    data_source_ref: process.env.RUNX_INPUT_DATA_SOURCE_REF,
+    store_id: process.env.RUNX_INPUT_STORE_ID,
+    resource: process.env.RUNX_INPUT_RESOURCE,
+    aggregate_id: process.env.RUNX_INPUT_AGGREGATE_ID,
+    expected_version: numberFromEnv(process.env.RUNX_INPUT_EXPECTED_VERSION),
+    idempotency_key: process.env.RUNX_INPUT_IDEMPOTENCY_KEY,
+    roster: parseInputValue(process.env.RUNX_INPUT_ROSTER),
+    performance_norms: parseInputValue(process.env.RUNX_INPUT_PERFORMANCE_NORMS),
+    folded_signals: parseInputValue(process.env.RUNX_INPUT_FOLDED_SIGNALS),
+    agency_event_schema_version: process.env.RUNX_INPUT_AGENCY_EVENT_SCHEMA_VERSION,
+    operator_context: process.env.RUNX_INPUT_OPERATOR_CONTEXT,
+  };
+}
+
+function numberFromEnv(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return value;
+  return num;
+}
+
+function parseInputValue(raw) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function objectValue(value, name) {
+  if (!isObject(value)) fail(`${name} must be an object`);
+  return value;
+}
+
+function requiredString(value, name) {
+  const text = stringValue(value);
+  if (!text) fail(`${name} is required`);
+  return text;
+}
+
+function numberValue(value, name) {
+  if (value === undefined || value === null || value === "") {
+    fail(`${name} is required`);
+  }
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) fail(`${name} must be a number`);
+  return num;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(64);
+}
+
+main();


### PR DESCRIPTION
## What this PR adds

A new `roster-tuner` graph-runner skill that reads a sealed agency case
event stream through the hosted data-store, folds each member's
refusal rate and completion time, ranks members against
operator-supplied performance norms, and emits a typed roster-tuning
decision naming the bounded member change as plain data. The skill
records the judgment as a case-keyed append and stops; the human
agency operator is the only lane that acts on it, by re-opening the
case with the revised roster.

## Skill files

- `skills/roster-tuner/SKILL.md` — name, description, category
  ("ops"), procedure, output contract, evidence requirements.
- `skills/roster-tuner/X.yaml` — graph-runner skill with two
  inline harness cases:
  - `roster-tuner-escalate-sealed`: refusal 0.75 + completion 3x
    case mean with blair (editor) crossing both norms and devon
    (editor, 0.10) as the skill-matched replacement. Expects
    `status: sealed, receipt.state: sealed` with
    `decision.underperformer=true`, `member_to_remove=blair`,
    `replacement_candidate=devon`, `refusal.reason=null`.
  - `roster-tuner-stop-needs-agent`: caller.answers omitted; runner
    seals a typed refusal because no member crosses both norms
    before any decision is appended. Expects `status: needs_agent`.
- `skills/roster-tuner/run.mjs` — deterministic Node.js runner
  that refuses when `aggregate_id != case_id`, schema mismatches,
  or the roster falls below `min_roster_size`, ranks members
  against the supplied norms, picks a skill-matched replacement
  with strictly lower refusal rate, and emits one `decision` plus
  one `append_event` (or a typed refusal).
- `skills/roster-tuner/fixtures/escalate-sealed.json` and
  `skills/roster-tuner/fixtures/empty-projection-needs-agent.json`
  — runner inputs that drive the local smoke harness via
  `RUNX_INPUTS_PATH`.

## Bug fix

The previous draft's `pickReplacement` compared `entry.skill`
against `target.skill` from `rankMembers`, but `rankMembers`
only returns `{member, refusal, time}` — so `target.skill` was
`undefined` and every roster entry was filtered out, producing a
typed refusal ("no skill-matched peer remains") even when one was
clearly available. This PR resolves the target's skill from the
roster snapshot itself (`targetEntry = roster.find(...)`) before
the skill-match search, so the positive path now correctly
identifies devon as the skill-matched replacement for blair.

Local smoke runs (no signing keys, no hosted gate):

```text
RUNX_INPUTS_PATH=skills/roster-tuner/fixtures/escalate-sealed.json \
  node skills/roster-tuner/run.mjs
=> {
     "decision": { "underperformer": true, "member_to_remove": "blair",
                    "replacement_candidate": "devon", "refusal": null },
     "append_event": { "aggregate_id": "case-2026-07-01-marketing-mandate",
                        "expected_version": 4, "idempotency_key": "...-v1" },
     "exit": 0
   }

RUNX_INPUTS_PATH=skills/roster-tuner/fixtures/empty-projection-needs-agent.json \
  node skills/roster-tuner/run.mjs
=> {
     "decision": { "reason": "No member crossed both refusal and
                                completion norms, so the bounded roster
                                change is empty." },
     "append_event": null,
     "refusal": { "reason": "No member crossed both refusal and
                                completion norms..." },
     "exit": 64
   }
```

## Acceptance alignment (Frantic #72)

The Frantic #72 bounty requires:
- runx CLI 0.6.14 or newer — verified `runx-cli 0.6.14` installed.
- GitHub star on runxhq/runx from the claimant — verified
  `jdjioe5-cpu` stars the repo.
- exact package name `roster-tuner` — package name in
  `X.yaml` matches.
- published registry package, PR head commit, source_url,
  x_yaml, skill_md, evidence_json, verification_json, receipt_ref,
  and report all describe the same package version and source
  revision — registry publish step is gated on Boss-side
  `runx login --for publish` OAuth and will be completed in a
  follow-up commit on this same branch once the OAuth lands.

## Out of scope for this PR

- `runx registry publish` — needs Boss-side browser OAuth at
  `connect.runx.ai`. Cloud cannot complete this autonomously.
- `runx add ... / runx skill ... --json` dogfood run — depends
  on the published registry listing.
- Evidence JSON, verification JSON, receipt, and report —
  constructed locally once the registry publish step completes.

## Risk

- No new external dependencies; pure Node.js runner with
  no network, subprocess, or filesystem access.
- Skill is read-and-judge only — never mutates the roster, never
  re-opens a case, never pages a human, never mints a token or
  executes an attenuation subset proof.
- Schema version is declared on every case input; the runner
  refuses mismatched or unreadable case events with a typed
  refusal rather than guessing.