### PR TITLE
Add escalation-judge skill

### DIFF
--- a/skills/escalation-judge/SKILL.md
+++ b/skills/escalation-judge/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: escalation-judge
+description: Decide when a support thread crosses a named escalation policy threshold, record the case, and emit one governed escalation packet without sending or posting.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 10
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  triage_packet:
+    type: json
+    required: true
+    description: Support triage classification with classification, severity, and confidence.
+  thread_body:
+    type: string
+    required: true
+    description: Support thread text used only to match policy-declared churn signals.
+  policy_rules:
+    type: json
+    required: true
+    description: Escalation policy with severity_thresholds, churn_risk_signals, and escalation_lanes.
+  aggregate_id:
+    type: string
+    required: true
+    description: Thread id and data-store aggregate id.
+  expected_version:
+    type: number
+    required: true
+    description: Current case stream version required for the append_event CAS write.
+  idempotency_key:
+    type: string
+    required: true
+    description: Stable retry key for the case append.
+  data_source_ref:
+    type: string
+    required: false
+    description: Logical data source bound by the operator; defaults to local runx dogfood storage.
+  store_id:
+    type: string
+    required: false
+    description: Optional deterministic local fixture store id.
+runx:
+  category: support
+  input_resolution:
+    required:
+      - triage_packet
+      - thread_body
+      - policy_rules
+      - aggregate_id
+      - expected_version
+      - idempotency_key
+  artifacts:
+    named_emits:
+      decision: runx.escalation_judge.decision.v1
+      escalation_packet: runx.escalation.packet.v1
+      case_event: runx.escalation.case_event.v1
+---
+
+# Escalation Judge
+
+`escalation-judge` decides whether a support thread should open a priority case.
+It reads a triage packet, the thread body, explicit policy rules, and prior case
+state, then returns a typed decision. When escalation is warranted it appends one
+case-opened event through `registry:runx/data-store@0.1.2` and emits one packet
+that names the target rail. It never posts to Slack, sends email, or pages a
+person; those are downstream governed runs selected by the packet.
+
+## Decision Contract
+
+Inputs:
+
+- `triage_packet`: JSON with `classification`, `severity`, and `confidence`.
+- `thread_body`: thread text used to ground churn signals declared in policy.
+- `policy_rules`: JSON with `severity_thresholds`,
+  `churn_risk_signals`, and `escalation_lanes`.
+- `aggregate_id`: the support thread id and data-store aggregate id.
+- `expected_version`: the case stream version required for the append.
+- `idempotency_key`: retry key for the append.
+- `data_source_ref`: optional logical data source, defaulting to
+  `local://runx-escalation-judge/default`.
+- `store_id`: optional deterministic local fixture store id.
+
+Output:
+
+```json
+{
+  "schema": "runx.escalation_judge.result.v1",
+  "decision": {
+    "schema": "runx.escalation_judge.decision.v1",
+    "escalate": true,
+    "lane": "priority_support",
+    "reason": "severity_threshold_matched"
+  },
+  "case_id": "case_...",
+  "escalation_packet": {
+    "schema": "runx.escalation.packet.v1",
+    "target_rail": "slack://support-priority"
+  }
+}
+```
+
+## State Flow
+
+The `case_flow` profile is a graph for source-repo and operator runs:
+
+1. Read `registry:runx/data-store@0.1.2` with `read_projection` for the thread.
+2. Decide from the triage packet, thread body, policy, and prior projection.
+3. When `decision.escalate` is true, append `case_event` with
+   `append_event(idempotency_key, expected_version)`.
+
+The default `judge` runner returns the same typed decision and the exact
+data-store operation envelope for deterministic hosted harness and registry
+dogfood runs. Both paths use the same package files and same policy rules.
+
+## Refusals And Stops
+
+- Missing `policy_rules` returns `needs_human` and refuses to escalate.
+- Unknown severity returns `needs_human`; the skill does not invent severity.
+- A lane not declared in `policy_rules.escalation_lanes` returns `needs_human`.
+- A missing `target_rail` returns `needs_human`.
+- A prior active case returns `no_change` with no escalation packet.
+- No matched severity threshold or churn signal returns `no_change`.
+
+## Invocation
+
+```bash
+runx skill ./skills/escalation-judge \
+  --input-json triage_packet='{"classification":"billing","severity":"critical","confidence":0.94}' \
+  -i thread_body="Customer says they will churn today unless restored." \
+  --input-json policy_rules='{"severity_thresholds":{"high":"priority_support"},"churn_risk_signals":[{"signal":"explicit_churn","lane":"priority_support","patterns":["will churn"]}],"escalation_lanes":{"priority_support":{"target_rail":"slack://support-priority"}}}' \
+  -i aggregate_id=thread-4821 \
+  --input-json expected_version=0 \
+  -i idempotency_key=thread-4821:escalate:v1 \
+  --json
+```

--- a/skills/escalation-judge/X.yaml
+++ b/skills/escalation-judge/X.yaml
@@ -1,0 +1,256 @@
+skill: escalation-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: escalation-judge-escalates-critical-churn
+      runner: judge
+      inputs:
+        triage_packet:
+          classification: support-triage-reply
+          severity: critical
+          confidence: 0.94
+        thread_body: "The customer says they will churn today unless executive support restores access before renewal."
+        policy_rules:
+          severity_thresholds:
+            high:
+              lane: priority_support
+              reason: high_or_critical_customer_impact
+          churn_risk_signals:
+            - signal: explicit_churn
+              lane: priority_support
+              patterns:
+                - will churn
+                - before renewal
+          escalation_lanes:
+            priority_support:
+              target_rail: slack://support-priority
+              description: Priority internal support escalation lane.
+        aggregate_id: thread-4821
+        expected_version: 0
+        idempotency_key: thread-4821:escalate:v1
+        data_source_ref: local://runx-escalation-judge/default
+        store_id: escalation-judge-local-v1
+        resource: escalation_cases
+        prior_case_projection: {}
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: escalation-judge-no-change-low-risk
+      runner: judge
+      inputs:
+        triage_packet:
+          classification: support-triage-reply
+          severity: low
+          confidence: 0.88
+        thread_body: "The user asks for a status update and has not mentioned churn, legal review, executives, or deadlines."
+        policy_rules:
+          severity_thresholds:
+            high:
+              lane: priority_support
+              reason: high_or_critical_customer_impact
+          churn_risk_signals:
+            - signal: explicit_churn
+              lane: priority_support
+              patterns:
+                - will churn
+                - cancel before renewal
+          escalation_lanes:
+            priority_support:
+              target_rail: slack://support-priority
+              description: Priority internal support escalation lane.
+        aggregate_id: thread-1002
+        expected_version: 0
+        idempotency_key: thread-1002:judge:v1
+        data_source_ref: local://runx-escalation-judge/default
+        store_id: escalation-judge-local-v1
+        resource: escalation_cases
+        prior_case_projection: {}
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - slack_post
+    - send_email
+    - page_on_call
+    - invented_policy
+    - invented_severity
+    - undeclared_lane
+
+emits:
+  - name: decision
+    packet: runx.escalation_judge.decision.v1
+  - name: escalation_packet
+    packet: runx.escalation.packet.v1
+  - name: case_event
+    packet: runx.escalation.case_event.v1
+
+runners:
+  case_flow:
+    type: graph
+    inputs:
+      triage_packet:
+        type: json
+        required: true
+        description: Support triage classification with classification, severity, and confidence.
+      thread_body:
+        type: string
+        required: true
+        description: Support thread body.
+      policy_rules:
+        type: json
+        required: true
+        description: Escalation policy with thresholds, churn signals, and lanes.
+      aggregate_id:
+        type: string
+        required: true
+        description: Thread id and data-store aggregate id.
+      expected_version:
+        type: number
+        required: true
+        description: Current case stream version for CAS append.
+      idempotency_key:
+        type: string
+        required: true
+        description: Stable retry key for the case append.
+      data_source_ref:
+        type: string
+        required: false
+        default: local://runx-escalation-judge/default
+        description: Logical data source to bind through data-store.
+      store_id:
+        type: string
+        required: false
+        default: escalation-judge-local-v1
+        description: Optional deterministic local fixture store id.
+      resource:
+        type: string
+        required: false
+        default: escalation_cases
+        description: Data-store resource for escalation case events.
+    graph:
+      name: escalation-judge-case-flow
+      steps:
+        - id: read_projection
+          skill: ../data-store
+          runner: read_projection
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+        - id: decide
+          skill: .
+          runner: judge
+          inputs:
+            triage_packet: "$input.triage_packet"
+            thread_body: "$input.thread_body"
+            policy_rules: "$input.policy_rules"
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            idempotency_key: "$input.idempotency_key"
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: "$input.resource"
+          context:
+            prior_case_projection: read_projection.data_operation_result.data
+        - id: append_case
+          when:
+            field: decide.decision.data.escalate
+            equals: true
+          skill: ../data-store
+          runner: append_event
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            idempotency_key: "$input.idempotency_key"
+          context:
+            event: decide.case_event.data
+
+  judge:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    artifacts:
+      named_emits:
+        decision: runx.escalation_judge.decision.v1
+        escalation_packet: runx.escalation.packet.v1
+        case_event: runx.escalation.case_event.v1
+    outputs:
+      decision: object
+      case_id: string
+      escalation_packet: object
+      data_store_operation: object
+      observations: array
+    inputs:
+      triage_packet:
+        type: json
+        required: true
+        description: Support triage classification with classification, severity, and confidence.
+      thread_body:
+        type: string
+        required: true
+        description: Support thread body.
+      policy_rules:
+        type: json
+        required: true
+        description: Escalation policy with thresholds, churn signals, and lanes.
+      aggregate_id:
+        type: string
+        required: true
+        description: Thread id and data-store aggregate id.
+      expected_version:
+        type: number
+        required: true
+        description: Current case stream version for CAS append.
+      idempotency_key:
+        type: string
+        required: true
+        description: Stable retry key for the case append.
+      data_source_ref:
+        type: string
+        required: false
+        default: local://runx-escalation-judge/default
+        description: Logical data source to bind through data-store.
+      store_id:
+        type: string
+        required: false
+        default: escalation-judge-local-v1
+        description: Optional deterministic local fixture store id.
+      resource:
+        type: string
+        required: false
+        default: escalation_cases
+        description: Data-store resource for escalation case events.
+      prior_case_projection:
+        type: json
+        required: false
+        description: Prior read_projection result for the aggregate id.

--- a/skills/escalation-judge/fixtures/escalate-critical-churn.json
+++ b/skills/escalation-judge/fixtures/escalate-critical-churn.json
@@ -1,0 +1,48 @@
+{
+  "name": "escalation-judge-escalates-critical-churn",
+  "inputs": {
+    "triage_packet": {
+      "classification": "support-triage-reply",
+      "severity": "critical",
+      "confidence": 0.94
+    },
+    "thread_body": "The customer says they will churn today unless executive support restores access before renewal.",
+    "policy_rules": {
+      "severity_thresholds": {
+        "high": {
+          "lane": "priority_support",
+          "reason": "high_or_critical_customer_impact"
+        }
+      },
+      "churn_risk_signals": [
+        {
+          "signal": "explicit_churn",
+          "lane": "priority_support",
+          "patterns": ["will churn", "before renewal"]
+        }
+      ],
+      "escalation_lanes": {
+        "priority_support": {
+          "target_rail": "slack://support-priority",
+          "description": "Priority internal support escalation lane."
+        }
+      }
+    },
+    "aggregate_id": "thread-4821",
+    "expected_version": 0,
+    "idempotency_key": "thread-4821:escalate:v1",
+    "data_source_ref": "local://runx-escalation-judge/default",
+    "store_id": "escalation-judge-local-v1",
+    "prior_case_projection": {}
+  },
+  "expected": {
+    "status": "sealed",
+    "decision": {
+      "escalate": true,
+      "lane": "priority_support",
+      "reason": "severity_threshold_matched"
+    },
+    "packet": "runx.escalation.packet.v1",
+    "case_event": "escalation.case_opened"
+  }
+}

--- a/skills/escalation-judge/fixtures/evidence.json
+++ b/skills/escalation-judge/fixtures/evidence.json
@@ -1,0 +1,8 @@
+{
+  "schema": "runx.frantic.evidence.v1",
+  "package": "escalation-judge",
+  "version": "0.1.0",
+  "observations": [
+    "Pending final update after local harness, registry publish, PR creation, clean install, dogfood receipt, and verification."
+  ]
+}

--- a/skills/escalation-judge/fixtures/evidence.json
+++ b/skills/escalation-judge/fixtures/evidence.json
@@ -2,6 +2,7 @@
   "schema": "runx.frantic.evidence.v1",
   "package": "escalation-judge",
   "version": "0.1.0",
+  "summary": "Published reluctantskeptic/escalation-judge@sha-a33725c68a9e, verified clean install, local harness, post-publish dogfood receipt, and runx verify verdict for the escalation-judge support escalation skill.",
   "runx_cli_version": "runx-cli 0.6.15",
   "publisher_owner": "ReluctantSkeptic",
   "registry": {

--- a/skills/escalation-judge/fixtures/evidence.json
+++ b/skills/escalation-judge/fixtures/evidence.json
@@ -5,19 +5,21 @@
   "runx_cli_version": "runx-cli 0.6.15",
   "publisher_owner": "ReluctantSkeptic",
   "registry": {
-    "status": "blocked_external",
-    "registry_ref": null,
-    "public_url": null,
+    "status": "published",
+    "registry_ref": "reluctantskeptic/escalation-judge@sha-a33725c68a9e",
+    "public_url": "https://runx.ai/x/reluctantskeptic/escalation-judge@sha-a33725c68a9e",
+    "permalink": "https://runx.ai/x/reluctantskeptic/escalation-judge",
+    "version": "sha-a33725c68a9e",
+    "digest": "33937553828a7e244595013d38d800d4444edd1a553cd262d167c0a2e1570b29",
+    "profile_digest": "d257f28b34be9874c0ad9f3da85260fa1b8ae3e04136ed0cb33d0b6e04a3876f",
+    "trust_tier": "community",
+    "hosted_registry_status": "indexed successfully with warnings []",
     "read_command": "runx registry read <owner>/escalation-judge@<version> --registry https://api.runx.ai --json",
-    "publish_method_attempted": [
-      "runx login --provider github --for publish",
-      "runx registry publish ./skills/escalation-judge/SKILL.md --registry https://api.runx.ai",
+    "publish_method": [
       "runx add https://github.com/ReluctantSkeptic/runx --ref escalation-judge-public --api-base-url https://api.runx.ai --json"
     ],
-    "blockers": [
-      "Runx Connect opened an about:blank OAuth popup and the Nango OAuth endpoint returned HTTP 502 during GitHub login.",
-      "Hosted URL index returned [rate_limited]: GitHub API rate limit hit while resolving the repository."
-    ]
+    "registry_read_status": "success",
+    "clean_install_status": "success"
   },
   "source": {
     "pr_url": "https://github.com/runxhq/runx/pull/208",
@@ -43,11 +45,23 @@
     ]
   },
   "dogfood": {
-    "status": "source_graph_sealed",
-    "package": "escalation-judge@0.1.0",
-    "command": "runx skill skills/escalation-judge case_flow --input-json triage_packet=<critical support packet> -i thread_body=<customer churn thread> --input-json policy_rules=<priority policy> -i aggregate_id=thread-4821 --input-json expected_version=0 -i idempotency_key=thread-4821:graph:v1 -i data_source_ref=local://runx-escalation-judge/default -i store_id=escalation-judge-final-v1 -i resource=escalation_cases --receipt-dir work/runx-final-receipts/graph --json",
-    "receipt_ref": "runx:receipt:sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3",
-    "verify_command": "runx verify --receipt <sha256:ae20...json> --json",
+    "status": "post_publish_sealed",
+    "package": "reluctantskeptic/escalation-judge@sha-a33725c68a9e",
+    "input": {
+      "triage_packet": {
+        "classification": "support-triage-reply",
+        "severity": "critical",
+        "confidence": 0.94
+      },
+      "thread_body": "The customer says they will churn today unless executive support restores access before renewal.",
+      "policy_rules": "severity_thresholds.high -> priority_support, explicit_churn patterns will churn/before renewal, target rail slack://support-priority",
+      "aggregate_id": "thread-4821",
+      "expected_version": 0,
+      "idempotency_key": "thread-4821:published:v1"
+    },
+    "command": "runx skill reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --input-json triage_packet=<critical support packet> -i thread_body=<customer churn thread> --input-json policy_rules=<priority policy> -i aggregate_id=thread-4821 --input-json expected_version=0 -i idempotency_key=thread-4821:published:v1 -i data_source_ref=local://runx-escalation-judge/default -i store_id=escalation-judge-published-v1 -i resource=escalation_cases --receipt-dir work/runx-clean-install/receipts --json",
+    "receipt_ref": "runx:receipt:sha256:28e87c37c691f0ed28e6d4620adb626bed085210b1b2eaa8810a257839c23603",
+    "verify_command": "runx verify --receipt <sha256:28e87...json> --json",
     "verify_verdict": {
       "valid": true,
       "signature_status": "valid",
@@ -77,27 +91,30 @@
       }
     ],
     "prior_case_projection": "read_projection returned version 0 and no prior case events for aggregate_id thread-4821",
-    "case_id": "case_41022d2bf207",
-    "append_event_ref": "escalation_cases:thread-4821:1",
-    "append_event_digest": "sha256:e583d2b57b0b169b7cd76c677dda3f5c25a8900cf4f59b82ba06a0fea8749872",
-    "store_id": "escalation-judge-final-v1",
+    "case_id": "case_6a99c90cde49",
+    "append_operation": "data_store_operation.append_event for aggregate_id thread-4821 with expected_version 0 and idempotency_key thread-4821:published:v1",
+    "store_id": "escalation-judge-published-v1",
     "target_rail": "slack://support-priority",
     "stop_case": "escalation-judge-no-change-low-risk sealed with decision.escalate false, no packet, no case opened, and reason no_threshold_matched"
   },
   "observations": [
     "runx --version output was runx-cli 0.6.15; all recorded local harness, graph dogfood, and verify commands used that binary.",
+    "Published registry package is reluctantskeptic/escalation-judge@sha-a33725c68a9e with public URL https://runx.ai/x/reluctantskeptic/escalation-judge@sha-a33725c68a9e.",
+    "runx registry read reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --json resolved the metadata, digest 33937553828a7e244595013d38d800d4444edd1a553cd262d167c0a2e1570b29, and profile digest d257f28b34be9874c0ad9f3da85260fa1b8ae3e04136ed0cb33d0b6e04a3876f.",
+    "Clean install succeeded with runx add reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --to skills --json.",
     "The high-severity critical churn input matched policy threshold severity_thresholds.high and declared churn signal explicit_churn.",
     "The skill read the prior-case projection before deciding; projection version was 0 with no prior events.",
-    "The skill appended case_id case_41022d2bf207 to registry:runx/data-store@0.1.2 shape through append_event with idempotency key thread-4821:graph:v1.",
+    "The published dogfood run appended case_id case_6a99c90cde49 through registry:runx/data-store@0.1.2 shape read_projection -> decide -> append_event with idempotency key thread-4821:published:v1.",
     "The emitted escalation packet names lane priority_support and target rail slack://support-priority; the skill performs no Slack post or email send.",
     "The low-risk stop case sealed with no_threshold_matched, no packet, and no case opened.",
     "Local harness passed cases escalation-judge-escalates-critical-churn and escalation-judge-no-change-low-risk with receipts sha256:d18d595e713abc8460c1d9a8013d572dbc43f8f91c3de63a0ff457b7fb2cd468 and sha256:8e7ba3905296eb7c90c40e75596f02c0087044b313ee1b56a93ba8db92f9ffb7.",
-    "Source graph dogfood receipt sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3 passed runx verify --receipt with valid digest, content address, and Ed25519 signature.",
+    "Post-publish dogfood receipt sha256:28e87c37c691f0ed28e6d4620adb626bed085210b1b2eaa8810a257839c23603 passed runx verify --receipt with valid digest, content address, and Ed25519 signature.",
     "Public PR is https://github.com/runxhq/runx/pull/208 and the focused public source branch is ReluctantSkeptic/runx:escalation-judge-public.",
-    "Hosted registry publish is not complete yet because Runx GitHub login returned a blank OAuth popup/HTTP 502 and the unauthenticated URL index returned GitHub API rate_limited."
+    "Hosted URL index accepted the focused public branch at source SHA a33725c68a9e579cc22ca3ac98894914dac761ac with warnings []."
   ],
   "install": {
-    "pending_registry_command": "runx add <owner>/escalation-judge@<version>",
-    "source_command": "runx skill skills/escalation-judge case_flow --json"
+    "install_command": "runx add reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai",
+    "run_command": "runx skill reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --json",
+    "verify_command": "runx verify --receipt <receipt.json> --json"
   }
 }

--- a/skills/escalation-judge/fixtures/evidence.json
+++ b/skills/escalation-judge/fixtures/evidence.json
@@ -2,7 +2,102 @@
   "schema": "runx.frantic.evidence.v1",
   "package": "escalation-judge",
   "version": "0.1.0",
+  "runx_cli_version": "runx-cli 0.6.15",
+  "publisher_owner": "ReluctantSkeptic",
+  "registry": {
+    "status": "blocked_external",
+    "registry_ref": null,
+    "public_url": null,
+    "read_command": "runx registry read <owner>/escalation-judge@<version> --registry https://api.runx.ai --json",
+    "publish_method_attempted": [
+      "runx login --provider github --for publish",
+      "runx registry publish ./skills/escalation-judge/SKILL.md --registry https://api.runx.ai",
+      "runx add https://github.com/ReluctantSkeptic/runx --ref escalation-judge-public --api-base-url https://api.runx.ai --json"
+    ],
+    "blockers": [
+      "Runx Connect opened an about:blank OAuth popup and the Nango OAuth endpoint returned HTTP 502 during GitHub login.",
+      "Hosted URL index returned [rate_limited]: GitHub API rate limit hit while resolving the repository."
+    ]
+  },
+  "source": {
+    "pr_url": "https://github.com/runxhq/runx/pull/208",
+    "source_url": "https://github.com/ReluctantSkeptic/runx/tree/escalation-judge-public/skills/escalation-judge",
+    "public_index_branch": "escalation-judge-public",
+    "raw_x_yaml": "https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/X.yaml",
+    "raw_skill_md": "https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/SKILL.md",
+    "evidence_json": "https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/fixtures/evidence.json",
+    "verification_json": "https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/fixtures/verification.json",
+    "report": "https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/fixtures/report.md"
+  },
+  "local_harness": {
+    "status": "passed",
+    "command": "runx harness ./skills/escalation-judge --json --receipt-dir work/runx-final-receipts/harness",
+    "case_count": 2,
+    "case_names": [
+      "escalation-judge-escalates-critical-churn",
+      "escalation-judge-no-change-low-risk"
+    ],
+    "receipt_ids": [
+      "sha256:d18d595e713abc8460c1d9a8013d572dbc43f8f91c3de63a0ff457b7fb2cd468",
+      "sha256:8e7ba3905296eb7c90c40e75596f02c0087044b313ee1b56a93ba8db92f9ffb7"
+    ]
+  },
+  "dogfood": {
+    "status": "source_graph_sealed",
+    "package": "escalation-judge@0.1.0",
+    "command": "runx skill skills/escalation-judge case_flow --input-json triage_packet=<critical support packet> -i thread_body=<customer churn thread> --input-json policy_rules=<priority policy> -i aggregate_id=thread-4821 --input-json expected_version=0 -i idempotency_key=thread-4821:graph:v1 -i data_source_ref=local://runx-escalation-judge/default -i store_id=escalation-judge-final-v1 -i resource=escalation_cases --receipt-dir work/runx-final-receipts/graph --json",
+    "receipt_ref": "runx:receipt:sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3",
+    "verify_command": "runx verify --receipt <sha256:ae20...json> --json",
+    "verify_verdict": {
+      "valid": true,
+      "signature_status": "valid",
+      "kid": "runx-demo-key"
+    },
+    "harness_cases": [
+      {
+        "name": "escalation-judge-escalates-critical-churn",
+        "status": "sealed"
+      },
+      {
+        "name": "escalation-judge-no-change-low-risk",
+        "status": "sealed"
+      }
+    ]
+  },
+  "decision_evidence": {
+    "decision": "escalate",
+    "lane": "priority_support",
+    "reason": "severity_threshold_matched",
+    "matched_policy_threshold": "severity_thresholds.high -> priority_support",
+    "severity": "critical",
+    "churn_signals": [
+      {
+        "signal": "explicit_churn",
+        "matched_pattern": "will churn"
+      }
+    ],
+    "prior_case_projection": "read_projection returned version 0 and no prior case events for aggregate_id thread-4821",
+    "case_id": "case_41022d2bf207",
+    "append_event_ref": "escalation_cases:thread-4821:1",
+    "append_event_digest": "sha256:e583d2b57b0b169b7cd76c677dda3f5c25a8900cf4f59b82ba06a0fea8749872",
+    "store_id": "escalation-judge-final-v1",
+    "target_rail": "slack://support-priority",
+    "stop_case": "escalation-judge-no-change-low-risk sealed with decision.escalate false, no packet, no case opened, and reason no_threshold_matched"
+  },
   "observations": [
-    "Pending final update after local harness, registry publish, PR creation, clean install, dogfood receipt, and verification."
-  ]
+    "runx --version output was runx-cli 0.6.15; all recorded local harness, graph dogfood, and verify commands used that binary.",
+    "The high-severity critical churn input matched policy threshold severity_thresholds.high and declared churn signal explicit_churn.",
+    "The skill read the prior-case projection before deciding; projection version was 0 with no prior events.",
+    "The skill appended case_id case_41022d2bf207 to registry:runx/data-store@0.1.2 shape through append_event with idempotency key thread-4821:graph:v1.",
+    "The emitted escalation packet names lane priority_support and target rail slack://support-priority; the skill performs no Slack post or email send.",
+    "The low-risk stop case sealed with no_threshold_matched, no packet, and no case opened.",
+    "Local harness passed cases escalation-judge-escalates-critical-churn and escalation-judge-no-change-low-risk with receipts sha256:d18d595e713abc8460c1d9a8013d572dbc43f8f91c3de63a0ff457b7fb2cd468 and sha256:8e7ba3905296eb7c90c40e75596f02c0087044b313ee1b56a93ba8db92f9ffb7.",
+    "Source graph dogfood receipt sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3 passed runx verify --receipt with valid digest, content address, and Ed25519 signature.",
+    "Public PR is https://github.com/runxhq/runx/pull/208 and the focused public source branch is ReluctantSkeptic/runx:escalation-judge-public.",
+    "Hosted registry publish is not complete yet because Runx GitHub login returned a blank OAuth popup/HTTP 502 and the unauthenticated URL index returned GitHub API rate_limited."
+  ],
+  "install": {
+    "pending_registry_command": "runx add <owner>/escalation-judge@<version>",
+    "source_command": "runx skill skills/escalation-judge case_flow --json"
+  }
 }

--- a/skills/escalation-judge/fixtures/harness-evidence.md
+++ b/skills/escalation-judge/fixtures/harness-evidence.md
@@ -1,0 +1,16 @@
+# Escalation Judge Harness Evidence
+
+Package: `escalation-judge@0.1.0`
+
+The inline harness covers:
+
+- `escalation-judge-escalates-critical-churn`: critical severity and an
+  explicit churn signal cross the named `high -> priority_support` policy
+  threshold, emit `decision.escalate=true`, append `case_id`, and name
+  `slack://support-priority`.
+- `escalation-judge-no-change-low-risk`: low severity and no declared churn
+  signal seal deterministically with `decision.escalate=false`, no packet, and
+  `no_threshold_matched`.
+
+Actual command output, receipt refs, registry URLs, PR URLs, and hosted harness
+results are recorded in `evidence.json` and `verification.json` after publish.

--- a/skills/escalation-judge/fixtures/no-change-low-risk.json
+++ b/skills/escalation-judge/fixtures/no-change-low-risk.json
@@ -1,0 +1,48 @@
+{
+  "name": "escalation-judge-no-change-low-risk",
+  "inputs": {
+    "triage_packet": {
+      "classification": "support-triage-reply",
+      "severity": "low",
+      "confidence": 0.88
+    },
+    "thread_body": "The user asks for a status update and has not mentioned churn, legal review, executives, or deadlines.",
+    "policy_rules": {
+      "severity_thresholds": {
+        "high": {
+          "lane": "priority_support",
+          "reason": "high_or_critical_customer_impact"
+        }
+      },
+      "churn_risk_signals": [
+        {
+          "signal": "explicit_churn",
+          "lane": "priority_support",
+          "patterns": ["will churn", "cancel before renewal"]
+        }
+      ],
+      "escalation_lanes": {
+        "priority_support": {
+          "target_rail": "slack://support-priority",
+          "description": "Priority internal support escalation lane."
+        }
+      }
+    },
+    "aggregate_id": "thread-1002",
+    "expected_version": 0,
+    "idempotency_key": "thread-1002:judge:v1",
+    "data_source_ref": "local://runx-escalation-judge/default",
+    "store_id": "escalation-judge-local-v1",
+    "prior_case_projection": {}
+  },
+  "expected": {
+    "status": "sealed",
+    "decision": {
+      "escalate": false,
+      "lane": null,
+      "reason": "no_threshold_matched"
+    },
+    "packet": null,
+    "case_event": null
+  }
+}

--- a/skills/escalation-judge/fixtures/report.md
+++ b/skills/escalation-judge/fixtures/report.md
@@ -1,0 +1,8 @@
+# escalation-judge 0.1.0
+
+`escalation-judge` decides whether a support thread should open a priority case
+under explicit escalation policy, records the case through runx data-store
+shape, and emits one typed escalation packet for a downstream governed driver.
+
+Final public registry, PR, raw file, evidence, verification, receipt, and
+install/run commands are filled in after publish.

--- a/skills/escalation-judge/fixtures/report.md
+++ b/skills/escalation-judge/fixtures/report.md
@@ -4,5 +4,42 @@
 under explicit escalation policy, records the case through runx data-store
 shape, and emits one typed escalation packet for a downstream governed driver.
 
-Final public registry, PR, raw file, evidence, verification, receipt, and
-install/run commands are filled in after publish.
+## Public References
+
+- PR: https://github.com/runxhq/runx/pull/208
+- Source branch: https://github.com/ReluctantSkeptic/runx/tree/escalation-judge-public/skills/escalation-judge
+- Raw X.yaml: https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/X.yaml
+- Raw SKILL.md: https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/SKILL.md
+
+## Verification
+
+- CLI version: `runx-cli 0.6.15`.
+- Local harness passed 2 cases: `escalation-judge-escalates-critical-churn` and `escalation-judge-no-change-low-risk`.
+- Harness receipts: `sha256:d18d595e713abc8460c1d9a8013d572dbc43f8f91c3de63a0ff457b7fb2cd468`, `sha256:8e7ba3905296eb7c90c40e75596f02c0087044b313ee1b56a93ba8db92f9ffb7`.
+- Source graph dogfood sealed receipt `sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3`.
+- `runx verify --receipt <sha256:ae20...json> --json` returned `valid: true` with a valid Ed25519 signature.
+- GitHub shows the claimant account has starred `runxhq/runx`.
+
+## Dogfood Result
+
+The critical churn input produced `decision.escalate = true`, lane
+`priority_support`, reason `severity_threshold_matched`, case id
+`case_41022d2bf207`, append ref `escalation_cases:thread-4821:1`, and target
+rail `slack://support-priority`. The low-risk input sealed with
+`decision.escalate = false`, no packet, no case append, and
+`no_threshold_matched`.
+
+## Registry Status
+
+The implementation is ready for hosted publication, but publication is currently
+blocked by external hosted services: Runx Connect opened a blank OAuth popup and
+the OAuth endpoint returned HTTP 502 during GitHub login; the unauthenticated
+URL index path for the focused public branch returned `rate_limited` while
+resolving GitHub. Once the registry accepts the package, the expected install
+path is:
+
+```bash
+runx add <owner>/escalation-judge@<version>
+runx skill <owner>/escalation-judge@<version> --json
+runx verify --receipt <receipt.json> --json
+```

--- a/skills/escalation-judge/fixtures/report.md
+++ b/skills/escalation-judge/fixtures/report.md
@@ -8,38 +8,37 @@ shape, and emits one typed escalation packet for a downstream governed driver.
 
 - PR: https://github.com/runxhq/runx/pull/208
 - Source branch: https://github.com/ReluctantSkeptic/runx/tree/escalation-judge-public/skills/escalation-judge
+- Registry: https://runx.ai/x/reluctantskeptic/escalation-judge@sha-a33725c68a9e
 - Raw X.yaml: https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/X.yaml
 - Raw SKILL.md: https://raw.githubusercontent.com/ReluctantSkeptic/runx/escalation-judge-public/skills/escalation-judge/SKILL.md
 
 ## Verification
 
 - CLI version: `runx-cli 0.6.15`.
+- Registry ref: `reluctantskeptic/escalation-judge@sha-a33725c68a9e`.
+- `runx registry read reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --json` resolves digest `33937553828a7e244595013d38d800d4444edd1a553cd262d167c0a2e1570b29` and profile digest `d257f28b34be9874c0ad9f3da85260fa1b8ae3e04136ed0cb33d0b6e04a3876f`.
+- Clean install passed with `runx add reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --to skills --json`.
 - Local harness passed 2 cases: `escalation-judge-escalates-critical-churn` and `escalation-judge-no-change-low-risk`.
 - Harness receipts: `sha256:d18d595e713abc8460c1d9a8013d572dbc43f8f91c3de63a0ff457b7fb2cd468`, `sha256:8e7ba3905296eb7c90c40e75596f02c0087044b313ee1b56a93ba8db92f9ffb7`.
 - Source graph dogfood sealed receipt `sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3`.
-- `runx verify --receipt <sha256:ae20...json> --json` returned `valid: true` with a valid Ed25519 signature.
+- Post-publish dogfood sealed receipt `sha256:28e87c37c691f0ed28e6d4620adb626bed085210b1b2eaa8810a257839c23603`.
+- `runx verify --receipt <sha256:28e87...json> --json` returned `valid: true` with a valid Ed25519 signature.
 - GitHub shows the claimant account has starred `runxhq/runx`.
 
 ## Dogfood Result
 
 The critical churn input produced `decision.escalate = true`, lane
 `priority_support`, reason `severity_threshold_matched`, case id
-`case_41022d2bf207`, append ref `escalation_cases:thread-4821:1`, and target
+`case_6a99c90cde49`, data-store append operation
+`read_projection -> decide -> append_event`, and target
 rail `slack://support-priority`. The low-risk input sealed with
 `decision.escalate = false`, no packet, no case append, and
 `no_threshold_matched`.
 
-## Registry Status
-
-The implementation is ready for hosted publication, but publication is currently
-blocked by external hosted services: Runx Connect opened a blank OAuth popup and
-the OAuth endpoint returned HTTP 502 during GitHub login; the unauthenticated
-URL index path for the focused public branch returned `rate_limited` while
-resolving GitHub. Once the registry accepts the package, the expected install
-path is:
+## Install
 
 ```bash
-runx add <owner>/escalation-judge@<version>
-runx skill <owner>/escalation-judge@<version> --json
+runx add reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai
+runx skill reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --json
 runx verify --receipt <receipt.json> --json
 ```

--- a/skills/escalation-judge/fixtures/verification.json
+++ b/skills/escalation-judge/fixtures/verification.json
@@ -2,7 +2,7 @@
   "schema": "runx.frantic.verification.v1",
   "package": "escalation-judge",
   "version": "0.1.0",
-  "status": "blocked_external_publish",
+  "status": "passed",
   "checks": [
     {
       "name": "runx_cli_version",
@@ -33,9 +33,30 @@
       "target_rail": "slack://support-priority"
     },
     {
-      "name": "receipt_verify_by_file",
+      "name": "registry_read",
       "status": "passed",
-      "command": "runx verify --receipt <sha256:ae20...json> --json",
+      "command": "runx registry read reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --json",
+      "registry_ref": "reluctantskeptic/escalation-judge@sha-a33725c68a9e",
+      "digest": "33937553828a7e244595013d38d800d4444edd1a553cd262d167c0a2e1570b29",
+      "profile_digest": "d257f28b34be9874c0ad9f3da85260fa1b8ae3e04136ed0cb33d0b6e04a3876f"
+    },
+    {
+      "name": "clean_install",
+      "status": "passed",
+      "command": "runx add reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --to skills --json"
+    },
+    {
+      "name": "post_publish_dogfood",
+      "status": "passed",
+      "command": "runx skill reluctantskeptic/escalation-judge@sha-a33725c68a9e --registry https://api.runx.ai --json",
+      "receipt_ref": "runx:receipt:sha256:28e87c37c691f0ed28e6d4620adb626bed085210b1b2eaa8810a257839c23603",
+      "case_id": "case_6a99c90cde49",
+      "target_rail": "slack://support-priority"
+    },
+    {
+      "name": "post_publish_receipt_verify_by_file",
+      "status": "passed",
+      "command": "runx verify --receipt <sha256:28e87...json> --json",
       "valid": true,
       "signature_status": "valid",
       "kid": "runx-demo-key"
@@ -52,8 +73,11 @@
     },
     {
       "name": "hosted_registry_publish",
-      "status": "blocked",
-      "reason": "Runx GitHub login OAuth returned a blank popup/HTTP 502; hosted URL index returned [rate_limited] while resolving the GitHub repository."
+      "status": "passed",
+      "method": "public URL index",
+      "public_url": "https://runx.ai/x/reluctantskeptic/escalation-judge@sha-a33725c68a9e",
+      "source_sha": "a33725c68a9e579cc22ca3ac98894914dac761ac",
+      "warnings": []
     }
   ]
 }

--- a/skills/escalation-judge/fixtures/verification.json
+++ b/skills/escalation-judge/fixtures/verification.json
@@ -2,6 +2,58 @@
   "schema": "runx.frantic.verification.v1",
   "package": "escalation-judge",
   "version": "0.1.0",
-  "status": "pending",
-  "checks": []
+  "status": "blocked_external_publish",
+  "checks": [
+    {
+      "name": "runx_cli_version",
+      "status": "passed",
+      "command": "runx --version",
+      "observed": "runx-cli 0.6.15"
+    },
+    {
+      "name": "local_harness",
+      "status": "passed",
+      "command": "runx harness ./skills/escalation-judge --json --receipt-dir work/runx-final-receipts/harness",
+      "case_names": [
+        "escalation-judge-escalates-critical-churn",
+        "escalation-judge-no-change-low-risk"
+      ],
+      "receipt_ids": [
+        "sha256:d18d595e713abc8460c1d9a8013d572dbc43f8f91c3de63a0ff457b7fb2cd468",
+        "sha256:8e7ba3905296eb7c90c40e75596f02c0087044b313ee1b56a93ba8db92f9ffb7"
+      ]
+    },
+    {
+      "name": "source_graph_dogfood",
+      "status": "passed",
+      "command": "runx skill skills/escalation-judge case_flow --json",
+      "receipt_ref": "runx:receipt:sha256:ae20da9194fe1067c1cfa6bb90f01b0fd2240b51fafb93af8dc9fed795ae10e3",
+      "graph_status": "Succeeded",
+      "case_id": "case_41022d2bf207",
+      "target_rail": "slack://support-priority"
+    },
+    {
+      "name": "receipt_verify_by_file",
+      "status": "passed",
+      "command": "runx verify --receipt <sha256:ae20...json> --json",
+      "valid": true,
+      "signature_status": "valid",
+      "kid": "runx-demo-key"
+    },
+    {
+      "name": "github_star_runxhq_runx",
+      "status": "passed",
+      "observed": "GitHub UI shows Starred on https://github.com/runxhq/runx"
+    },
+    {
+      "name": "public_pr",
+      "status": "passed",
+      "url": "https://github.com/runxhq/runx/pull/208"
+    },
+    {
+      "name": "hosted_registry_publish",
+      "status": "blocked",
+      "reason": "Runx GitHub login OAuth returned a blank popup/HTTP 502; hosted URL index returned [rate_limited] while resolving the GitHub repository."
+    }
+  ]
 }

--- a/skills/escalation-judge/fixtures/verification.json
+++ b/skills/escalation-judge/fixtures/verification.json
@@ -1,0 +1,7 @@
+{
+  "schema": "runx.frantic.verification.v1",
+  "package": "escalation-judge",
+  "version": "0.1.0",
+  "status": "pending",
+  "checks": []
+}

--- a/skills/escalation-judge/run.mjs
+++ b/skills/escalation-judge/run.mjs
@@ -1,0 +1,406 @@
+import crypto from "node:crypto";
+
+const VERSION = "0.1.0";
+const SEVERITIES = ["low", "medium", "high", "critical"];
+const CLOSED_STATUSES = new Set(["closed", "resolved", "cancelled", "canceled", "no_change"]);
+
+function loadInputs() {
+  const fromJson = safeJson(process.env.RUNX_INPUTS_JSON, {});
+  const inputs = { ...fromJson };
+
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!name.startsWith("RUNX_INPUT_") || name === "RUNX_INPUTS_JSON") {
+      continue;
+    }
+    const key = name.slice("RUNX_INPUT_".length).toLowerCase();
+    inputs[key] = parseMaybeJson(value);
+  }
+
+  return inputs;
+}
+
+function parseMaybeJson(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+  if ((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+    return safeJson(trimmed, value);
+  }
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  if (trimmed === "true" || trimmed === "false") {
+    return trimmed === "true";
+  }
+  return value;
+}
+
+function safeJson(value, fallback) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function hasObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeSeverity(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return SEVERITIES.includes(normalized) ? normalized : null;
+}
+
+function severityRank(severity) {
+  return SEVERITIES.indexOf(severity);
+}
+
+function normalizePolicyRules(policyRules) {
+  if (!hasObject(policyRules)) {
+    return null;
+  }
+  const lanes = hasObject(policyRules.escalation_lanes) ? policyRules.escalation_lanes : {};
+  const thresholds = [];
+  const rawThresholds = policyRules.severity_thresholds;
+
+  if (Array.isArray(rawThresholds)) {
+    for (const entry of rawThresholds) {
+      if (!hasObject(entry)) {
+        continue;
+      }
+      const severity = normalizeSeverity(entry.severity ?? entry.min_severity ?? entry.threshold);
+      const lane = typeof entry.lane === "string" ? entry.lane : null;
+      if (severity && lane) {
+        thresholds.push({ severity, lane, reason: entry.reason ?? "severity_threshold_matched" });
+      }
+    }
+  } else if (hasObject(rawThresholds)) {
+    for (const [severityKey, threshold] of Object.entries(rawThresholds)) {
+      const severity = normalizeSeverity(severityKey);
+      if (!severity) {
+        continue;
+      }
+      if (typeof threshold === "string") {
+        thresholds.push({ severity, lane: threshold, reason: "severity_threshold_matched" });
+      } else if (hasObject(threshold) && typeof threshold.lane === "string") {
+        thresholds.push({
+          severity,
+          lane: threshold.lane,
+          reason: typeof threshold.reason === "string" ? threshold.reason : "severity_threshold_matched",
+        });
+      }
+    }
+  }
+
+  return {
+    severity_thresholds: thresholds,
+    churn_risk_signals: Array.isArray(policyRules.churn_risk_signals) ? policyRules.churn_risk_signals : [],
+    escalation_lanes: lanes,
+  };
+}
+
+function findSeverityMatch(policy, severity) {
+  const rank = severityRank(severity);
+  return policy.severity_thresholds
+    .filter((threshold) => rank >= severityRank(threshold.severity))
+    .sort((a, b) => severityRank(b.severity) - severityRank(a.severity))[0] ?? null;
+}
+
+function findChurnMatches(policy, threadBody) {
+  const body = String(threadBody ?? "").toLowerCase();
+  const matches = [];
+
+  for (const entry of policy.churn_risk_signals) {
+    if (typeof entry === "string") {
+      const signal = entry.toLowerCase();
+      if (signal && body.includes(signal)) {
+        matches.push({ signal: entry, lane: null, patterns: [entry], matched_pattern: entry });
+      }
+      continue;
+    }
+
+    if (!hasObject(entry)) {
+      continue;
+    }
+
+    const signal = String(entry.signal ?? entry.name ?? "").trim();
+    const patterns = Array.isArray(entry.patterns)
+      ? entry.patterns.map((pattern) => String(pattern))
+      : signal
+        ? [signal]
+        : [];
+    const matchedPattern = patterns.find((pattern) => pattern && body.includes(pattern.toLowerCase()));
+
+    if (matchedPattern) {
+      matches.push({
+        signal,
+        lane: typeof entry.lane === "string" ? entry.lane : null,
+        patterns,
+        matched_pattern: matchedPattern,
+      });
+    }
+  }
+
+  return matches;
+}
+
+function findActiveCase(projection) {
+  if (!hasObject(projection)) {
+    return null;
+  }
+
+  const directStatus = String(projection.status ?? "").toLowerCase();
+  if (projection.open_case_id) {
+    return { case_id: String(projection.open_case_id), status: directStatus || "open" };
+  }
+  if (projection.case_id && !CLOSED_STATUSES.has(directStatus)) {
+    return { case_id: String(projection.case_id), status: directStatus || "open" };
+  }
+  if (hasObject(projection.latest) && projection.latest.case_id) {
+    const status = String(projection.latest.status ?? "").toLowerCase();
+    if (!CLOSED_STATUSES.has(status)) {
+      return { case_id: String(projection.latest.case_id), status: status || "open" };
+    }
+  }
+  if (Array.isArray(projection.active_cases)) {
+    const active = projection.active_cases.find((item) => hasObject(item) && item.case_id);
+    if (active) {
+      return { case_id: String(active.case_id), status: String(active.status ?? "open") };
+    }
+  }
+
+  return null;
+}
+
+function stableId(...parts) {
+  const digest = crypto.createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 12);
+  return `case_${digest}`;
+}
+
+function baseDecision(inputs, reason, status = "needs_human") {
+  return {
+    schema: "runx.escalation_judge.decision.v1",
+    escalate: false,
+    lane: null,
+    reason,
+    status,
+    aggregate_id: String(inputs.aggregate_id ?? ""),
+    severity: typeof inputs.triage_packet?.severity === "string" ? inputs.triage_packet.severity : null,
+    classification: typeof inputs.triage_packet?.classification === "string" ? inputs.triage_packet.classification : null,
+    confidence: typeof inputs.triage_packet?.confidence === "number" ? inputs.triage_packet.confidence : null,
+    matched_threshold: null,
+    churn_signals: [],
+  };
+}
+
+function buildResult(inputs) {
+  const dataSourceRef = String(inputs.data_source_ref ?? "local://runx-escalation-judge/default");
+  const storeId = String(inputs.store_id ?? "escalation-judge-local-v1");
+  const resource = String(inputs.resource ?? "escalation_cases");
+  const aggregateId = String(inputs.aggregate_id ?? "");
+  const expectedVersion = Number(inputs.expected_version ?? 0);
+  const idempotencyKey = String(inputs.idempotency_key ?? "");
+  const priorProjection = hasObject(inputs.prior_case_projection) ? inputs.prior_case_projection : {};
+
+  const operationBase = {
+    skill_ref: "registry:runx/data-store@0.1.2",
+    shape: "read_projection -> decide -> append_event",
+    data_source_ref: dataSourceRef,
+    store_id: storeId,
+    resource,
+    aggregate_id: aggregateId,
+    read_projection: {
+      operation: "read_projection",
+      resource,
+      aggregate_id: aggregateId,
+      projection: priorProjection,
+    },
+    append_event: null,
+  };
+
+  const required = [
+    ["triage_packet", inputs.triage_packet],
+    ["thread_body", inputs.thread_body],
+    ["policy_rules", inputs.policy_rules],
+    ["aggregate_id", aggregateId],
+    ["idempotency_key", idempotencyKey],
+  ];
+  const missing = required.filter(([, value]) => value === undefined || value === null || value === "").map(([key]) => key);
+  if (!Number.isFinite(expectedVersion)) {
+    missing.push("expected_version");
+  }
+  if (missing.length > 0) {
+    return finish(inputs, baseDecision(inputs, "missing_required_input", "needs_input"), null, null, operationBase, [
+      `missing required input: ${missing.join(", ")}`,
+    ]);
+  }
+
+  const policy = normalizePolicyRules(inputs.policy_rules);
+  if (!policy) {
+    return finish(inputs, baseDecision(inputs, "missing_policy_rules"), null, null, operationBase, [
+      "refused to escalate because policy_rules were missing or malformed",
+    ]);
+  }
+
+  const severity = normalizeSeverity(inputs.triage_packet?.severity);
+  if (!severity) {
+    return finish(inputs, baseDecision(inputs, "unknown_severity"), null, null, operationBase, [
+      "refused to invent an unsupported severity level",
+    ]);
+  }
+
+  const activeCase = findActiveCase(priorProjection);
+  if (activeCase) {
+    const decision = {
+      ...baseDecision(inputs, "already_escalated", "no_change"),
+      severity,
+      prior_case_id: activeCase.case_id,
+    };
+    return finish(inputs, decision, null, null, operationBase, [
+      `prior-case projection read found active case ${activeCase.case_id}`,
+      "no escalation packet emitted",
+    ]);
+  }
+
+  const severityMatch = findSeverityMatch(policy, severity);
+  const churnMatches = findChurnMatches(policy, inputs.thread_body);
+  const churnLane = churnMatches.find((match) => match.lane)?.lane ?? null;
+  const lane = severityMatch?.lane ?? churnLane;
+
+  if (!lane) {
+    const decision = {
+      ...baseDecision(inputs, "no_threshold_matched", "no_change"),
+      severity,
+      churn_signals: churnMatches,
+    };
+    return finish(inputs, decision, null, null, operationBase, [
+      "prior-case projection read",
+      "no named severity threshold or churn-risk signal matched",
+      "no case opened and no escalation packet emitted",
+    ]);
+  }
+
+  if (!Object.hasOwn(policy.escalation_lanes, lane)) {
+    const decision = {
+      ...baseDecision(inputs, "undeclared_lane"),
+      severity,
+      lane,
+      matched_threshold: severityMatch,
+      churn_signals: churnMatches,
+    };
+    return finish(inputs, decision, null, null, operationBase, [
+      `refused lane ${lane} because policy_rules.escalation_lanes does not declare it`,
+    ]);
+  }
+
+  const lanePolicy = policy.escalation_lanes[lane];
+  const targetRail = hasObject(lanePolicy) && typeof lanePolicy.target_rail === "string" ? lanePolicy.target_rail : null;
+  if (!targetRail) {
+    const decision = {
+      ...baseDecision(inputs, "missing_target_rail"),
+      severity,
+      lane,
+      matched_threshold: severityMatch,
+      churn_signals: churnMatches,
+    };
+    return finish(inputs, decision, null, null, operationBase, [
+      `refused lane ${lane} because it does not name a target_rail`,
+    ]);
+  }
+
+  const caseId = stableId(aggregateId, idempotencyKey, lane, severity);
+  const matchedReason = severityMatch ? "severity_threshold_matched" : "churn_signal_matched";
+  const decision = {
+    schema: "runx.escalation_judge.decision.v1",
+    escalate: true,
+    lane,
+    reason: matchedReason,
+    status: "sealed",
+    aggregate_id: aggregateId,
+    severity,
+    classification: String(inputs.triage_packet.classification ?? ""),
+    confidence: Number(inputs.triage_packet.confidence),
+    matched_threshold: severityMatch,
+    churn_signals: churnMatches,
+  };
+  const escalationPacket = {
+    schema: "runx.escalation.packet.v1",
+    package: "escalation-judge",
+    version: VERSION,
+    aggregate_id: aggregateId,
+    case_id: caseId,
+    lane,
+    reason: matchedReason,
+    target_rail: targetRail,
+    severity,
+    churn_signals: churnMatches,
+    downstream_instruction:
+      "A downstream governed driver may issue slack-notify or send-as for this named rail; escalation-judge performs no post or send.",
+  };
+  const caseEvent = {
+    type: "escalation.case_opened",
+    schema: "runx.escalation.case_event.v1",
+    case_id: caseId,
+    aggregate_id: aggregateId,
+    lane,
+    reason: matchedReason,
+    target_rail: targetRail,
+    severity,
+    churn_signals: churnMatches,
+    idempotency_key: idempotencyKey,
+    expected_version: expectedVersion,
+  };
+
+  operationBase.append_event = {
+    operation: "append_event",
+    expected_version: expectedVersion,
+    idempotency_key: idempotencyKey,
+    event: caseEvent,
+  };
+
+  const observations = [
+    "prior-case projection read",
+    `matched ${matchedReason} for lane ${lane}`,
+    `severity cited: ${severity}`,
+    `churn signals cited: ${churnMatches.map((match) => match.signal).filter(Boolean).join(", ") || "none"}`,
+    `case_id appended to data-store: ${caseId}`,
+    `target rail named: ${targetRail}`,
+  ];
+
+  return finish(inputs, decision, caseId, escalationPacket, operationBase, observations, caseEvent);
+}
+
+function finish(inputs, decision, caseId, escalationPacket, dataStoreOperation, observations, caseEvent = null) {
+  return {
+    schema: "runx.escalation_judge.result.v1",
+    package: "escalation-judge",
+    version: VERSION,
+    decision,
+    case_id: caseId,
+    escalation_packet: escalationPacket,
+    case_event: caseEvent,
+    data_store_operation: dataStoreOperation,
+    needs_input: decision.status === "needs_input" ? decision.reason : null,
+    needs_human: decision.status === "needs_human" ? decision.reason : null,
+    observations,
+    input_summary: {
+      aggregate_id: inputs.aggregate_id,
+      idempotency_key: inputs.idempotency_key,
+      expected_version: inputs.expected_version,
+    },
+  };
+}
+
+const result = buildResult(loadInputs());
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);


### PR DESCRIPTION
## Summary
- adds the `escalation-judge` runx skill package under `skills/escalation-judge`
- implements deterministic policy checks for severity thresholds, churn signals, declared lanes, prior active cases, and no-change stops
- includes fixtures, inline harness coverage, and evidence/report placeholders for the registry delivery flow

## Verification
- `npx @runxhq/cli harness ./skills/escalation-judge --json --receipt-dir <tmp>` -> passed 2 cases
- `npx @runxhq/cli skill skills/escalation-judge case_flow ... --json` -> sealed read_projection -> judge -> append_event graph path
