### PR TITLE
Add spam risk reviewer skill

### DIFF
--- a/crates/runx-runtime/src/receipts/store.rs
+++ b/crates/runx-runtime/src/receipts/store.rs
@@ -1,7 +1,7 @@
 // rust-style-allow: large-file -- local store read/write/index semantics stay
 // together until the receipt-store API finishes the hard-cutover review.
 use std::ffi::OsStr;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -759,7 +759,13 @@ fn write_temp_file(path: &Path, contents: &[u8], durable: bool) -> Result<(), st
 }
 
 fn sync_directory(path: &Path) -> Result<(), std::io::Error> {
-    File::open(path)?.sync_all()
+    #[cfg(windows)]
+    {
+        let _ = path;
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    fs::File::open(path)?.sync_all()
 }
 
 fn temp_file_name(file_name: &str) -> String {

--- a/skills/spam-risk-reviewer/SKILL.md
+++ b/skills/spam-risk-reviewer/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: spam-risk-reviewer
+description: Review supplied campaign, list hygiene, and sender authentication signals before a send-as preflight can clear.
+runx:
+  category: deliverability
+---
+
+# Spam Risk Reviewer
+
+Use this skill when a campaign owner needs a read-only deliverability gate before
+a separate governed `send-as` run can send anything. The skill reads only the
+provided campaign draft, subscriber list metadata, and sender authentication
+posture. It returns a bounded `send_risk_verdict`.
+
+This skill never sends a message, never mints authority, never reads live DNS or
+domain state, and never emits `runx.operational_proposal.v1`. The public send
+effect belongs to `send-as`, not this reviewer. A non-clear verdict blocks
+`send-as` preflight and routes the case to human approval.
+
+## Inputs
+
+- `campaign_draft.from`: sender address or sender identity supplied by the
+  caller.
+- `campaign_draft.subject`: proposed subject line.
+- `campaign_draft.content_digest`: short summary of the message content and
+  consent context.
+- `list_metadata.size`: recipient count.
+- `list_metadata.bounce_rate`: recent or expected bounce rate as a decimal.
+- `list_metadata.complaint_rate`: recent complaint rate as a decimal.
+- `list_metadata.freshness`: supplied freshness signal for the audience.
+- `sender_auth_posture.spf_pass`: whether SPF passes.
+- `sender_auth_posture.dkim_pass`: whether DKIM passes.
+- `sender_auth_posture.dmarc_pass`: whether DMARC passes.
+- `sender_auth_posture.warm_up_days`: number of warm-up days for the sender.
+
+## Output
+
+The default runner returns:
+
+- `send_risk_verdict.risk_level`: `pass`, `hold`, or `refuse`.
+- `send_risk_verdict.preflight_clear`: boolean; true only when the send-as
+  preflight may continue.
+- `send_risk_verdict.blockers[]`: concrete reasons when the preflight must stop.
+- `send_risk_verdict.evidence_summary`: supplied facts and thresholds used.
+
+## Decision Rules
+
+- Refuse to set `preflight_clear` true when SPF, DKIM, or DMARC do not pass.
+- Refuse to clear preflight when bounce rate exceeds 0.02.
+- Refuse to clear preflight when complaint rate exceeds 0.001.
+- Treat unknown or stale list freshness as a blocker.
+- Treat sender warm-up below 14 days as a blocker.
+- Never invent authentication, consent, freshness, bounce, or complaint signals
+  that are not present in the input.
+- Route borderline, missing, or high-risk cases to the `send-as` human approval
+  lane. The actual delivery remains a separate governed `send-as` run.
+
+## Harness Cases
+
+- `low-risk-verified-sender`: full SPF, DKIM, and DMARC pass; list hygiene is
+  inside policy; warm-up is mature. Expected verdict is `pass` with
+  `preflight_clear: true` and no blockers.
+- `high-risk-incomplete-auth-poor-list`: DKIM fails and list metrics exceed
+  policy. Expected verdict is `hold`, `preflight_clear: false`, blockers naming
+  each risk, and escalation to human approval.
+- `missing-authentication-stop`: authentication and list hygiene are not
+  sufficiently supplied. Expected status is `needs_agent`, proving the reviewer
+  stops instead of inventing signals.
+
+## Quality Profile
+
+- Purpose: make one bounded deliverability risk judgment before send-as.
+- Audience: operators using send-as preflight and human approval gates.
+- Evidence bar: cite only supplied authentication and list hygiene metrics.
+- Safety bar: no send effect, no live-domain lookup, no authority mint, no
+  operational proposal, and no private data access.

--- a/skills/spam-risk-reviewer/X.yaml
+++ b/skills/spam-risk-reviewer/X.yaml
@@ -1,0 +1,135 @@
+skill: spam-risk-reviewer
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: low-risk-verified-sender
+      runner: triage
+      inputs:
+        campaign_draft:
+          from: "newsletter@example.org"
+          subject: "June product update for workspace admins"
+          content_digest: "Opt-in product update for existing admins, includes sender identity, preference link, and unsubscribe footer."
+        list_metadata:
+          size: 1250
+          bounce_rate: 0.004
+          complaint_rate: 0.0001
+          freshness: "active_opt_in_last_45_days"
+        sender_auth_posture:
+          spf_pass: true
+          dkim_pass: true
+          dmarc_pass: true
+          warm_up_days: 45
+      caller:
+        answers:
+          agent_task.spam-risk-reviewer.output:
+            send_risk_verdict:
+              risk_level: "pass"
+              preflight_clear: true
+              blockers: []
+              evidence_summary:
+                authentication: "SPF, DKIM, and DMARC all pass."
+                list_hygiene: "bounce_rate 0.004 <= 0.02, complaint_rate 0.0001 <= 0.001, freshness active_opt_in_last_45_days."
+                content_flags: []
+                routing: "send-as preflight may continue; public_send remains owned by the separate send-as run."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: high-risk-incomplete-auth-poor-list
+      runner: triage
+      inputs:
+        campaign_draft:
+          from: "promo@example.net"
+          subject: "Urgent free offer for all contacts"
+          content_digest: "Cold promotional copy with weak consent evidence and sweepstakes language; sender identity is incomplete."
+        list_metadata:
+          size: 84000
+          bounce_rate: 0.067
+          complaint_rate: 0.004
+          freshness: "unknown_or_stale_365d"
+        sender_auth_posture:
+          spf_pass: true
+          dkim_pass: false
+          dmarc_pass: true
+          warm_up_days: 3
+      caller:
+        answers:
+          agent_task.spam-risk-reviewer.output:
+            send_risk_verdict:
+              risk_level: "hold"
+              preflight_clear: false
+              blockers:
+                - "DKIM does not pass."
+                - "bounce_rate 0.067 exceeds policy threshold 0.02."
+                - "complaint_rate 0.004 exceeds policy threshold 0.001."
+                - "freshness unknown_or_stale_365d is not acceptable for preflight clearance."
+                - "warm_up_days 3 is below the 14 day minimum."
+              evidence_summary:
+                authentication: "SPF and DMARC pass, but DKIM does not pass."
+                list_hygiene: "Large list with high bounce and complaint rates plus stale freshness signal."
+                content_flags:
+                  - "cold promotional copy"
+                  - "weak consent evidence"
+                  - "incomplete sender identity"
+                routing: "send-as preflight is blocked and the case routes to the send-as human approval lane."
+            escalation:
+              lane: "send-as-human-approval"
+              reason: "A non-clear verdict cannot satisfy send-as preflight."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: missing-authentication-stop
+      runner: triage
+      inputs:
+        campaign_draft:
+          from: "unknown@example.invalid"
+          subject: "Quick update"
+          content_digest: "Campaign draft is present, but consent and sender identity are not grounded."
+        list_metadata:
+          size: 5000
+          bounce_rate: null
+          complaint_rate: null
+          freshness: "unknown"
+        sender_auth_posture:
+          spf_pass: null
+          dkim_pass: null
+          dmarc_pass: null
+          warm_up_days: null
+      expect:
+        status: needs_agent
+
+runners:
+  triage:
+    default: true
+    type: agent-task
+    agent: operator
+    task: "spam-risk-reviewer"
+    outputs:
+      send_risk_verdict: object
+      escalation: object
+    artifacts:
+      wrap_as: send_risk_verdict
+      packet: "runx.send_risk_verdict.v1"
+    inputs:
+      campaign_draft:
+        type: json
+        required: true
+        description: "Provided campaign draft with from, subject, and content_digest."
+      list_metadata:
+        type: json
+        required: true
+        description: "Provided list size, bounce_rate, complaint_rate, and freshness."
+      sender_auth_posture:
+        type: json
+        required: true
+        description: "Provided SPF, DKIM, DMARC, and sender warm-up signals."

--- a/skills/spam-risk-reviewer/fixtures/high-risk-incomplete-auth-poor-list.json
+++ b/skills/spam-risk-reviewer/fixtures/high-risk-incomplete-auth-poor-list.json
@@ -1,0 +1,19 @@
+{
+  "campaign_draft": {
+    "from": "promo@example.net",
+    "subject": "Urgent free offer for all contacts",
+    "content_digest": "Cold promotional copy with weak consent evidence and sweepstakes language; sender identity is incomplete."
+  },
+  "list_metadata": {
+    "size": 84000,
+    "bounce_rate": 0.067,
+    "complaint_rate": 0.004,
+    "freshness": "unknown_or_stale_365d"
+  },
+  "sender_auth_posture": {
+    "spf_pass": true,
+    "dkim_pass": false,
+    "dmarc_pass": true,
+    "warm_up_days": 3
+  }
+}

--- a/skills/spam-risk-reviewer/fixtures/low-risk-verified-sender.json
+++ b/skills/spam-risk-reviewer/fixtures/low-risk-verified-sender.json
@@ -1,0 +1,19 @@
+{
+  "campaign_draft": {
+    "from": "newsletter@example.org",
+    "subject": "June product update for workspace admins",
+    "content_digest": "Opt-in product update for existing admins, includes sender identity, preference link, and unsubscribe footer."
+  },
+  "list_metadata": {
+    "size": 1250,
+    "bounce_rate": 0.004,
+    "complaint_rate": 0.0001,
+    "freshness": "active_opt_in_last_45_days"
+  },
+  "sender_auth_posture": {
+    "spf_pass": true,
+    "dkim_pass": true,
+    "dmarc_pass": true,
+    "warm_up_days": 45
+  }
+}

--- a/skills/spam-risk-reviewer/fixtures/missing-authentication-stop.json
+++ b/skills/spam-risk-reviewer/fixtures/missing-authentication-stop.json
@@ -1,0 +1,19 @@
+{
+  "campaign_draft": {
+    "from": "unknown@example.invalid",
+    "subject": "Quick update",
+    "content_digest": "Campaign draft is present, but consent and sender identity are not grounded."
+  },
+  "list_metadata": {
+    "size": 5000,
+    "bounce_rate": null,
+    "complaint_rate": null,
+    "freshness": "unknown"
+  },
+  "sender_auth_posture": {
+    "spf_pass": null,
+    "dkim_pass": null,
+    "dmarc_pass": null,
+    "warm_up_days": null
+  }
+}

--- a/skills/spam-risk-reviewer/harness-evidence/evidence.json
+++ b/skills/spam-risk-reviewer/harness-evidence/evidence.json
@@ -3,13 +3,66 @@
   "bounty_id": 62,
   "package": "spam-risk-reviewer",
   "owner": "liomilet4-png",
+  "summary": "spam-risk-reviewer is a bounded read-only runx skill for reviewing supplied campaign draft, list hygiene, and sender authentication posture before a separate send-as workflow continues. The public package was published, installed from the registry, exercised on synthetic inputs, and checked with a local dogfood receipt; it never sends email, reads live DNS, mints authority, or uses customer data.",
   "registry_ref": "liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd",
+  "receipt_ref": "runx:receipt:sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7",
+  "runx_cli_version": "runx-cli 0.6.15",
   "public_url": "https://runx.ai/x/liomilet4-png/spam-risk-reviewer",
   "source_url": "https://github.com/liomilet4-png/runx/tree/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer",
   "pull_request_url": "https://github.com/runxhq/runx/pull/213",
   "source_commit": "659d3bb2acbd8c7ba970fad8fb616086bd127d20",
   "skill_md": "https://raw.githubusercontent.com/liomilet4-png/runx/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer/SKILL.md",
   "x_yaml": "https://raw.githubusercontent.com/liomilet4-png/runx/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer/X.yaml",
+  "observations": [
+    {
+      "name": "runx cli version",
+      "command": "npx -y @runxhq/cli@0.6.15 --version",
+      "status": "passed",
+      "evidence": "runx-cli 0.6.15"
+    },
+    {
+      "name": "registry publish",
+      "command": "POST https://api.runx.ai/v1/skills using the spam-risk-reviewer package and harness",
+      "status": "passed",
+      "evidence": "HTTP 201, status=published, harness_status=passed, case_count=3, assertion_error_count=0"
+    },
+    {
+      "name": "registry read",
+      "command": "runx registry read liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai --json",
+      "status": "passed",
+      "evidence": "skill_id=liomilet4-png/spam-risk-reviewer, version=sha-659d3bb2acbd, digest=sha256:04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89"
+    },
+    {
+      "name": "clean install",
+      "command": "runx add liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai",
+      "status": "passed",
+      "evidence": "signed install succeeded with runx-registry-ed25519-v1 and digest sha256:04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89"
+    },
+    {
+      "name": "dogfood triage",
+      "command": "runx skill liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd triage using synthetic low-risk campaign/list/auth inputs",
+      "status": "passed",
+      "evidence": "the skill requested structured agent answers without sending email or touching customer data"
+    },
+    {
+      "name": "dogfood resume",
+      "command": "runx resume run_agent_task-spam-risk-reviewer-output answers_low_risk.json --receipt-dir receipts_patched --json",
+      "status": "passed",
+      "evidence": "sealed with receipt sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7 and pass/preflight_clear=true"
+    },
+    {
+      "name": "receipt verify check",
+      "command": "npx -y @runxhq/cli@0.6.15 verify --receipt C:\\runx62_dogfood\\receipts_patched\\sha256-3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7.json --json --allow-local-development-signatures",
+      "status": "partial",
+      "evidence": "digest and content address are valid; released verifier reports local-development signature_malformed for the local audit signature, so this evidence does not claim a trusted registry signature"
+    },
+    {
+      "name": "scope safety",
+      "command": "manual artifact review",
+      "status": "passed",
+      "evidence": "fixtures are synthetic; the skill does not call public_send, live DNS, private services, wallet, payment, or customer data"
+    }
+  ],
   "registry_publish": {
     "http_status": 201,
     "status": "published",

--- a/skills/spam-risk-reviewer/harness-evidence/evidence.json
+++ b/skills/spam-risk-reviewer/harness-evidence/evidence.json
@@ -1,0 +1,83 @@
+{
+  "schema": "runx.skill_delivery_evidence.v1",
+  "bounty_id": 62,
+  "package": "spam-risk-reviewer",
+  "owner": "liomilet4-png",
+  "registry_ref": "liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd",
+  "public_url": "https://runx.ai/x/liomilet4-png/spam-risk-reviewer",
+  "source_url": "https://github.com/liomilet4-png/runx/tree/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer",
+  "pull_request_url": "https://github.com/runxhq/runx/pull/213",
+  "source_commit": "659d3bb2acbd8c7ba970fad8fb616086bd127d20",
+  "skill_md": "https://raw.githubusercontent.com/liomilet4-png/runx/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer/SKILL.md",
+  "x_yaml": "https://raw.githubusercontent.com/liomilet4-png/runx/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer/X.yaml",
+  "registry_publish": {
+    "http_status": 201,
+    "status": "published",
+    "digest": "04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89",
+    "profile_digest": "30a7923a40027c20218cdd7b078095a27ff49581cee14265e61274576fafd517",
+    "trust_tier": "community",
+    "maturity": "beta"
+  },
+  "published_harness": {
+    "status": "passed",
+    "case_count": 3,
+    "assertion_error_count": 0,
+    "case_names": [
+      "low-risk-verified-sender",
+      "high-risk-incomplete-auth-poor-list",
+      "missing-authentication-stop"
+    ],
+    "receipt_ids": [
+      "sha256:9ff08d52779c25f36211296f0248cda44b8fd6fc9150bca849355d2e0c8e77e5",
+      "sha256:d822ce2f381571fb2a3535f3bcdbde6f57e7e408c96fe0131bab5edbe30488cc"
+    ],
+    "evidence_id": "runx-harness:liomilet4-png/spam-risk-reviewer:sha-659d3bb2acbd",
+    "evidence_url": "https://runx.ai/x/liomilet4-png/spam-risk-reviewer#harness"
+  },
+  "clean_install": {
+    "cli": "@runxhq/cli@0.6.15",
+    "command": "runx add liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai",
+    "status": "installed",
+    "signed": "yes (runx-registry-ed25519-v1)",
+    "digest": "sha256:04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89"
+  },
+  "dogfood": {
+    "scenario": "low-risk-verified-sender",
+    "input_scope": "synthetic campaign draft, synthetic list metadata, and synthetic sender authentication posture",
+    "send_effect": "none",
+    "status": "sealed",
+    "receipt_id": "sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7",
+    "receipt_digest": "sha256:a9672b0ecb647b2873eb14fa90decc7599bd1b8846c05d83fc93e1e3f8cdf57a",
+    "structured_output": {
+      "send_risk_verdict": {
+        "risk_level": "pass",
+        "preflight_clear": true,
+        "blockers": [],
+        "evidence_summary": {
+          "authentication": "SPF, DKIM, and DMARC all pass.",
+          "list_hygiene": "bounce_rate 0.004 <= 0.02, complaint_rate 0.0001 <= 0.001, freshness active_opt_in_last_45_days.",
+          "content_flags": [],
+          "routing": "send-as preflight may continue; public_send remains owned by the separate send-as run."
+        }
+      },
+      "escalation": {
+        "lane": "none",
+        "reason": "Low-risk supplied signals clear the reviewer gate only; no send action is performed."
+      }
+    }
+  },
+  "windows_note": {
+    "official_cli": "@runxhq/cli@0.6.15",
+    "official_cli_registry_read": "success",
+    "official_cli_clean_install": "success",
+    "official_cli_resume_on_windows": "blocked by existing Windows receipt-store directory sync error: os error 5",
+    "pr_fix_scope": "crates/runx-runtime/src/receipts/store.rs skips directory fsync on Windows while preserving file fsync and index rebuild"
+  },
+  "safety": {
+    "uses_real_customer_data": false,
+    "sends_email_or_public_send": false,
+    "reads_live_dns_or_private_domain_state": false,
+    "mints_authority": false,
+    "emits_operational_proposal": false
+  }
+}

--- a/skills/spam-risk-reviewer/harness-evidence/report.md
+++ b/skills/spam-risk-reviewer/harness-evidence/report.md
@@ -14,6 +14,7 @@ does not mint authority, and does not emit an operational proposal.
 - Registry ref: `liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd`
 - Registry page: <https://runx.ai/x/liomilet4-png/spam-risk-reviewer>
 - PR: <https://github.com/runxhq/runx/pull/213>
+- Delivery receipt ref: `runx:receipt:sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7`
 - Source commit: `659d3bb2acbd8c7ba970fad8fb616086bd127d20`
 - Skill source: <https://github.com/liomilet4-png/runx/tree/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer>
 
@@ -35,6 +36,10 @@ hygiene inputs are missing instead of inventing signals.
 - Registry publish harness: passed, `case_count=3`, `assertion_error_count=0`.
 - Dogfood with synthetic low-risk input: sealed with receipt
   `sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7`.
+- Receipt verification using `@runxhq/cli@0.6.15`: digest and content-address
+  checks are valid. The released verifier reports `signature_malformed` for the
+  local-development audit signature, so this report does not claim the dogfood
+  receipt has a trusted registry signature.
 
 ## Windows note
 

--- a/skills/spam-risk-reviewer/harness-evidence/report.md
+++ b/skills/spam-risk-reviewer/harness-evidence/report.md
@@ -1,0 +1,54 @@
+# spam-risk-reviewer delivery report
+
+## Summary
+
+This delivery adds `spam-risk-reviewer`, a bounded read-only deliverability gate for
+reviewing supplied campaign, list hygiene, and sender authentication signals
+before a separate governed `send-as` run can continue.
+
+The skill does not send messages, does not read live DNS or private domain state,
+does not mint authority, and does not emit an operational proposal.
+
+## Public artifacts
+
+- Registry ref: `liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd`
+- Registry page: <https://runx.ai/x/liomilet4-png/spam-risk-reviewer>
+- PR: <https://github.com/runxhq/runx/pull/213>
+- Source commit: `659d3bb2acbd8c7ba970fad8fb616086bd127d20`
+- Skill source: <https://github.com/liomilet4-png/runx/tree/659d3bb2acbd8c7ba970fad8fb616086bd127d20/skills/spam-risk-reviewer>
+
+## Harness coverage
+
+The registry publish harness passed with three cases:
+
+- `low-risk-verified-sender`
+- `high-risk-incomplete-auth-poor-list`
+- `missing-authentication-stop`
+
+The third case verifies the required stop behavior when authentication and list
+hygiene inputs are missing instead of inventing signals.
+
+## Verification
+
+- `runx registry read` using `@runxhq/cli@0.6.15`: passed.
+- Clean install using `@runxhq/cli@0.6.15`: passed.
+- Registry publish harness: passed, `case_count=3`, `assertion_error_count=0`.
+- Dogfood with synthetic low-risk input: sealed with receipt
+  `sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7`.
+
+## Windows note
+
+The released Windows CLI `@runxhq/cli@0.6.15` can read the registry and cleanly
+install the package. A follow-up `resume` on Windows currently hits the existing
+receipt-store directory sync error (`os error 5`). This PR includes the minimal
+runtime fix in `crates/runx-runtime/src/receipts/store.rs`: on Windows it skips
+directory `fsync` while preserving receipt file `sync_all` and index rebuilds.
+
+Using the PR-patched Windows CLI, the same dogfood flow seals successfully.
+
+## Safety boundaries
+
+- Synthetic fixture inputs only.
+- No real recipient list, customer data, DNS lookup, or private service access.
+- No `public_send` or equivalent send effect.
+- The skill only returns `send_risk_verdict` and optional escalation guidance.

--- a/skills/spam-risk-reviewer/harness-evidence/verification.json
+++ b/skills/spam-risk-reviewer/harness-evidence/verification.json
@@ -2,6 +2,54 @@
   "schema": "runx.skill_delivery_verification.v1",
   "bounty_id": 62,
   "package": "spam-risk-reviewer",
+  "summary": "Verification covers registry publication, registry read, clean install, harness coverage, synthetic dogfood execution, and receipt verification behavior for the spam-risk-reviewer package.",
+  "registry_ref": "liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd",
+  "receipt_ref": "runx:receipt:sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7",
+  "runx_cli_version": "runx-cli 0.6.15",
+  "observations": [
+    {
+      "name": "runx cli version",
+      "command": "npx -y @runxhq/cli@0.6.15 --version",
+      "status": "passed",
+      "observed": "runx-cli 0.6.15"
+    },
+    {
+      "name": "registry publish harness",
+      "command": "POST https://api.runx.ai/v1/skills using skills/spam-risk-reviewer package payload",
+      "status": "passed",
+      "observed": "HTTP 201, status=published, harness_status=passed, case_count=3, assertion_error_count=0"
+    },
+    {
+      "name": "registry read",
+      "command": "runx registry read liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai --json",
+      "status": "passed",
+      "observed": "trusted community package with digest sha256:04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89"
+    },
+    {
+      "name": "clean install",
+      "command": "runx add liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai",
+      "status": "passed",
+      "observed": "signed install completed"
+    },
+    {
+      "name": "dogfood run",
+      "command": "runx skill liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd triage with synthetic low-risk fixture input",
+      "status": "passed",
+      "observed": "agent answer collection was requested without a send side effect"
+    },
+    {
+      "name": "dogfood resume",
+      "command": "runx resume run_agent_task-spam-risk-reviewer-output answers_low_risk.json --receipt-dir receipts_patched --json",
+      "status": "passed",
+      "observed": "sealed receipt sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7"
+    },
+    {
+      "name": "receipt verify",
+      "command": "npx -y @runxhq/cli@0.6.15 verify --receipt C:\\runx62_dogfood\\receipts_patched\\sha256-3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7.json --json --allow-local-development-signatures",
+      "status": "partial",
+      "observed": "digest and content_address valid; local-development signature reported signature_malformed by released verifier"
+    }
+  ],
   "checks": [
     {
       "name": "published registry read",
@@ -18,7 +66,7 @@
     },
     {
       "name": "published harness",
-      "command": "registry publish response from https://api.runx.ai/v1/skills",
+      "command": "POST https://api.runx.ai/v1/skills using skills/spam-risk-reviewer package payload",
       "tooling": "runx registry API",
       "status": "passed",
       "observed": {
@@ -41,7 +89,7 @@
     },
     {
       "name": "dogfood run with synthetic low-risk input",
-      "command": "runx skill ... then runx resume run_agent_task-spam-risk-reviewer-output answers_low_risk.json --receipt-dir receipts_patched --json",
+      "command": "runx skill liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd triage with synthetic low-risk fixture input; runx resume run_agent_task-spam-risk-reviewer-output answers_low_risk.json --receipt-dir receipts_patched --json",
       "tooling": "patched Windows CLI from PR branch",
       "status": "passed",
       "observed": {
@@ -50,6 +98,20 @@
         "risk_level": "pass",
         "preflight_clear": true,
         "blocker_count": 0
+      }
+    },
+    {
+      "name": "dogfood receipt verify",
+      "command": "npx -y @runxhq/cli@0.6.15 verify --receipt C:\\runx62_dogfood\\receipts_patched\\sha256-3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7.json --json --allow-local-development-signatures",
+      "tooling": "@runxhq/cli@0.6.15",
+      "status": "partial",
+      "observed": {
+        "digest_status": "valid",
+        "content_address_status": "valid",
+        "receipt_id": "sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7",
+        "signature_status": "invalid",
+        "signature_finding": "signature_malformed",
+        "note": "This is a local audit receipt from the PR-patched Windows dogfood run, not a trusted registry signature."
       }
     },
     {

--- a/skills/spam-risk-reviewer/harness-evidence/verification.json
+++ b/skills/spam-risk-reviewer/harness-evidence/verification.json
@@ -1,0 +1,84 @@
+{
+  "schema": "runx.skill_delivery_verification.v1",
+  "bounty_id": 62,
+  "package": "spam-risk-reviewer",
+  "checks": [
+    {
+      "name": "published registry read",
+      "command": "runx registry read liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai --json",
+      "tooling": "@runxhq/cli@0.6.15",
+      "status": "passed",
+      "observed": {
+        "skill_id": "liomilet4-png/spam-risk-reviewer",
+        "version": "sha-659d3bb2acbd",
+        "digest": "sha256:04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89",
+        "trust_state": "trusted",
+        "trust_tier": "community"
+      }
+    },
+    {
+      "name": "published harness",
+      "command": "registry publish response from https://api.runx.ai/v1/skills",
+      "tooling": "runx registry API",
+      "status": "passed",
+      "observed": {
+        "http_status": 201,
+        "harness_status": "passed",
+        "case_count": 3,
+        "assertion_error_count": 0
+      }
+    },
+    {
+      "name": "clean install",
+      "command": "runx add liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai",
+      "tooling": "@runxhq/cli@0.6.15",
+      "status": "passed",
+      "observed": {
+        "status": "installed",
+        "signed": "yes (runx-registry-ed25519-v1)",
+        "digest": "sha256:04af3daac9439b5761cbf735a56f9bda4d94f4a19336819962445cec22a9dd89"
+      }
+    },
+    {
+      "name": "dogfood run with synthetic low-risk input",
+      "command": "runx skill ... then runx resume run_agent_task-spam-risk-reviewer-output answers_low_risk.json --receipt-dir receipts_patched --json",
+      "tooling": "patched Windows CLI from PR branch",
+      "status": "passed",
+      "observed": {
+        "final_status": "sealed",
+        "receipt_id": "sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7",
+        "risk_level": "pass",
+        "preflight_clear": true,
+        "blocker_count": 0
+      }
+    },
+    {
+      "name": "official Windows resume limitation",
+      "command": "runx resume run_agent_task-spam-risk-reviewer-output answers_low_risk.json --receipt-dir receipts_ci --json",
+      "tooling": "@runxhq/cli@0.6.15 on Windows",
+      "status": "known_blocked",
+      "observed": {
+        "error": "receipt store is unreadable: access denied (os error 5)",
+        "mitigation": "the PR includes the Windows receipt-store directory sync fix used by the patched CLI dogfood run"
+      }
+    }
+  ],
+  "fixtures": [
+    "fixtures/low-risk-verified-sender.json",
+    "fixtures/high-risk-incomplete-auth-poor-list.json",
+    "fixtures/missing-authentication-stop.json"
+  ],
+  "requirements_coverage": {
+    "typed_inputs": [
+      "campaign_draft",
+      "list_metadata",
+      "sender_auth_posture"
+    ],
+    "bounded_output": "send_risk_verdict",
+    "has_stop_case": true,
+    "no_send_effect": true,
+    "public_pr": true,
+    "published_registry_package": true,
+    "clean_install_verified": true
+  }
+}


### PR DESCRIPTION
## Summary

Add `spam-risk-reviewer`, a read-only runx skill for deliverability preflight review.

- evaluates supplied campaign, list hygiene, and sender-authentication signals
- emits bounded `send_risk_verdict` output only
- includes low-risk pass, high-risk hold, and missing-evidence stop harness cases plus fixtures
- skips directory fsync on Windows receipt stores so local harness indexing can complete after receipt files are written

## Public Artifacts

- Registry ref: `liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd`
- Registry page: https://runx.ai/x/liomilet4-png/spam-risk-reviewer
- Evidence: https://raw.githubusercontent.com/liomilet4-png/runx/2593bb43a5ba0aec705f68b9915276b33064b030/skills/spam-risk-reviewer/harness-evidence/evidence.json
- Verification: https://raw.githubusercontent.com/liomilet4-png/runx/2593bb43a5ba0aec705f68b9915276b33064b030/skills/spam-risk-reviewer/harness-evidence/verification.json
- Report: https://raw.githubusercontent.com/liomilet4-png/runx/2593bb43a5ba0aec705f68b9915276b33064b030/skills/spam-risk-reviewer/harness-evidence/report.md

## Validation

- `runx-cli 0.6.13`
- `cargo run --manifest-path crates\Cargo.toml -p runx-cli -- harness .\skills\spam-risk-reviewer --receipt-dir receipts_62_local_stopcase --json`
- Result: `status=passed`, `case_count=3`, `assertion_error_count=0`

Published registry harness:

- `http_status=201`
- `harness.status=passed`
- `harness.case_count=3`
- `harness.assertion_error_count=0`

Clean install:

- `runx add liomilet4-png/spam-risk-reviewer@sha-659d3bb2acbd --registry https://api.runx.ai`
- Result: `status=installed`, signed by `runx-registry-ed25519-v1`

Dogfood:

- Synthetic low-risk input only; no email send or public-send effect.
- Final status: `sealed`
- Receipt: `sha256:3fa99e0f7d51a886cac4e6611763d44e12e55a7d36500d766fcc17a01e5e53a7`

## Scope

The skill does not send mail, mint authority, read live DNS/domain state, or emit `runx.operational_proposal.v1`. The Windows receipt-store change is limited to directory fsync behavior; receipt files are still written and synced before the store index is rebuilt.