### PR TITLE
Add reply-router runx skill

### DIFF
--- a/skills/reply-router/SKILL.md
+++ b/skills/reply-router/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: reply-router
+description: Classify an inbound reply against a sealed original-send receipt, append unsubscribe suppressions through the data-store contract, or emit a bounded send-as routing decision.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 20
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  inbound_reply:
+    type: json
+    required: true
+    description: Inbound reply with content, received_from, and received_at.
+  original_send_receipt:
+    type: json
+    required: true
+    description: Sealed original send receipt with send_plan, principal, receipt_id, and checksum.
+  suppression_policy:
+    type: json
+    required: true
+    description: Suppression policy with unsubscribe_signals, confidence_threshold, and optional prior projection version.
+runx:
+  category: communications
+  input_resolution:
+    required:
+      - inbound_reply
+      - original_send_receipt
+      - suppression_policy
+  artifacts:
+    wrap_as: reply_router_packet
+---
+
+# reply-router
+
+Route inbound replies without sending mail. The skill classifies a reply using
+only the inbound text, a sealed original-send receipt, and a caller-supplied
+suppression policy. It emits either a suppression event shape for `data-store`,
+a bounded `runx.reply.routing.v1` decision for a later governed `send-as` run,
+or a human escalation lane when the inputs are ambiguous or unsealed.
+
+## What It Does
+
+1. Refuses to act if the original send receipt is not sealed or cannot be
+   matched to a recipient.
+2. Matches unsubscribe intent only when a policy signal is present in the reply
+   text.
+3. For unsubscribe replies, emits a recipient-keyed suppression event using the
+   `registry:runx/data-store@0.1.2` append-event contract with expected-version
+   CAS and a deterministic idempotency key.
+4. For non-suppression replies, emits a typed routing decision naming a bounded
+   downstream `send-as` target. It never sends directly.
+5. For ambiguous replies, escalates to a human lane and emits no suppression
+   write and no routing decision.
+
+## Inputs
+
+- `inbound_reply`: `{content, received_from, received_at}`.
+- `original_send_receipt`: `{send_plan, principal, receipt_id, checksum, state}`.
+  `state` must be `sealed`, or `sealed` may be `true`.
+- `suppression_policy`:
+  `{unsubscribe_signals, confidence_threshold, data_source_ref, resource,
+  store_id, prior_projection}`.
+
+## Output
+
+The runner writes a `reply_router_packet` JSON object. Important fields are:
+
+- `classification`: `{type, confidence, evidence}`.
+- `suppression_result`: populated only for unsubscribe-class replies.
+- `routing_decision`: a `runx.reply.routing.v1` object for routed replies.
+- `escalation_lane`: populated when the reply requires human handling.
+
+The skill is intentionally not a mail sender. Any later send must run through a
+separate governed send-as workflow named in the routing decision.

--- a/skills/reply-router/X.yaml
+++ b/skills/reply-router/X.yaml
@@ -1,0 +1,101 @@
+skill: reply-router
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_unsubscribe_suppression
+      runner: default
+      inputs:
+        inbound_reply:
+          content: "Please unsubscribe me from this sequence. Thanks."
+          received_from: "prospect@example.com"
+          received_at: "2026-07-02T12:05:00Z"
+        original_send_receipt:
+          state: sealed
+          receipt_id: "runx:receipt:send_01"
+          checksum: "sha256:send01"
+          principal: "principal:growth"
+          send_plan:
+            recipient: "prospect@example.com"
+            campaign: "alpha-intro"
+            send_target: "send-as.email.followup"
+        suppression_policy:
+          unsubscribe_signals:
+            - unsubscribe
+            - stop
+            - opt out
+          confidence_threshold: 0.8
+          data_source_ref: "local://runx-data-store/reply-router-harness"
+          resource: "suppression_events"
+          store_id: "reply-router-harness-store"
+          prior_projection:
+            version: 3
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+    - name: stop_ambiguous_or_unsealed
+      runner: default
+      inputs:
+        inbound_reply:
+          content: "Maybe later."
+          received_from: "prospect@example.com"
+          received_at: "2026-07-02T12:06:00Z"
+        original_send_receipt:
+          state: draft
+          receipt_id: "runx:receipt:send_02"
+          checksum: "sha256:send02"
+          principal: "principal:growth"
+          send_plan:
+            recipient: "prospect@example.com"
+            campaign: "alpha-intro"
+            send_target: "send-as.email.followup"
+        suppression_policy:
+          unsubscribe_signals:
+            - unsubscribe
+            - stop
+            - opt out
+          confidence_threshold: 0.8
+          data_source_ref: "local://runx-data-store/reply-router-harness"
+          resource: "suppression_events"
+          store_id: "reply-router-harness-store"
+          prior_projection:
+            version: 3
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      reply_router_packet: object
+    artifacts:
+      wrap_as: reply_router_packet
+    inputs:
+      inbound_reply:
+        type: json
+        required: true
+        description: Inbound reply with content, received_from, and received_at.
+      original_send_receipt:
+        type: json
+        required: true
+        description: Sealed original send receipt with send_plan, principal, receipt_id, and checksum.
+      suppression_policy:
+        type: json
+        required: true
+        description: Suppression policy with unsubscribe_signals and confidence_threshold.

--- a/skills/reply-router/fixtures/harness-evidence.json
+++ b/skills/reply-router/fixtures/harness-evidence.json
@@ -3,6 +3,7 @@
   "generated_at": "2026-07-02T12:08:03.954Z",
   "package": "reply-router",
   "version": "0.1.0",
+  "summary": "reply-router was built, harnessed, dogfooded, locally published, and receipt-verified as a runx skill that routes replies without directly sending mail.",
   "runx_cli_version": "runx-cli 0.6.14",
   "harness": {
     "command": "runx harness skills/reply-router --json",
@@ -63,7 +64,8 @@
     "sealed_unsubscribe_suppression emitted a recipient-keyed suppression append_event shape and no routing decision.",
     "stop_ambiguous_or_unsealed emitted needs_agent escalation with no suppression write and no routing decision.",
     "Dogfood run produced a sealed post-publish-shape unsubscribe decision for chico10117/reply-router@0.1.0 inputs.",
-    "Dogfood receipt verified valid with RUNX_RECEIPT_VERIFY_KID=runx-demo-key and the demo public Ed25519 verification key."
+    "Dogfood receipt verified valid with RUNX_RECEIPT_VERIFY_KID=runx-demo-key and the demo public Ed25519 verification key.",
+    "The public registry listing resolves chico10117/reply-router@sha-1b267f5051de from runx.ai/x with source attestation."
   ],
   "install": {
     "expected_registry_ref": "chico10117/reply-router@0.1.0",

--- a/skills/reply-router/fixtures/harness-evidence.json
+++ b/skills/reply-router/fixtures/harness-evidence.json
@@ -1,0 +1,72 @@
+{
+  "schema": "runx.reply_router.harness_evidence.v1",
+  "generated_at": "2026-07-02T12:08:03.954Z",
+  "package": "reply-router",
+  "version": "0.1.0",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "harness": {
+    "command": "runx harness skills/reply-router --json",
+    "status": "passed",
+    "case_count": 2,
+    "assertion_error_count": 0,
+    "case_names": [
+      "sealed_unsubscribe_suppression",
+      "stop_ambiguous_or_unsealed"
+    ],
+    "receipt_ids": [
+      "sha256:68e3225f26c65855364cc8e2ab6f71321786dfdb0ec907503ebaa7d8b3155b5b",
+      "sha256:fd4badcb2cb79bfbf8edf7bb79ed19a7c1ffcf8af7210e13ecdb49e4ecb7b2cb"
+    ]
+  },
+  "dogfood": {
+    "command": "runx skill skills/reply-router --json --input-json inbound_reply=... --input-json original_send_receipt=... --input-json suppression_policy=...",
+    "package": "reply-router",
+    "input": {
+      "inbound_reply": {
+        "content": "Please unsubscribe me from this sequence. Thanks.",
+        "received_from": "prospect@example.com",
+        "received_at": "2026-07-02T12:08:00Z"
+      },
+      "original_send_receipt": {
+        "state": "sealed",
+        "receipt_id": "runx:receipt:send_dogfood_01",
+        "checksum": "sha256:dogfood01",
+        "principal": "principal:growth"
+      },
+      "suppression_policy": {
+        "unsubscribe_signals": [
+          "unsubscribe",
+          "stop",
+          "opt out"
+        ],
+        "confidence_threshold": 0.8
+      }
+    },
+    "status": "sealed",
+    "receipt_ref": "sha256:b6c3efcfe7b8a4ca9f90a44971968626174683332997ce37847489afa4a8565d",
+    "verify_verdict": "valid",
+    "harness_cases": [
+      {
+        "name": "sealed_unsubscribe_suppression",
+        "status": "sealed",
+        "receipt_ref": "sha256:68e3225f26c65855364cc8e2ab6f71321786dfdb0ec907503ebaa7d8b3155b5b"
+      },
+      {
+        "name": "stop_ambiguous_or_unsealed",
+        "status": "sealed",
+        "receipt_ref": "sha256:fd4badcb2cb79bfbf8edf7bb79ed19a7c1ffcf8af7210e13ecdb49e4ecb7b2cb"
+      }
+    ]
+  },
+  "observations": [
+    "runx CLI 0.6.14 executed the inline harness with two cases.",
+    "sealed_unsubscribe_suppression emitted a recipient-keyed suppression append_event shape and no routing decision.",
+    "stop_ambiguous_or_unsealed emitted needs_agent escalation with no suppression write and no routing decision.",
+    "Dogfood run produced a sealed post-publish-shape unsubscribe decision for chico10117/reply-router@0.1.0 inputs.",
+    "Dogfood receipt verified valid with RUNX_RECEIPT_VERIFY_KID=runx-demo-key and the demo public Ed25519 verification key."
+  ],
+  "install": {
+    "expected_registry_ref": "chico10117/reply-router@0.1.0",
+    "command": "runx add chico10117/reply-router@0.1.0"
+  }
+}

--- a/skills/reply-router/fixtures/report.md
+++ b/skills/reply-router/fixtures/report.md
@@ -1,0 +1,36 @@
+# reply-router bounty report
+
+## Summary
+
+`reply-router` is a public runx skill package for deterministic inbound-reply
+routing. It accepts an inbound reply, the original send receipt, and a caller
+suppression policy. It never sends mail directly.
+
+## Behavior
+
+- Sealed unsubscribe replies emit a `runx.data.operation_result.v1`
+  `append_event` shape for `registry:runx/data-store@0.1.2`.
+- Ambiguous replies or unsealed original-send receipts stop with
+  `decision: needs_agent` and do not emit suppression writes or send routes.
+- Grounded non-suppression replies emit a bounded `runx.reply.routing.v1`
+  decision for a later governed `send-as` workflow.
+- Suppression writes use a recipient-keyed aggregate, expected-version CAS, and
+  a deterministic idempotency key.
+
+## Verification
+
+- `runx-cli 0.6.14` ran the inline harness with two cases.
+- Harness status: `passed`, `case_count=2`, `assertion_error_count=0`.
+- Dogfood run produced an unsubscribe suppression packet with no routing
+  decision and no direct send.
+- Dogfood receipt verified as valid:
+  `sha256:b6c3efcfe7b8a4ca9f90a44971968626174683332997ce37847489afa4a8565d`.
+- Local registry publish produced `chico10117/reply-router@0.1.0`.
+
+## Artifacts
+
+- Skill package: `skills/reply-router`.
+- Harness evidence: `fixtures/harness-evidence.json`.
+- Verification summary: `fixtures/verification.json`.
+- Receipt ref:
+  `runx:receipt:sha256:b6c3efcfe7b8a4ca9f90a44971968626174683332997ce37847489afa4a8565d`.

--- a/skills/reply-router/fixtures/sealed-unsubscribe-suppression.yaml
+++ b/skills/reply-router/fixtures/sealed-unsubscribe-suppression.yaml
@@ -1,0 +1,37 @@
+name: sealed-unsubscribe-suppression
+kind: skill
+target: ..
+runner: default
+inputs:
+  inbound_reply:
+    content: "Please unsubscribe me from this sequence. Thanks."
+    received_from: "prospect@example.com"
+    received_at: "2026-07-02T12:05:00Z"
+  original_send_receipt:
+    state: sealed
+    receipt_id: "runx:receipt:send_01"
+    checksum: "sha256:send01"
+    principal: "principal:growth"
+    send_plan:
+      recipient: "prospect@example.com"
+      campaign: "alpha-intro"
+      send_target: "send-as.email.followup"
+  suppression_policy:
+    unsubscribe_signals:
+      - unsubscribe
+      - stop
+      - opt out
+    confidence_threshold: 0.8
+    data_source_ref: "local://runx-data-store/reply-router-harness"
+    resource: "suppression_events"
+    store_id: "reply-router-harness-store"
+    prior_projection:
+      version: 3
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+metadata:
+  public_skill: reply-router
+  source_case: sealed_unsubscribe_suppression
+  source: skills-fixture

--- a/skills/reply-router/fixtures/stop-ambiguous-or-unsealed.yaml
+++ b/skills/reply-router/fixtures/stop-ambiguous-or-unsealed.yaml
@@ -1,0 +1,37 @@
+name: stop-ambiguous-or-unsealed
+kind: skill
+target: ..
+runner: default
+inputs:
+  inbound_reply:
+    content: "Maybe later."
+    received_from: "prospect@example.com"
+    received_at: "2026-07-02T12:06:00Z"
+  original_send_receipt:
+    state: draft
+    receipt_id: "runx:receipt:send_02"
+    checksum: "sha256:send02"
+    principal: "principal:growth"
+    send_plan:
+      recipient: "prospect@example.com"
+      campaign: "alpha-intro"
+      send_target: "send-as.email.followup"
+  suppression_policy:
+    unsubscribe_signals:
+      - unsubscribe
+      - stop
+      - opt out
+    confidence_threshold: 0.8
+    data_source_ref: "local://runx-data-store/reply-router-harness"
+    resource: "suppression_events"
+    store_id: "reply-router-harness-store"
+    prior_projection:
+      version: 3
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+metadata:
+  public_skill: reply-router
+  source_case: stop_ambiguous_or_unsealed
+  source: skills-fixture

--- a/skills/reply-router/fixtures/verification.json
+++ b/skills/reply-router/fixtures/verification.json
@@ -1,0 +1,46 @@
+{
+  "schema": "runx.reply_router.verification.v1",
+  "generated_at": "2026-07-02T12:10:00Z",
+  "package": "reply-router",
+  "version": "0.1.0",
+  "checks": [
+    {
+      "name": "runx_cli_version",
+      "status": "passed",
+      "value": "runx-cli 0.6.14"
+    },
+    {
+      "name": "inline_harness",
+      "status": "passed",
+      "case_count": 2,
+      "assertion_error_count": 0,
+      "case_names": [
+        "sealed_unsubscribe_suppression",
+        "stop_ambiguous_or_unsealed"
+      ]
+    },
+    {
+      "name": "dogfood_receipt_verify",
+      "status": "passed",
+      "receipt_ref": "sha256:b6c3efcfe7b8a4ca9f90a44971968626174683332997ce37847489afa4a8565d",
+      "verdict": {
+        "schema": "runx.verify_verdict.v1",
+        "valid": true,
+        "digest_status": "valid",
+        "content_address_status": "valid",
+        "signature_status": "valid",
+        "signature_kid": "runx-demo-key"
+      }
+    },
+    {
+      "name": "local_registry_publish",
+      "status": "passed",
+      "skill_id": "chico10117/reply-router",
+      "version": "0.1.0",
+      "digest": "b05666eb13332e5fe2b5643ccbf1f3a89839f4b4f1f023e4aaacd27c056efe90",
+      "profile_digest": "2cab7927881e22d693f51969f7a6eddc8bf2a0fae3fae2c5aadd1abd1dc961b3",
+      "install_command": "runx add chico10117/reply-router@0.1.0"
+    }
+  ],
+  "receipt_ref": "runx:receipt:sha256:b6c3efcfe7b8a4ca9f90a44971968626174683332997ce37847489afa4a8565d"
+}

--- a/skills/reply-router/run.mjs
+++ b/skills/reply-router/run.mjs
@@ -1,0 +1,240 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+const inputs = readInputs();
+const inboundReply = objectValue(inputs.inbound_reply);
+const originalReceipt = objectValue(inputs.original_send_receipt);
+const suppressionPolicy = objectValue(inputs.suppression_policy);
+
+const content = stringValue(inboundReply.content);
+const normalizedContent = (content || "").toLowerCase();
+const sender = stringValue(inboundReply.received_from);
+const receivedAt = stringValue(inboundReply.received_at);
+const sendPlan = objectValue(originalReceipt.send_plan);
+const principal = stringValue(originalReceipt.principal) || stringValue(sendPlan.principal);
+const recipient = stringValue(sendPlan.recipient) || sender;
+const receiptId = stringValue(originalReceipt.receipt_id);
+const checksum = stringValue(originalReceipt.checksum);
+const threshold = numberValue(suppressionPolicy.confidence_threshold, 0.8);
+const signals = arrayValue(suppressionPolicy.unsubscribe_signals)
+  .map((entry) => String(entry).trim().toLowerCase())
+  .filter(Boolean);
+const priorProjection = objectValue(suppressionPolicy.prior_projection);
+const beforeVersion = numberValue(priorProjection.version, 0);
+const dataSourceRef = stringValue(suppressionPolicy.data_source_ref) || "registry:runx/data-store@0.1.2";
+const resource = stringValue(suppressionPolicy.resource) || "suppression_events";
+const storeId = stringValue(suppressionPolicy.store_id) || "reply-router-suppression-v1";
+
+const packet = routeReply();
+process.stdout.write(`${JSON.stringify(packet, null, 2)}\n`);
+
+function routeReply() {
+  const base = {
+    schema: "runx.reply.router.v1",
+    package: "reply-router",
+    version: "0.1.0",
+    input_refs: {
+      inbound_from: sender,
+      received_at: receivedAt,
+      original_receipt_id: receiptId,
+      original_receipt_checksum: checksum,
+      principal,
+    },
+  };
+
+  if (!content || !sender || !recipient) {
+    return escalate(base, "missing_required_reply_context", [
+      "inbound_reply.content, inbound_reply.received_from, and send_plan.recipient or received_from are required",
+    ]);
+  }
+
+  if (!isSealedReceipt(originalReceipt)) {
+    return escalate(base, "unsealed_original_send_receipt", [
+      "original_send_receipt.state is not sealed and original_send_receipt.sealed is not true",
+    ]);
+  }
+
+  const unsubscribeEvidence = signals.filter((signal) => normalizedContent.includes(signal));
+  if (unsubscribeEvidence.length > 0) {
+    const confidence = Math.max(threshold, 0.99);
+    const aggregateId = `recipient:${recipient.toLowerCase()}`;
+    const idempotencyKey = hash([
+      "reply-router",
+      "unsubscribe",
+      aggregateId,
+      receiptId,
+      checksum,
+      content,
+    ].join("\n"));
+    const event = {
+      type: "reply.unsubscribe_suppressed",
+      payload: {
+        recipient,
+        received_from: sender,
+        received_at: receivedAt,
+        matched_signals: unsubscribeEvidence,
+        original_receipt_id: receiptId,
+        original_receipt_checksum: checksum,
+        principal,
+      },
+    };
+    return {
+      ...base,
+      decision: "suppress",
+      classification: {
+        type: "unsubscribe",
+        confidence,
+        evidence: unsubscribeEvidence.map((signal) => `matched policy signal: ${signal}`),
+      },
+      suppression_result: {
+        schema: "runx.data.operation_result.v1",
+        operation: "append_event",
+        data_source_ref: dataSourceRef,
+        store_id: storeId,
+        resource,
+        aggregate_id: aggregateId,
+        expected_version: beforeVersion,
+        before_version: beforeVersion,
+        after_version: beforeVersion + 1,
+        idempotency_key: idempotencyKey,
+        event,
+        status: "append_event_ready",
+        contract_ref: "registry:runx/data-store@0.1.2",
+      },
+      routing_decision: null,
+      escalation_lane: null,
+      summary: `Suppressed ${recipient} because the reply contained ${unsubscribeEvidence.join(", ")}; no send route was emitted.`,
+    };
+  }
+
+  const routed = classifyRoutable(normalizedContent);
+  if (!routed) {
+    return escalate(base, "ambiguous_reply", [
+      "reply text did not contain unsubscribe intent or enough grounded routing evidence",
+    ]);
+  }
+
+  return {
+    ...base,
+    decision: "route",
+    classification: {
+      type: routed.type,
+      confidence: routed.confidence,
+      evidence: routed.evidence,
+    },
+    suppression_result: null,
+    routing_decision: {
+      schema: "runx.reply.routing.v1",
+      classification: {
+        type: routed.type,
+        confidence: routed.confidence,
+      },
+      send_target: {
+        name: routed.sendTarget,
+        bounded: true,
+        reason: routed.reason,
+      },
+      principal,
+      dispatch: {
+        kind: "named_governed_run",
+        runner: "send-as",
+        status: "not_sent",
+        note: "reply-router never sends; a downstream governed send-as run must honor this decision later.",
+      },
+    },
+    escalation_lane: null,
+    summary: `Routed ${recipient} as ${routed.type}; no suppression write was emitted and no send was performed.`,
+  };
+}
+
+function classifyRoutable(text) {
+  if (/\b(interested|tell me more|send details|book|schedule|demo)\b/i.test(text)) {
+    return {
+      type: "interested",
+      confidence: 0.91,
+      evidence: ["reply contains positive buying or scheduling intent"],
+      sendTarget: "send-as.reply.interested",
+      reason: "respond with the bounded interested-reply target",
+    };
+  }
+  if (/\b(price|cost|expensive|budget|not now|later)\b/i.test(text)) {
+    return {
+      type: "objection",
+      confidence: 0.86,
+      evidence: ["reply contains budget or timing objection evidence"],
+      sendTarget: "send-as.reply.objection",
+      reason: "respond with the bounded objection-handling target",
+    };
+  }
+  if (/\b(out of office|ooo|vacation|away until|back on)\b/i.test(text)) {
+    return {
+      type: "out_of_office",
+      confidence: 0.93,
+      evidence: ["reply contains out-of-office evidence"],
+      sendTarget: "send-as.reply.defer",
+      reason: "schedule a deferred governed send-as follow-up",
+    };
+  }
+  if (/\b(wrong person|not me|contact someone else|try )\b/i.test(text)) {
+    return {
+      type: "wrong_person",
+      confidence: 0.9,
+      evidence: ["reply says the recipient is not the right contact"],
+      sendTarget: "send-as.reply.redirect_request",
+      reason: "ask for the appropriate contact without continuing the original sequence",
+    };
+  }
+  return null;
+}
+
+function escalate(base, reasonCode, evidence) {
+  return {
+    ...base,
+    decision: "needs_agent",
+    classification: {
+      type: "needs_agent",
+      confidence: 0,
+      evidence,
+    },
+    suppression_result: null,
+    routing_decision: null,
+    escalation_lane: {
+      type: "human_approval",
+      reason_code: reasonCode,
+      caller_answers_required: ["classification.review", "original_send_receipt.review"],
+    },
+    summary: `Stopped for ${reasonCode}; no suppression write and no routing decision were emitted.`,
+  };
+}
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function isSealedReceipt(receipt) {
+  return receipt.sealed === true || stringValue(receipt.state) === "sealed";
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function numberValue(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function hash(value) {
+  return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
+}


### PR DESCRIPTION
## Summary
- add a reply-router skill package under skills/reply-router
- classify inbound replies against a sealed original-send receipt
- emit unsubscribe suppression append_event shapes or bounded send-as routing decisions
- include inline harness cases and harness evidence for Frantic bounty #70

## Verification
- RUNX_RECEIPT_SIGN_KID=runx-demo-key RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=... RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted npx -y @runxhq/cli@0.6.14 harness skills/reply-router --json
- RUNX_RECEIPT_VERIFY_KID=runx-demo-key RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=... npx -y @runxhq/cli@0.6.14 verify --receipt dogfood-receipt.json --json

## Notes
- The skill never sends mail directly; routed replies name a downstream governed send-as run.
- Unsubscribe replies emit a recipient-keyed data-store append_event contract and no routing decision.
- Ambiguous or unsealed inputs stop with needs_agent escalation and no write/route.