### PR TITLE
fix(runtime): tolerate Windows receipt fsync limits

### DIFF
--- a/crates/runx-runtime/src/receipts/store.rs
+++ b/crates/runx-runtime/src/receipts/store.rs
@@ -1,7 +1,9 @@
 // rust-style-allow: large-file -- local store read/write/index semantics stay
 // together until the receipt-store API finishes the hard-cutover review.
 use std::ffi::OsStr;
-use std::fs::{self, File, OpenOptions};
+#[cfg(not(windows))]
+use std::fs::File;
+use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -753,12 +755,27 @@ fn write_temp_file(path: &Path, contents: &[u8], durable: bool) -> Result<(), st
     file.write_all(contents)?;
     file.flush()?;
     if durable {
-        file.sync_all()?;
+        sync_temp_file(&file)?;
     }
     Ok(())
 }
 
+fn sync_temp_file(file: &fs::File) -> Result<(), std::io::Error> {
+    match file.sync_all() {
+        Ok(()) => Ok(()),
+        #[cfg(windows)]
+        Err(error) if error.raw_os_error() == Some(87) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 fn sync_directory(path: &Path) -> Result<(), std::io::Error> {
+    #[cfg(windows)]
+    {
+        let _ = path;
+        return Ok(());
+    }
+    #[cfg(not(windows))]
     File::open(path)?.sync_all()
 }
 


### PR DESCRIPTION
## Summary

Fixes a remaining Windows receipt-store durability failure on the current `main` branch.

- route durable temporary-file sync through a helper that keeps normal errors strict
- tolerate Windows `sync_all` raw OS error 87 after the receipt file has been written and flushed
- make receipt-directory sync a no-op on Windows, while keeping non-Windows `File::open(path)?.sync_all()` behavior unchanged

This is intentionally a focused one-file PR. Existing broader receipt/skill PRs such as #201 are conflict-heavy and do not cover the temp-file `sync_all` error path on current `main`.

## Validation

- `cargo fmt -p runx-runtime -- --check`
  - passed
- `git diff --check -- crates/runx-runtime/src/receipts/store.rs`
  - passed
- `cargo test -p runx-runtime receipt_store -- --nocapture`
  - passed: `receipt_store` 26 passed, 0 failed

## Scope

The change is limited to local receipt-store durability sync behavior. It does not change receipt IDs, receipt file naming, signatures, verification policy, harness authority, or any public schema.