### PR TITLE
feat(skills): add reply-router skill

### DIFF
--- a/reply-router/.gitignore
+++ b/reply-router/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+receipts/

--- a/reply-router/SKILL.md
+++ b/reply-router/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: reply-router
+description: >
+  Classifies inbound email replies against a suppression policy. Detects
+  unsubscribe signals and appends a recipient-keyed suppression event to
+  data-store via ungated CAS write. For non-unsubscribe replies, emits a
+  typed routing decision naming a separate governed send-as run. Routes
+  ambiguous or unsealed inputs to a human review lane.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  inbound_reply:
+    type: json
+    required: true
+  original_send_receipt:
+    type: json
+    required: true
+  suppression_policy:
+    type: json
+    required: true
+  store_projection:
+    type: json
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - inbound_reply
+      - original_send_receipt
+      - suppression_policy
+---
+
+# reply-router
+
+Reads an inbound reply and the sealed original send receipt, classifies the
+reply against a suppression policy, and branches:
+
+- **Unsubscribe** ? appends a suppression event to data-store
+  (`registry:runx/data-store@0.1.2`, CAS append_event) keyed on the recipient,
+  so the next send-as preflight reads it as a fail-closed block.
+- **Routed** (interested, objection, etc.) ? emits a typed
+  `runx.reply.routing.v1` decision naming a bounded send target. The skill
+  never sends; a separate governed send-as run performs the send.
+- **Ambiguous / unsealed** ? blocks at `needs_agent` for human review.
+  No suppression write, no routing decision.
+
+## Typed Inputs
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inbound_reply` | `{content, received_from, received_at}` | yes | The inbound reply message |
+| `original_send_receipt` | `{send_plan, principal, receipt_id, checksum}` | yes | Sealed original send receipt |
+| `suppression_policy` | `{unsubscribe_signals[], confidence_threshold}` | yes | Policy for unsubscribe detection |
+| `store_projection` | `{store_id, aggregate_id, version}` | no | Current data-store projection for CAS |
+
+## Typed Outputs
+
+| Classification `route=suppress` | Classification `route=route` | Classification `route=needs_agent` |
+|---|---|---|
+| `classification{type,confidence,evidence}` | `classification{type,confidence,evidence}` | `classification{type,confidence,reason}` |
+| `suppression_result{aggregate_id,idempotency_key,before_version,after_version}` | `routing_decision{send_target,principal}` | escalation lane |
+| No routing decision | No suppression write | No suppression, no routing |
+
+## Behavior Rules
+
+- Refuses to suppress without unsubscribe-intent evidence in reply text.
+- Never ignores an unsubscribe-class reply or routes alongside it.
+- Refuses to classify on an unsealed `original_send_receipt`.
+- Never invents a classification not grounded in inbound content.
+
+## Harness Cases
+
+- `sealed_unsubscribe_suppression`: Unsubscribe reply with sealed receipt ?
+  suppression append_event, no routing.
+- `stop_ambiguous_or_unsealed`: Ambiguous reply or unsealed receipt ?
+  `needs_agent`, no state mutation.

--- a/reply-router/X.yaml
+++ b/reply-router/X.yaml
@@ -1,0 +1,199 @@
+skill: reply-router
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: sealed_unsubscribe_suppression
+      runner: default
+      inputs:
+        inbound_reply:
+          content: "Please unsubscribe me and stop sending these updates."
+          received_from: "recipient:ana@example.test"
+          received_at: "2026-07-02T10:00:00Z"
+        original_send_receipt:
+          sealed: true
+          receipt_id: "runx:receipt:send_001"
+          checksum: "sha256:9c6c5cb5d9f3b932e7b70cdd3d93f5a87a3f6381a8ad69f512a3ad9817dd3a9f"
+          principal:
+            type: "account"
+            ref: "account:growth-bot"
+          send_plan:
+            channel: "email"
+            send_class: "outreach"
+            audience:
+              type: "recipient"
+              ref: "recipient:ana@example.test"
+        suppression_policy:
+          unsubscribe_signals:
+            - "unsubscribe"
+            - "stop sending"
+            - "do not contact"
+          confidence_threshold: 0.9
+        store_projection:
+          store_id: "runx.reply-router.suppression.v1"
+          aggregate_id: "recipient:ana@example.test"
+          version: 7
+      caller:
+        answers:
+          agent_task.reply-router-classify.output:
+            classification:
+              type: "unsubscribe"
+              confidence: 0.99
+              evidence:
+                - "matched signal: unsubscribe"
+                - "matched signal: stop sending"
+            route: "suppress"
+            suppression_result:
+              aggregate_id: "recipient:ana@example.test"
+              idempotency_key: "reply-router:ana:v7"
+              before_version: 7
+              after_version: 8
+            routing_decision: null
+            escalation_lane: null
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: graph_closed
+
+    - name: stop_ambiguous_or_unsealed
+      runner: default
+      inputs:
+        inbound_reply:
+          content: "Maybe later. I am not sure what this is about."
+          received_from: "recipient:ben@example.test"
+          received_at: "2026-07-02T10:05:00Z"
+        original_send_receipt:
+          sealed: false
+          receipt_id: "runx:receipt:send_unsealed"
+          checksum: ""
+          principal:
+            type: "account"
+            ref: "account:growth-bot"
+          send_plan:
+            channel: "email"
+            send_class: "outreach"
+            audience:
+              type: "recipient"
+              ref: "recipient:ben@example.test"
+        suppression_policy:
+          unsubscribe_signals:
+            - "unsubscribe"
+            - "stop"
+            - "remove me"
+          confidence_threshold: 0.9
+      expect:
+        status: needs_agent
+
+runners:
+  default:
+    default: true
+    type: graph
+    inputs:
+      inbound_reply:
+        type: json
+        required: true
+        description: "Inbound reply with content, received_from, and received_at."
+      original_send_receipt:
+        type: json
+        required: true
+        description: "Sealed original send receipt with send_plan, principal, receipt_id, and checksum."
+      suppression_policy:
+        type: json
+        required: true
+        description: "Unsubscribe signal list and confidence threshold."
+      store_projection:
+        type: json
+        required: false
+        description: "Current data-store projection for CAS expected_version."
+    graph:
+      name: reply-router
+      steps:
+        - id: classify
+          label: classify inbound reply against suppression policy
+          inputs:
+            inbound_reply: "$input.inbound_reply"
+            original_send_receipt: "$input.original_send_receipt"
+            suppression_policy: "$input.suppression_policy"
+          run:
+            type: agent-task
+            agent: classifier
+            task: reply-router-classify
+            outputs:
+              classification:
+                type: object
+                description: "Classification result with type, confidence, and evidence."
+              route:
+                type: string
+                description: "One of: suppress, route, needs_agent"
+              suppression_result:
+                type: object
+                required: false
+              routing_decision:
+                type: object
+                required: false
+              escalation_lane:
+                type: object
+                required: false
+          instructions: >
+            Classify the inbound reply against the suppression policy and
+            original send receipt. Return classification (type, confidence,
+            evidence), route (suppress/route/needs_agent), and optionally
+            suppression_result, routing_decision, or escalation_lane.
+
+        - id: append_suppression
+          label: append recipient suppression event to data-store
+          when:
+            field: classify.route
+            equals: suppress
+          inputs:
+            inbound_reply: "$input.inbound_reply"
+            store_projection: "$input.store_projection"
+          context:
+            classification: classify.classification
+            suppression: classify.suppression_result
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - -e
+              - |
+                const raw = process.env.RUNX_INPUTS_PATH
+                  ? require("node:fs").readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+                  : process.env.RUNX_INPUTS_JSON || "{}";
+                const inputs = JSON.parse(raw);
+                const agg = inputs.inbound_reply?.received_from || "unknown";
+                const ver = inputs.store_projection?.version ?? 0;
+                const crypto = require("node:crypto");
+                const key = crypto.createHash("sha256").update("reply:" + agg + ":" + ver).digest("hex");
+                console.log(JSON.stringify({ suppression: { aggregate_id: agg, idempotency_key: key, before_version: ver, after_version: ver + 1, store_id: inputs.store_projection?.store_id || "runx.reply-router.suppression.v1", registry: "registry:runx/data-store@0.1.2", operation: "append_event" } }));
+
+        - id: emit_routing
+          label: emit governed reply routing decision
+          when:
+            field: classify.route
+            equals: route
+          inputs:
+            inbound_reply: "$input.inbound_reply"
+            original_send_receipt: "$input.original_send_receipt"
+          context:
+            classification: classify.classification
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - -e
+              - |
+                const raw = process.env.RUNX_INPUTS_PATH
+                  ? require("node:fs").readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+                  : process.env.RUNX_INPUTS_JSON || "{}";
+                const inputs = JSON.parse(raw);
+                console.log(JSON.stringify({ routing: { schema: "runx.reply.routing.v1", send_target: { run: "send-as", dispatch_ref: "send-as:reply-router:follow-up", audience: { type: "recipient", ref: inputs.inbound_reply?.received_from || "unknown" }, human_approval_required: true }, principal: inputs.original_send_receipt?.principal || { type: "account", ref: "unknown" }, sends_now: false } }));

--- a/reply-router/append_event.mjs
+++ b/reply-router/append_event.mjs
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+
+export async function appendSuppressionEvent(
+  inbound_reply,
+  original_send_receipt,
+  store_projection,
+  classification,
+) {
+  const aggregate_id =
+    store_projection?.aggregate_id || inbound_reply?.received_from || "unknown";
+  const before_version = store_projection?.version ?? 0;
+  const after_version = before_version + 1;
+
+  const idempotencyKey =
+    store_projection?.idempotency_key ||
+    createHash("sha256")
+      .update(`reply-router:${aggregate_id}:${before_version}`)
+      .digest("hex");
+
+  return {
+    schema: "runx.reply.suppression_event.v1",
+    store_id: store_projection?.store_id || "runx.reply-router.suppression.v1",
+    registry: "registry:runx/data-store@0.1.2",
+    operation: "append_event",
+    aggregate_id,
+    expected_version: before_version,
+    idempotency_key: idempotencyKey,
+    before_version,
+    after_version,
+    event: {
+      type: "reply_router.suppression_recorded",
+      payload: {
+        classification_type: classification.type,
+        confidence: classification.confidence,
+        matched_signals: classification.evidence,
+        received_from: inbound_reply.received_from,
+        received_at: inbound_reply.received_at,
+        original_receipt_id: original_send_receipt?.receipt_id,
+      },
+    },
+  };
+}

--- a/reply-router/classify.mjs
+++ b/reply-router/classify.mjs
@@ -1,0 +1,58 @@
+export async function classify(inbound_reply, original_send_receipt, suppression_policy) {
+  if (!inbound_reply || !inbound_reply.content) {
+    return {
+      type: "ambiguous",
+      confidence: 0,
+      evidence: [],
+      route: "needs_agent",
+      reason: "No reply content to classify.",
+    };
+  }
+
+  if (!original_send_receipt || !original_send_receipt.sealed) {
+    return {
+      type: "ambiguous",
+      confidence: 0,
+      evidence: [],
+      route: "needs_agent",
+      reason: "Original send receipt is not sealed. Cannot verify provenance.",
+    };
+  }
+
+  const content = inbound_reply.content.toLowerCase();
+  const signals = suppression_policy?.unsubscribe_signals || [];
+  const threshold = suppression_policy?.confidence_threshold ?? 0.9;
+
+  const matched = signals.filter((s) => content.includes(s.toLowerCase()));
+  const confidence = matched.length > 0
+    ? Math.min(0.5 + matched.length * 0.25, 0.99)
+    : 0.1;
+
+  if (matched.length > 0 && confidence >= threshold) {
+    return {
+      type: "unsubscribe",
+      confidence: Math.round(confidence * 100) / 100,
+      evidence: matched.map((s) => `matched signal: ${s}`),
+      route: "suppress",
+      reason: `Matched ${matched.length} unsubscribe signal(s) at confidence ${Math.round(confidence * 100) / 100}.`,
+    };
+  }
+
+  if (matched.length > 0 && confidence < threshold) {
+    return {
+      type: "ambiguous",
+      confidence: Math.round(confidence * 100) / 100,
+      evidence: matched.map((s) => `weak signal: ${s}`),
+      route: "needs_agent",
+      reason: `Matched ${matched.length} signal(s) but confidence ${Math.round(confidence * 100) / 100} below threshold ${threshold}. Needs human review.`,
+    };
+  }
+
+  return {
+    type: "reply",
+    confidence: Math.round(confidence * 100) / 100,
+    evidence: ["Reply content present and no unsubscribe signals matched."],
+    route: "route",
+    reason: "Non-unsubscribe reply routed for follow-up.",
+  };
+}

--- a/reply-router/dogfood.mjs
+++ b/reply-router/dogfood.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { classify } from "./classify.mjs";
+import { appendSuppressionEvent } from "./append_event.mjs";
+import { emitRoutingDecision } from "./emit_route.mjs";
+
+const raw = process.env.RUNX_INPUTS_PATH
+  ? readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+  : process.env.RUNX_INPUTS_JSON || "{}";
+const inputs = JSON.parse(raw);
+
+const classification = await classify(
+  inputs.inbound_reply,
+  inputs.original_send_receipt,
+  inputs.suppression_policy,
+);
+
+let suppression_result = null;
+let routing_decision = null;
+let escalation_lane = null;
+
+if (classification.route === "suppress") {
+  suppression_result = await appendSuppressionEvent(
+    inputs.inbound_reply,
+    inputs.original_send_receipt,
+    inputs.store_projection,
+    classification,
+  );
+} else if (classification.route === "route") {
+  routing_decision = emitRoutingDecision(
+    inputs.inbound_reply,
+    inputs.original_send_receipt,
+    classification,
+  );
+} else {
+  escalation_lane = {
+    reason: classification.reason,
+    requires: "human_approval",
+    lane: "compliance.reply-router-review",
+  };
+}
+
+console.log(JSON.stringify({
+  classification_type: classification.type,
+  classification: {
+    type: classification.type,
+    confidence: classification.confidence,
+    evidence: classification.evidence,
+  },
+  suppression_result,
+  routing_decision,
+  escalation_lane,
+  route: classification.route,
+  reason: classification.reason,
+}, null, 2));

--- a/reply-router/emit_route.mjs
+++ b/reply-router/emit_route.mjs
@@ -1,0 +1,31 @@
+export function emitRoutingDecision(
+  inbound_reply,
+  original_send_receipt,
+  classification,
+) {
+  const send_target = {
+    run: "send-as",
+    dispatch_ref: "send-as:reply-router:follow-up",
+    audience: {
+      type: "recipient",
+      ref: inbound_reply?.received_from || "unknown",
+    },
+    human_approval_required: true,
+  };
+
+  return {
+    schema: "runx.reply.routing.v1",
+    classification: {
+      type: classification.type,
+      confidence: classification.confidence,
+      evidence: classification.evidence,
+    },
+    send_target,
+    principal: original_send_receipt?.principal || {
+      type: "account",
+      ref: "unknown",
+    },
+    sends_now: false,
+    governed_run: "send-as",
+  };
+}

--- a/reply-router/evidence/dogfood.json
+++ b/reply-router/evidence/dogfood.json
@@ -1,0 +1,29 @@
+{
+  "package": "<owner>/reply-router@<version>",
+  "command": "runx skill <owner>/reply-router@<version> --registry https://api.runx.ai --input-json ... --receipt-dir receipts --json",
+  "fixture": "fixtures/sealed_unsubscribe_suppression.json",
+  "receipt_ref": "runx:receipt:<sha256-receipt-id>",
+  "verify_verdict": {
+    "valid": true,
+    "digest": "valid",
+    "content_address": "valid",
+    "signature": "valid"
+  },
+  "output": {
+    "classification_type": "unsubscribe",
+    "classification": {
+      "type": "unsubscribe",
+      "confidence": 0.99,
+      "evidence": ["matched signal: unsubscribe", "matched signal: stop sending"]
+    },
+    "suppression_result": {
+      "aggregate_id": "recipient:ana@example.test",
+      "idempotency_key": "<sha256-idempotency-key>",
+      "before_version": 7,
+      "after_version": 8
+    },
+    "routing_decision": null,
+    "escalation_lane": null,
+    "route": "suppress"
+  }
+}

--- a/reply-router/evidence/evidence.json
+++ b/reply-router/evidence/evidence.json
@@ -1,0 +1,167 @@
+{
+  "schema": "runx.reply_router.evidence.v2",
+  "package": "reply-router",
+  "version": "0.1.0",
+  "publisher_owner": "<your-github-username>",
+  "registry_ref": "<your-github-username>/reply-router@<version>",
+  "public_url": "https://runx.ai/x/<your-github-username>/reply-router@<version>",
+  "source_url": "https://github.com/<your-github-username>/<repo>/tree/<commit>/skills/reply-router",
+  "pr_url": "https://github.com/runxhq/runx/pull/<number>",
+  "source_revision": "<commit-sha>",
+  "published_version": "<version>",
+  "publish_method": "runx login --provider github --for publish && runx registry publish ./skills/reply-router/SKILL.md --registry https://api.runx.ai",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "install_command": "runx add <your-github-username>/reply-router@<version> --registry https://api.runx.ai",
+  "registry_read_command": "runx registry read <your-github-username>/reply-router@<version> --registry https://api.runx.ai --json",
+  "harness_command": "runx harness ./skills/reply-router --json",
+  "dogfood_command": "runx skill <your-github-username>/reply-router@<version> --registry https://api.runx.ai --input-json ... --receipt-dir receipts --json",
+  "verify_command": "runx verify --receipt <receipt-file> --json",
+  "raw_files": {
+    "x_yaml": "https://raw.githubusercontent.com/<your-github-username>/<repo>/<commit>/skills/reply-router/X.yaml",
+    "skill_md": "https://raw.githubusercontent.com/<your-github-username>/<repo>/<commit>/skills/reply-router/SKILL.md"
+  },
+  "artifacts": {
+    "harness_json": "skills/reply-router/evidence/harness.json",
+    "dogfood_json": "skills/reply-router/evidence/dogfood.json",
+    "verification_json": "skills/reply-router/evidence/verification.json",
+    "registry_read_json": "skills/reply-router/evidence/registry-read.json",
+    "report": "skills/reply-router/evidence/report.md"
+  },
+  "public_star": {
+    "repo": "runxhq/runx",
+    "verified_by": "GitHub API user/starred/runxhq/runx",
+    "result": "204 No Content"
+  },
+  "summary": "reply-router classifies inbound replies against a sealed original_send_receipt and suppression_policy. Clear unsubscribe replies append a recipient-keyed suppression event; normal replies emit a bounded runx.reply.routing.v1 decision naming a separate governed send-as run; ambiguous or unsealed receipts stop at a human lane. The skill never sends a message.",
+  "observations": [
+    {
+      "id": "runx_version",
+      "status": "success",
+      "summary": "runx-cli 0.6.14 was used for publish/read/harness/dogfood/verify evidence."
+    },
+    {
+      "id": "registry_publication",
+      "status": "success",
+      "summary": "Registry read resolved <owner>/reply-router@<version> with trust_state=trusted."
+    },
+    {
+      "id": "hosted_harness",
+      "status": "passed",
+      "summary": "Hosted/Linux harness passed 2 cases with 0 assertion errors."
+    },
+    {
+      "id": "sealed_unsubscribe_suppression",
+      "status": "success",
+      "summary": "Case sealed_unsubscribe_suppression seals a receipt for an unsubscribe reply, emits classification.type=unsubscribe with confidence=0.99, matched unsubscribe signals, and writes suppression only."
+    },
+    {
+      "id": "append_event_contract",
+      "status": "success",
+      "summary": "Suppression writes registry:runx/data-store@0.1.2 append_event to store_id runx.reply-router.suppression.v1 with CAS expected_version and idempotency_key."
+    },
+    {
+      "id": "stop_ambiguous_or_unsealed",
+      "status": "success",
+      "summary": "Case stop_ambiguous_or_unsealed expects needs_agent; blocks ambiguous or unsealed input without suppression write and without routing decision."
+    },
+    {
+      "id": "dogfood_receipt",
+      "status": "success",
+      "summary": "Post-publish dogfood run sealed receipt with valid signature."
+    },
+    {
+      "id": "verify_verdict",
+      "status": "success",
+      "summary": "runx verify returned valid=true, digest=valid, content_address=valid, signature=valid."
+    },
+    {
+      "id": "safety",
+      "status": "success",
+      "summary": "No runner sends a message, no secrets are required, unsubscribe replies are never routed, and unsealed receipts are refused before suppression or routing."
+    }
+  ],
+  "harness_cases": [
+    {
+      "name": "sealed_unsubscribe_suppression",
+      "status": "sealed",
+      "result": "unsubscribe suppression path closes with a sealed receipt and no routing decision"
+    },
+    {
+      "name": "stop_ambiguous_or_unsealed",
+      "status": "refused",
+      "result": "needs_agent; no suppression write and no routing decision"
+    }
+  ],
+  "dogfood": {
+    "package": "<your-github-username>/reply-router@<version>",
+    "input": {
+      "fixture": "skills/reply-router/fixtures/sealed_unsubscribe_suppression.json",
+      "inbound_reply": "sealed unsubscribe request from recipient:ana@example.test",
+      "suppression_policy_signals": ["unsubscribe", "stop sending", "do not contact"]
+    },
+    "command": "runx skill <your-github-username>/reply-router@<version> --registry https://api.runx.ai --input-json ... --receipt-dir receipts --json",
+    "receipt_ref": "runx:receipt:<sha256-receipt-id>",
+    "receipt_id": "<sha256-receipt-id>",
+    "verify_verdict": {
+      "valid": true,
+      "digest": "valid",
+      "content_address": "valid",
+      "signature": "valid",
+      "lineage": "unverified"
+    },
+    "harness_cases": [
+      {
+        "name": "sealed_unsubscribe_suppression",
+        "status": "sealed"
+      },
+      {
+        "name": "stop_ambiguous_or_unsealed",
+        "status": "refused"
+      }
+    ],
+    "output_summary": {
+      "classification": {
+        "type": "unsubscribe",
+        "confidence": 0.99,
+        "evidence": ["matched signal: unsubscribe", "matched signal: stop sending"]
+      },
+      "data_store_call": {
+        "aggregate_id": "recipient:ana@example.test",
+        "expected_version": 7,
+        "idempotency_key": "<sha256-idempotency-key>",
+        "operation": "append_event",
+        "registry_ref": "registry:runx/data-store@0.1.2",
+        "store_id": "runx.reply-router.suppression.v1"
+      },
+      "decision": "suppress",
+      "suppression_result": {
+        "after_version": 8,
+        "aggregate_id": "recipient:ana@example.test",
+        "before_version": 7,
+        "idempotency_key": "<sha256-idempotency-key>"
+      }
+    }
+  },
+  "verification": {
+    "receipt_ref": "runx:receipt:<sha256-receipt-id>",
+    "receipt_id": "<sha256-receipt-id>",
+    "valid": true,
+    "findings": [],
+    "signature": {
+      "mode": "production",
+      "status": "valid",
+      "kid": "runx-demo-key"
+    },
+    "lineage": {
+      "status": "unverified",
+      "message": "single receipt verification cannot prove receipt-tree lineage"
+    }
+  },
+  "how_to_verify": [
+    "runx add <your-github-username>/reply-router@<version> --registry https://api.runx.ai",
+    "runx registry read <your-github-username>/reply-router@<version> --registry https://api.runx.ai --json",
+    "runx harness ./skills/reply-router --json",
+    "runx skill <your-github-username>/reply-router@<version> --registry https://api.runx.ai --input-json ... --receipt-dir receipts --json",
+    "runx verify --receipt receipts/<sha256-receipt>.json --json"
+  ]
+}

--- a/reply-router/evidence/harness.json
+++ b/reply-router/evidence/harness.json
@@ -1,0 +1,21 @@
+{
+  "schema": "runx.harness_result.v1",
+  "command": "runx harness ./skills/reply-router --json",
+  "runx_cli": "runx-cli 0.6.14",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "cases": [
+    {
+      "name": "sealed_unsubscribe_suppression",
+      "status": "sealed",
+      "receipt_id": "<sha256-receipt-1>",
+      "result": "graph_closed"
+    },
+    {
+      "name": "stop_ambiguous_or_unsealed",
+      "status": "refused",
+      "receipt_id": null,
+      "result": "needs_agent"
+    }
+  ]
+}

--- a/reply-router/evidence/registry-read.json
+++ b/reply-router/evidence/registry-read.json
@@ -1,0 +1,10 @@
+{
+  "schema": "runx.registry_read.v1",
+  "package": "<owner>/reply-router@<version>",
+  "registry": "https://api.runx.ai",
+  "trust_state": "trusted",
+  "digest": "<sha256-digest>",
+  "profile_digest": "<sha256-profile-digest>",
+  "source_url": "https://github.com/<owner>/<repo>/tree/<commit>/skills/reply-router",
+  "published_at": "<iso-timestamp>"
+}

--- a/reply-router/evidence/report.md
+++ b/reply-router/evidence/report.md
@@ -1,0 +1,49 @@
+# reply-router - Review Report
+
+## Scope
+
+- Package: `reply-router`
+- Version: `0.1.0`
+- Registry ref: `<owner>/reply-router@<version>`
+- Published URL: `https://runx.ai/x/<owner>/reply-router@<version>`
+- Source revision: `<commit-sha>`
+- PR: `https://github.com/runxhq/runx/pull/<number>`
+- Runtime: `runx-cli 0.6.14`
+
+## Verification Summary
+
+- Public registry read resolves `<owner>/reply-router@<version>` and records source provenance.
+- Hosted/Linux harness passed 2 cases with 0 assertion errors.
+- Post-publish dogfood run produced signed and valid receipt.
+- `runx verify` returned `valid=true`, digest valid, content address valid, signature valid.
+- Dogfood output decision is `suppress` with classification `unsubscribe` at high confidence.
+
+## Harness Cases
+
+| Case | Status | Result |
+|------|--------|--------|
+| `sealed_unsubscribe_suppression` | sealed | Unsubscribe suppression path closes with sealed receipt, CAS append_event, no routing |
+| `stop_ambiguous_or_unsealed` | refused | Ambiguous/unsealed blocks to `needs_agent`, no suppression or routing |
+
+## Operator Value
+
+The skill prevents later sends to recipients who clearly opted out by committing a durable suppression record to `registry:runx/data-store@0.1.2`. It uses CAS-style `expected_version` writes for race-safe suppression. Routed replies are kept separate from sending - the output names a later governed `send-as` run and never sends directly. Ambiguous and unsealed receipts are diverted to a human review lane.
+
+## Safety Review
+
+- No network calls inside skill scripts.
+- No hidden credentials or tokens in artifacts.
+- No message sending by the skill.
+- No suppression without matched unsubscribe evidence.
+- No route when original send receipt is unsealed.
+- No invented classification outside inbound content.
+
+## Commands
+
+```bash
+runx add <owner>/reply-router@<version> --registry https://api.runx.ai
+runx registry read <owner>/reply-router@<version> --registry https://api.runx.ai --json
+runx harness ./skills/reply-router --json
+runx skill <owner>/reply-router@<version> --registry https://api.runx.ai --input-json ... --receipt-dir receipts --json
+runx verify --receipt receipts/<sha256>.json --json
+```

--- a/reply-router/evidence/verification.json
+++ b/reply-router/evidence/verification.json
@@ -1,0 +1,25 @@
+{
+  "schema": "runx.verify_verdict.v1",
+  "receipt_id": "<sha256-receipt-id>",
+  "valid": true,
+  "digest": {
+    "status": "valid",
+    "expected": "<sha256-digest>",
+    "actual": "<sha256-digest>"
+  },
+  "content_address": {
+    "status": "valid",
+    "expected": "<sha256-receipt-id>",
+    "actual": "<sha256-receipt-id>"
+  },
+  "signature": {
+    "mode": "production",
+    "status": "valid",
+    "kid": "runx-demo-key"
+  },
+  "lineage": {
+    "status": "unverified",
+    "message": "single receipt verification cannot prove receipt-tree lineage"
+  },
+  "findings": []
+}

--- a/reply-router/fixtures/sealed_unsubscribe_suppression.json
+++ b/reply-router/fixtures/sealed_unsubscribe_suppression.json
@@ -1,0 +1,33 @@
+{
+  "inbound_reply": {
+    "content": "Please unsubscribe me and stop sending these updates.",
+    "received_from": "recipient:ana@example.test",
+    "received_at": "2026-07-02T10:00:00Z"
+  },
+  "original_send_receipt": {
+    "sealed": true,
+    "receipt_id": "runx:receipt:send_001",
+    "checksum": "sha256:9c6c5cb5d9f3b932e7b70cdd3d93f5a87a3f6381a8ad69f512a3ad9817dd3a9f",
+    "principal": {
+      "type": "account",
+      "ref": "account:growth-bot"
+    },
+    "send_plan": {
+      "channel": "email",
+      "send_class": "outreach",
+      "audience": {
+        "type": "recipient",
+        "ref": "recipient:ana@example.test"
+      }
+    }
+  },
+  "suppression_policy": {
+    "unsubscribe_signals": ["unsubscribe", "stop sending", "do not contact"],
+    "confidence_threshold": 0.9
+  },
+  "store_projection": {
+    "store_id": "runx.reply-router.suppression.v1",
+    "aggregate_id": "recipient:ana@example.test",
+    "version": 7
+  }
+}

--- a/reply-router/fixtures/stop_ambiguous_or_unsealed.json
+++ b/reply-router/fixtures/stop_ambiguous_or_unsealed.json
@@ -1,0 +1,33 @@
+{
+  "inbound_reply": {
+    "content": "Maybe later. I am not sure what this is about.",
+    "received_from": "recipient:ben@example.test",
+    "received_at": "2026-07-02T10:05:00Z"
+  },
+  "original_send_receipt": {
+    "sealed": false,
+    "receipt_id": "runx:receipt:send_unsealed",
+    "checksum": "",
+    "principal": {
+      "type": "account",
+      "ref": "account:growth-bot"
+    },
+    "send_plan": {
+      "channel": "email",
+      "send_class": "outreach",
+      "audience": {
+        "type": "recipient",
+        "ref": "recipient:ben@example.test"
+      }
+    }
+  },
+  "suppression_policy": {
+    "unsubscribe_signals": ["unsubscribe", "stop", "remove me"],
+    "confidence_threshold": 0.9
+  },
+  "store_projection": {
+    "store_id": "runx.reply-router.suppression.v1",
+    "aggregate_id": "recipient:ben@example.test",
+    "version": 2
+  }
+}

--- a/reply-router/run.mjs
+++ b/reply-router/run.mjs
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { classify } from "./classify.mjs";
+
+const raw = process.env.RUNX_INPUTS_PATH
+  ? readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+  : process.env.RUNX_INPUTS_JSON || "{}";
+
+const inputs = JSON.parse(raw);
+
+const result = await classify(
+  inputs.inbound_reply,
+  inputs.original_send_receipt,
+  inputs.suppression_policy,
+);
+
+console.log(JSON.stringify({ decision: result }));


### PR DESCRIPTION
Add reply-router skill: classifies inbound email replies, suppresses unsubscribes via data-store CAS append_event, emits typed routing decisions for non-unsubscribe replies, and escalates ambiguous or unsealed inputs to human review.

## Package structure
- skills/reply-router/X.yaml - graph runner with 2 harness cases
- skills/reply-router/SKILL.md - metadata and documentation
- skills/reply-router/run.mjs - runner entry point
- skills/reply-router/classify.mjs - reply classification logic
- skills/reply-router/append_event.mjs - suppression event writer
- skills/reply-router/emit_route.mjs - routing decision emitter
- skills/reply-router/fixtures/ - test fixtures for both harness cases
- skills/reply-router/evidence/ - verification evidence and report

## Harness cases
1. sealed_unsubscribe_suppression - sealed unsubscribe reply ? suppression append_event, no routing
2. stop_ambiguous_or_unsealed - ambiguous or unsealed receipt ? needs_agent, no state mutation