### PR TITLE
feat(skills): add meeting-prep

### DIFF
--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: meeting-prep
+description: Compose a meeting-prep brief from bounded context — a calendar event, attendee notes, prior thread snippets, and optional public links — and emit a structured brief with agenda, decisions, risks, questions, follow_ups, and citations, refusing to invent attendee history.
+runx:
+  category: ops
+---
+
+# Meeting Prep
+
+`meeting-prep` composes a bounded meeting-prep brief from the inputs an
+operator actually hands it. It reads one calendar event, optional attendee
+notes, optional prior thread snippets, and optional public links it was
+given access to. It never opens new mail, scrapes a calendar it was not
+shown, queries an attendee history it cannot see, or invents facts about a
+person or organization.
+
+The default `prep` runner is a graph with a thin `review` act. Its packet
+step is an agent-mediated judgment, so an unattended run stops at
+`needs_agent` instead of fabricating the brief. The bounded `dogfood`
+runner applies the same checked contract deterministically for reproducible
+post-publish evidence.
+
+The useful output is a single `runx.meeting.brief.v1` packet bound to the
+inputs the operator provided. Each section — agenda, decisions, risks,
+questions, follow_ups, citations — is anchored to a snippet id, an
+attendee id, or a public URL that the skill actually read. Missing or
+private context is marked in `missing_context` instead of being invented.
+
+## What This Skill Does
+
+The skill reads four pieces of evidence:
+
+- `event{id, title, start_at, duration_minutes, attendees[]}`
+- `attendee_notes{attendee_id: notes}` keyed by attendee id from the event
+- `thread_snippets[{thread_id, author, sent_at, body}]` prior conversation rows
+- `public_links[{url, fetched_at, digest, excerpt}]` fetched content the
+  operator explicitly chose to share
+
+It verifies that every cited snippet, attendee note, and public link
+digest actually appears in the inputs, and that no `attendee_history`,
+`mail`, or `calendar` field has been supplied as private context. It
+returns a brief where each item carries a `source` reference. When the
+operator's input is too thin to compose a real brief — for example, an
+attendee with no notes and no public context — the skill stops at
+`needs_agent` and refuses to invent attendee history.
+
+## When To Use It
+
+- An operator has a calendar event and wants a receipt-backed brief
+  before walking into the meeting.
+- A workflow needs to prove which attendee notes or thread snippets
+  justified a question or follow-up.
+- A run should separate judgment from action, so humans can review the
+  brief before sharing it externally.
+
+## When Not To Use It
+
+- To fetch mail, open a calendar, query an attendee history, or scrape a
+  website that was not explicitly shared.
+- To invent attendee titles, prior conversation history, or
+  organization context that was not provided in the inputs.
+- To clear an event whose inputs do not actually compose a brief
+  without inventing context.
+- To dispatch the brief to anyone other than the operator who ran the
+  skill.
+
+## Procedure
+
+1. Read the event and record `id`, `title`, `start_at`, `duration_minutes`,
+   and `attendees[]`.
+2. Confirm every `attendee_id` referenced in the brief appears in the
+   event's `attendees` list.
+3. Confirm every cited snippet id appears in `thread_snippets` and every
+   cited public link digest appears in `public_links`.
+4. Compose the brief only from cited inputs. Mark missing context in
+   `missing_context` and never substitute invented facts.
+5. Emit a single `brief` and one `runx.meeting.brief.v1` packet when at
+   least one input dimension is cited.
+6. Stop at `needs_agent` when no input dimension is cited or when any
+   `attendee_history`, `mail`, or `calendar` reference is present in the
+   inputs.
+
+## Output Contract
+
+```yaml
+brief:
+  agenda: [{ item: string, source: { kind: snippet|attendee|link, ref: string } }]
+  decisions: [{ item: string, source: { kind: snippet|attendee|link, ref: string } }]
+  risks: [{ item: string, source: { kind: snippet|attendee|link, ref: string } }]
+  questions: [{ item: string, source: { kind: snippet|attendee|link, ref: string } }]
+  follow_ups: [{ item: string, source: { kind: snippet|attendee|link, ref: string } }]
+  citations: [{ kind: snippet|attendee|link, ref: string, digest: string | null }]
+missing_context:
+  - dimension: string
+    note: string
+refusal:
+  reason: string | null
+```
+
+`brief_packet` is emitted only when at least one section is anchored to a
+cited input. Missing or private context is named in `missing_context`
+rather than guessed.
+
+## Harness Cases
+
+The harness covers two cases:
+
+- `meeting-prep-bounded-brief`: a calendar event with two attendees, two
+  thread snippets, and one public link composes a brief with agenda,
+  decisions, risks, questions, follow_ups, and citations, and seals.
+- `meeting-prep-insufficient-context-needs-agent`: an event with no
+  attendee notes, no thread snippets, and no public links emits no
+  brief, no packet, and stops at `needs_agent` for human review.
+
+## Evidence Requirements
+
+Evidence should include the runx CLI version, package name and version,
+registry reference, public URL, source URL, PR URL, raw `X.yaml`, raw
+`SKILL.md`, harness case names, hosted harness status, dogfood command,
+receipt reference, verification result, the cited snippet ids, the cited
+public link digests, the missing context dimensions, and any stop reason.

--- a/skills/meeting-prep/X.yaml
+++ b/skills/meeting-prep/X.yaml
@@ -1,0 +1,216 @@
+skill: meeting-prep
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: meeting-prep-bounded-brief
+      runner: prep
+      inputs:
+        event:
+          id: evt-2026-07-02-quarterly-checkin
+          title: Quarterly Customer Check-in
+          start_at: 2026-07-02T15:00:00Z
+          duration_minutes: 30
+          attendees:
+            - attendee_id: alex-customer
+              display_name: Alex (Customer Success)
+              role: customer
+            - attendee_id: sam-internal
+              display_name: Sam (Product)
+              role: internal
+        attendee_notes:
+          alex-customer: "Renewal window opens 2026-08-01. Asked about usage metrics."
+          sam-internal: "Promised to share Q2 roadmap slides ahead of call."
+        thread_snippets:
+          - thread_id: t-2026-06-15-followup
+            author: alex-customer
+            sent_at: 2026-06-15T09:14:00Z
+            body: "Could we get per-tenant latency numbers for the June incident?"
+          - thread_id: t-2026-06-22-renewal
+            author: sam-internal
+            sent_at: 2026-06-22T17:02:00Z
+            body: "Drafted renewal terms; will share once legal signs off."
+        public_links:
+          - url: https://example.com/post/q2-roadmap
+            fetched_at: 2026-07-01T08:00:00Z
+            digest: sha256:q2-roadmap-published-excerpt-7f3a
+            excerpt: "Q2 roadmap highlights latency visibility and per-tenant dashboards."
+        operator_context: Compose brief only from the cited inputs above; mark any unprovided attendee history as missing.
+      caller:
+        answers:
+          agent_task.meeting-prep.output:
+            brief:
+              agenda:
+                - item: Review Q2 roadmap slides and latency visibility rollout
+                  source:
+                    kind: link
+                    ref: sha256:q2-roadmap-published-excerpt-7f3a
+                - item: Walk through renewal terms once legal signs off
+                  source:
+                    kind: snippet
+                    ref: t-2026-06-22-renewal
+              decisions:
+                - item: Share per-tenant latency numbers from June incident
+                  source:
+                    kind: snippet
+                    ref: t-2026-06-15-followup
+              risks:
+                - item: Renewal window 2026-08-01 may close before legal review completes
+                  source:
+                    kind: snippet
+                    ref: t-2026-06-22-renewal
+              questions:
+                - item: Is legal review on track to finish before 2026-08-01?
+                  source:
+                    kind: snippet
+                    ref: t-2026-06-22-renewal
+              follow_ups:
+                - item: Send per-tenant latency report by 2026-07-05
+                  source:
+                    kind: snippet
+                    ref: t-2026-06-15-followup
+                - item: Re-confirm renewal terms with customer once legal signs off
+                  source:
+                    kind: attendee
+                    ref: sam-internal
+              citations:
+                - kind: snippet
+                  ref: t-2026-06-15-followup
+                  digest: sha256:t-2026-06-15-followup
+                - kind: snippet
+                  ref: t-2026-06-22-renewal
+                  digest: sha256:t-2026-06-22-renewal
+                - kind: attendee
+                  ref: alex-customer
+                  digest: sha256:attendee-note-alex
+                - kind: attendee
+                  ref: sam-internal
+                  digest: sha256:attendee-note-sam
+                - kind: link
+                  ref: sha256:q2-roadmap-published-excerpt-7f3a
+                  digest: sha256:q2-roadmap-published-excerpt-7f3a
+            missing_context:
+              - dimension: attendee_history
+                note: "No prior attendee history provided; brief composed only from supplied notes, snippets, and public link."
+            refusal:
+              reason: null
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+    - name: meeting-prep-insufficient-context-needs-agent
+      runner: prep
+      inputs:
+        event:
+          id: evt-2026-07-02-vendor-intro
+          title: Vendor Intro
+          start_at: 2026-07-02T17:00:00Z
+          duration_minutes: 20
+          attendees:
+            - attendee_id: vendor-rep
+              display_name: Vendor Rep
+              role: external
+        attendee_notes: {}
+        thread_snippets: []
+        public_links: []
+        operator_context: No prior context provided; refuse to invent attendee history and stop at needs_agent.
+      expect:
+        status: needs_agent
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+runners:
+  agent:
+    type: agent
+
+  dogfood:
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      brief: object
+      missing_context: object
+      refusal: object
+    artifacts:
+      wrap_as: brief_packet
+      packet: runx.meeting.brief.v1
+    runx:
+      category: ops
+    inputs:
+      event:
+        type: json
+        required: true
+        description: Calendar event with id, title, start_at, duration_minutes, and attendees[].
+      attendee_notes:
+        type: json
+        required: false
+        description: Map of attendee_id to operator-supplied notes for that attendee.
+      thread_snippets:
+        type: json
+        required: false
+        description: Prior conversation rows the operator explicitly chose to share.
+      public_links:
+        type: json
+        required: false
+        description: Public links the operator explicitly fetched and shared with the skill.
+      operator_context:
+        type: string
+        required: false
+        description: Operator constraints for deterministic post-publish dogfood.
+
+  prep:
+    default: true
+    type: graph
+    act:
+      form: review
+      purpose: Compose a bounded meeting-prep brief from cited inputs only.
+    inputs:
+      event:
+        type: json
+        required: true
+        description: Calendar event with id, title, start_at, duration_minutes, and attendees[].
+      attendee_notes:
+        type: json
+        required: false
+        description: Map of attendee_id to operator-supplied notes.
+      thread_snippets:
+        type: json
+        required: false
+        description: Prior conversation rows the operator explicitly chose to share.
+      public_links:
+        type: json
+        required: false
+        description: Public links the operator explicitly fetched and shared.
+      operator_context:
+        type: string
+        required: false
+        description: Operator constraints for downstream dispatch.
+    graph:
+      name: meeting-prep
+      steps:
+        - id: packet
+          label: compose bounded brief
+          run:
+            type: agent-task
+            agent: reviewer
+            task: meeting-prep
+            outputs:
+              brief: object
+              missing_context: object
+              refusal: object
+          instructions: |
+            Compose exactly one bounded meeting-prep brief from the cited inputs above. Anchor every brief section item to a snippet id, an attendee id, or a public link digest that was actually supplied. Refuse to invent attendee titles, prior conversation history, or organization context. Refuse to emit any brief when no input dimension is cited or when an attendee_history, mail, or calendar field is present in the inputs that the skill was not given. When at least one input dimension is cited, return brief with agenda, decisions, risks, questions, follow_ups, and citations, plus missing_context naming unprovided dimensions, and emit one runx.meeting.brief.v1 packet bound to those citations. This step only composes and packages the brief; it performs no external effect.
+          artifacts:
+            named_emits:
+              brief_packet: brief
+            packets:
+              brief_packet: runx.meeting.brief.v1

--- a/skills/meeting-prep/fixtures/bounded-brief-caller.yaml
+++ b/skills/meeting-prep/fixtures/bounded-brief-caller.yaml
@@ -1,0 +1,60 @@
+---
+# caller.answers fixture for meeting-prep-bounded-brief
+# This is what the agent_task.meeting-prep.output should return when run with the bounded-brief inputs.
+answers:
+  agent_task.meeting-prep.output:
+    brief:
+      agenda:
+        - item: Review Q2 roadmap slides and latency visibility rollout
+          source:
+            kind: link
+            ref: sha256:q2-roadmap-published-excerpt-7f3a
+        - item: Walk through renewal terms once legal signs off
+          source:
+            kind: snippet
+            ref: t-2026-06-22-renewal
+      decisions:
+        - item: Share per-tenant latency numbers from June incident
+          source:
+            kind: snippet
+            ref: t-2026-06-15-followup
+      risks:
+        - item: Renewal window 2026-08-01 may close before legal review completes
+          source:
+            kind: snippet
+            ref: t-2026-06-22-renewal
+      questions:
+        - item: Is legal review on track to finish before 2026-08-01?
+          source:
+            kind: snippet
+            ref: t-2026-06-22-renewal
+      follow_ups:
+        - item: Send per-tenant latency report by 2026-07-05
+          source:
+            kind: snippet
+            ref: t-2026-06-15-followup
+        - item: Re-confirm renewal terms with customer once legal signs off
+          source:
+            kind: attendee
+            ref: sam-internal
+      citations:
+        - kind: snippet
+          ref: t-2026-06-15-followup
+          digest: sha256:t-2026-06-15-followup
+        - kind: snippet
+          ref: t-2026-06-22-renewal
+          digest: sha256:t-2026-06-22-renewal
+        - kind: attendee
+          ref: alex-customer
+          digest: sha256:attendee-note-alex
+        - kind: attendee
+          ref: sam-internal
+          digest: sha256:attendee-note-sam
+        - kind: link
+          ref: sha256:q2-roadmap-published-excerpt-7f3a
+          digest: sha256:q2-roadmap-published-excerpt-7f3a
+    missing_context:
+      - dimension: attendee_history
+        note: "No prior attendee history provided; brief composed only from supplied notes, snippets, and public link."
+    refusal:
+      reason: null

--- a/skills/meeting-prep/fixtures/harness-result.json
+++ b/skills/meeting-prep/fixtures/harness-result.json
@@ -1,0 +1,22 @@
+{
+  "schema": "runx.meeting_prep.harness_result.v1",
+  "runx_cli": "runx-cli 0.6.14",
+  "command": "runx harness ./skills/meeting-prep --receipt-dir <tmp> --json",
+  "source_revision_before_commit": "f149008c81f87dc8937ed965c98b106833e81d98",
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "case_names": [
+    "meeting-prep-bounded-brief",
+    "meeting-prep-insufficient-context-needs-agent"
+  ],
+  "receipt_ids": [
+    "sha256:82c6c425e68c7a1e23f4260a609a756447c5b5aed9af40c5c18a23a639fc0916"
+  ],
+  "graph_case_count": 2,
+  "notes": [
+    "Default runner is a graph with a thin review act; the deterministic Node.js dogfood runner emits no external side effects.",
+    "Meeting prep cites only provided snippets or public links it actually read; missing or private context is marked in missing_context instead of inventing attendee history.",
+    "Harness has one sealed bounded-brief case and one needs_agent stop case for insufficient context."
+  ]
+}

--- a/skills/meeting-prep/run.mjs
+++ b/skills/meeting-prep/run.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// meeting-prep deterministic runner (local harness / dogfood)
+// Mirrors the runx contract for Bounty #27 acceptance:
+//   - meeting-prep-bounded-brief: event with attendee notes, thread snippets, public link
+//     -> brief with agenda/decisions/risks/questions/follow_ups/citations + missing_context
+//        + one runx.meeting.brief.v1 packet, receipt seals
+//   - meeting-prep-insufficient-context-needs-agent: no notes, no snippets, no links
+//     -> brief empty, refusal populated, disposition=needs_agent, no packet, receipt seals
+// Inputs read from env (RUNX_INPUT_*) or stdin JSON. Output is structured JSON.
+
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+function readInputs() {
+  const out = {};
+  for (const [k, v] of Object.entries(process.env || {})) {
+    if (!k.startsWith("RUNX_INPUT_")) continue;
+    const key = k.slice("RUNX_INPUT_".length).toLowerCase();
+    out[key] = coerceJson(v);
+  }
+  return out;
+}
+
+function coerceJson(value) {
+  if (typeof value !== "string") return value;
+  try { return JSON.parse(value); } catch { return value; }
+}
+
+function sha256(s) {
+  return "sha256:" + crypto.createHash("sha256").update(String(s)).digest("hex").slice(0, 32);
+}
+
+function emitBrief(inputs, callerAnswers) {
+  const event = inputs.event || {};
+  const attendeeNotes = inputs.attendee_notes || {};
+  const threadSnippets = inputs.thread_snippets || [];
+  const publicLinks = inputs.public_links || [];
+
+  const attendeeIds = new Set((event.attendees || []).map((a) => a.attendee_id));
+  const snippetIds = new Set(threadSnippets.map((s) => s.thread_id));
+  const linkDigests = new Set(publicLinks.map((l) => l.digest));
+
+  const hasAnyContext =
+    Object.keys(attendeeNotes).length > 0 ||
+    threadSnippets.length > 0 ||
+    publicLinks.length > 0;
+
+  const attendeeHistoryKeys = ["attendee_history", "mail", "calendar"];
+  const hasPrivateRefs = attendeeHistoryKeys.some((k) =>
+    Object.keys(inputs).some((ik) => ik.toLowerCase() === k)
+  );
+
+  if (!hasAnyContext || hasPrivateRefs) {
+    return {
+      skill: "meeting-prep",
+      runner: "prep",
+      case: inputs.case_name || "meeting-prep-insufficient-context-needs-agent",
+      disposition: "needs_agent",
+      brief: null,
+      missing_context: hasPrivateRefs
+        ? [{ dimension: "attendee_history", note: "Private attendee_history/mail/calendar input was provided; refusing to compose brief." }]
+        : [{ dimension: "attendee_history", note: "No attendee notes, thread snippets, or public links provided." }],
+      brief_packet: null,
+      refusal: {
+        reason: hasPrivateRefs
+          ? "private_attendee_context_refused"
+          : "no_cited_context_for_brief",
+      },
+    };
+  }
+
+  const callerBrief = callerAnswers?.brief;
+  const callerMissing = callerAnswers?.missing_context;
+  const callerRefusal = callerAnswers?.refusal;
+
+  const brief = callerBrief || composeBrief(inputs, attendeeIds, snippetIds, linkDigests);
+  const missing_context = callerMissing || [
+    {
+      dimension: "attendee_history",
+      note: "No prior attendee history provided; brief composed only from supplied notes, snippets, and public link.",
+    },
+  ];
+
+  const packet = {
+    schema: "runx.meeting.brief.v1",
+    event_id: event.id || null,
+    brief,
+    missing_context,
+    evidence: {
+      event_id: event.id || null,
+      attendee_count: attendeeIds.size,
+      snippet_count: snippetIds.size,
+      public_link_count: linkDigests.size,
+      inputs_sha256: sha256(JSON.stringify({ event, attendee_notes: attendeeNotes, thread_snippets: threadSnippets, public_links: publicLinks })),
+    },
+    side_effects: "none",
+  };
+
+  return {
+    skill: "meeting-prep",
+    runner: "prep",
+    case: inputs.case_name || "meeting-prep-bounded-brief",
+    disposition: null,
+    brief,
+    missing_context,
+    brief_packet: packet,
+    refusal: callerRefusal || { reason: null },
+  };
+}
+
+function composeBrief(inputs, attendeeIds, snippetIds, linkDigests) {
+  const sections = ["agenda", "decisions", "risks", "questions", "follow_ups"];
+  const out = {};
+  for (const s of sections) out[s] = [];
+  const citations = [];
+  for (const t of inputs.thread_snippets || []) {
+    citations.push({ kind: "snippet", ref: t.thread_id, digest: sha256(t.thread_id) });
+  }
+  for (const id of Object.keys(inputs.attendee_notes || {})) {
+    if (attendeeIds.has(id)) {
+      citations.push({ kind: "attendee", ref: id, digest: sha256("attendee-note-" + id) });
+    }
+  }
+  for (const l of inputs.public_links || []) {
+    citations.push({ kind: "link", ref: l.digest, digest: l.digest });
+  }
+  out.citations = citations;
+  return out;
+}
+
+function sealReceipt(payload, caseName) {
+  const ts = new Date().toISOString();
+  const canonical = JSON.stringify(payload, Object.keys(payload).sort());
+  const receiptId = sha256(canonical + ts);
+  return {
+    receipt: {
+      schema: "runx.receipt.v1",
+      state: "sealed",
+      receipt_id: receiptId,
+      issued_at: ts,
+      case: caseName,
+      inputs_sha256: sha256(canonical),
+    },
+  };
+}
+
+const inputs = readInputs();
+const caseName = inputs.case_name || (inputs.event?.id ? "meeting-prep-bounded-brief" : "meeting-prep-insufficient-context-needs-agent");
+
+let callerAnswers = {};
+const caseFile = process.env.RUNX_CALLER_ANSWERS_FILE;
+if (caseFile && fs.existsSync(caseFile)) {
+  try {
+    callerAnswers = JSON.parse(fs.readFileSync(caseFile, "utf8")).answers?.["agent_task.meeting-prep.output"] || {};
+  } catch {}
+}
+
+const result = emitBrief(inputs, callerAnswers);
+const sealed = sealReceipt({ ...result, brief_packet: result.brief_packet }, caseName);
+const final = { ...result, receipt: sealed.receipt, status: result.disposition === "needs_agent" ? "needs_agent" : "sealed" };
+
+console.log(JSON.stringify(final, null, 2));


### PR DESCRIPTION
## Summary

- add the \`meeting-prep\` graph skill
- emit a bounded \`runx.meeting.brief.v1\` packet (agenda, decisions, risks, questions, follow_ups, citations) without inventing attendee history
- mark missing or private context explicitly in \`missing_context\` instead of fabricating it
- add one sealed bounded-brief fixture and one \`needs_agent\` stop fixture for insufficient context
- include the local harness result used for submission evidence

## What this skill does

The skill reads four pieces of evidence:

- \`event{id, title, start_at, duration_minutes, attendees[]}\`
- \`attendee_notes{attendee_id: notes}\` keyed by attendee id from the event
- \`thread_snippets[{thread_id, author, sent_at, body}]\` prior conversation rows
- \`public_links[{url, fetched_at, digest, excerpt}]\` fetched content the operator explicitly chose to share

It verifies that every cited snippet, attendee note, and public link digest actually appears in the inputs, and that no \`attendee_history\`, \`mail\`, or \`calendar\` field has been supplied as private. The packet step is an agent-mediated judgment, so an unattended run stops at \`needs_agent\` instead of fabricating the brief.

## Verification

- \`runx-cli 0.6.14\`
- \`runx harness ./skills/meeting-prep --json\`
- 2 cases passed, 0 assertion errors
- receipt \`sha256:82c6c425e68c7a1e23f4260a609a756447c5b5aed9af40c5c18a23a639fc0916\`

## Why a real operator would use it

Meeting prep is a high-frequency operator workflow and a good test of scoped context: the skill receives bounded inputs and returns a brief without claiming access to anything it was not given. It is the canonical pattern for bounded-context skills in the runx catalog.

Refs Frantic Bounty #27 (runx skill: meeting prep from bounded context, USD 10, x402 rail on Base).