### PR TITLE
feat(skills): add exact CVE audit

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -81,6 +81,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "aa446e7d3ab8a3168facd2372b8bd8fe63736a3e061438d38cc83ea8f294b971",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/exact-cve-audit",
+        version: "sha-bce4476cee8b",
+        digest: "bf49029b9e20629aed3f8e29dae50fc8e2b2f402e2edb9c1fba2fc6767cb583a",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/github-sync",
         version: "sha-e685e9e8b5c6",
         digest: "6981adc877736f05a41d764b3e42d479d87de3bc2d69a65992dff457b635bd9a",

--- a/dist/packets/security.exact-cve-audit.v1.schema.json
+++ b/dist/packets/security.exact-cve-audit.v1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.runx.ai/runx/security/exact-cve-audit/v1.json",
+  "x-runx-packet-id": "runx.security.exact_cve_audit.v1",
+  "type": "object",
+  "required": ["schema", "scanner_version", "generated_at", "target", "dependency_scope", "inventory", "findings", "result"],
+  "properties": {
+    "schema": { "const": "runx.security.exact_cve_audit.v1" },
+    "scanner_version": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "target": { "$ref": "#/$defs/target" },
+    "dependency_scope": { "enum": ["direct-production", "all-installed"] },
+    "inventory": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/dependency" }
+    },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["exact_dependencies_queried", "affected_dependencies", "advisory_findings", "source", "source_url"],
+      "properties": {
+        "exact_dependencies_queried": { "type": "integer", "minimum": 0 },
+        "affected_dependencies": { "type": "integer", "minimum": 0 },
+        "advisory_findings": { "type": "integer", "minimum": 0 },
+        "source": { "const": "OSV" },
+        "source_url": { "type": "string", "format": "uri" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "target": {
+      "type": "object",
+      "required": ["name", "repo", "commit", "lockfile_url", "lockfile_sha256", "lockfile_version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "repo": { "type": "string", "format": "uri" },
+        "commit": { "type": "string", "pattern": "^[0-9a-fA-F]{40}$" },
+        "lockfile_url": { "type": "string", "format": "uri" },
+        "lockfile_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "lockfile_version": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "dependency": {
+      "type": "object",
+      "required": ["name", "version", "path", "direct", "development"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "direct": { "type": "boolean" },
+        "development": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "finding": {
+      "type": "object",
+      "required": ["dependency", "exact_version", "advisory_id", "advisory_url", "exact_query"],
+      "properties": {
+        "dependency": { "type": "string", "minLength": 1 },
+        "exact_version": { "type": "string", "minLength": 1 },
+        "advisory_id": { "type": "string", "minLength": 1 },
+        "advisory_url": { "type": "string", "format": "uri" },
+        "exact_query": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/dist/packets/security.exact-cve-delivery.v1.schema.json
+++ b/dist/packets/security.exact-cve-delivery.v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.runx.ai/runx/security/exact-cve-delivery/v1.json",
+  "x-runx-packet-id": "runx.security.exact_cve_delivery.v1",
+  "type": "object",
+  "required": ["schema", "created_at", "target", "dependency_scope", "result", "verification", "artifacts", "delivery_digest"],
+  "properties": {
+    "schema": { "const": "runx.security.exact_cve_delivery.v1" },
+    "created_at": { "type": "string", "minLength": 1 },
+    "target": { "type": "object", "additionalProperties": true },
+    "dependency_scope": { "enum": ["direct-production", "all-installed"] },
+    "result": { "type": "object", "additionalProperties": true },
+    "verification": {
+      "type": "object",
+      "required": ["verified", "false_hits", "missing_hits", "exact_dependencies_replayed", "verified_findings"],
+      "properties": {
+        "verified": { "const": true },
+        "false_hits": { "type": "integer", "minimum": 0 },
+        "missing_hits": { "type": "integer", "minimum": 0 },
+        "exact_dependencies_replayed": { "type": "integer", "minimum": 0 },
+        "verified_findings": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "artifacts": {
+      "type": "object",
+      "required": ["report", "evidence", "audit_result", "verification"],
+      "properties": {
+        "report": { "$ref": "#/$defs/artifact" },
+        "evidence": { "$ref": "#/$defs/artifact" },
+        "audit_result": { "$ref": "#/$defs/artifact" },
+        "verification": { "$ref": "#/$defs/artifact" }
+      },
+      "additionalProperties": true
+    },
+    "delivery_digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "artifact": { "$ref": "#/$defs/artifact" }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/dist/packets/security.exact-cve-evidence.v1.schema.json
+++ b/dist/packets/security.exact-cve-evidence.v1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.runx.ai/runx/security/exact-cve-evidence/v1.json",
+  "x-runx-packet-id": "runx.security.exact_cve_evidence.v1",
+  "type": "object",
+  "required": ["schema", "generated_at", "summary", "observations", "target", "dependency_scope", "method", "queries", "findings"],
+  "properties": {
+    "schema": { "const": "runx.security.exact_cve_evidence.v1" },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
+    "observations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "statement", "evidence"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "statement": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      }
+    },
+    "target": { "type": "object", "additionalProperties": true },
+    "dependency_scope": { "enum": ["direct-production", "all-installed"] },
+    "method": { "type": "object", "additionalProperties": true },
+    "queries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["query", "returned_advisory_ids"],
+        "properties": {
+          "query": { "type": "object", "additionalProperties": true },
+          "returned_advisory_ids": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "artifact": { "$ref": "#/$defs/artifact" },
+    "audit_artifact": { "$ref": "#/$defs/artifact" }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/dist/packets/security.exact-cve-report.v1.schema.json
+++ b/dist/packets/security.exact-cve-report.v1.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.runx.ai/runx/security/exact-cve-report/v1.json",
+  "x-runx-packet-id": "runx.security.exact_cve_report.v1",
+  "type": "object",
+  "required": ["schema", "artifact", "finding_count", "markdown_sha256"],
+  "properties": {
+    "schema": { "const": "runx.security.exact_cve_report.v1" },
+    "artifact": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      },
+      "additionalProperties": true
+    },
+    "finding_count": { "type": "integer", "minimum": 0 },
+    "markdown_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  },
+  "additionalProperties": true
+}

--- a/dist/packets/security.exact-cve-verification.v1.schema.json
+++ b/dist/packets/security.exact-cve-verification.v1.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.runx.ai/runx/security/exact-cve-verification/v1.json",
+  "x-runx-packet-id": "runx.security.exact_cve_verification.v1",
+  "type": "object",
+  "required": ["schema", "verified_at", "target", "dependency_scope", "verified", "exact_dependencies_replayed", "verified_findings", "false_hits", "missing_hits", "withdrawn_hits_excluded", "replay"],
+  "properties": {
+    "schema": { "const": "runx.security.exact_cve_verification.v1" },
+    "verified_at": { "type": "string", "minLength": 1 },
+    "target": { "type": "object", "additionalProperties": true },
+    "dependency_scope": { "enum": ["direct-production", "all-installed"] },
+    "verified": { "type": "boolean" },
+    "exact_dependencies_replayed": { "type": "integer", "minimum": 0 },
+    "verified_findings": { "type": "integer", "minimum": 0 },
+    "false_hits": { "type": "integer", "minimum": 0 },
+    "missing_hits": { "type": "integer", "minimum": 0 },
+    "withdrawn_hits_excluded": { "type": "integer", "minimum": 0 },
+    "replay": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["dependency", "exact_version", "reported_advisory_ids", "replayed_advisory_ids", "exact_set_match"],
+        "properties": {
+          "dependency": { "type": "string", "minLength": 1 },
+          "exact_version": { "type": "string", "minLength": 1 },
+          "reported_advisory_ids": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "replayed_advisory_ids": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "exact_set_match": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -98,6 +98,13 @@
     "catalog_role": "canonical"
   },
   {
+    "skill_id": "runx/exact-cve-audit",
+    "version": "sha-bce4476cee8b",
+    "digest": "bf49029b9e20629aed3f8e29dae50fc8e2b2f402e2edb9c1fba2fc6767cb583a",
+    "catalog_visibility": "public",
+    "catalog_role": "canonical"
+  },
+  {
     "skill_id": "runx/github-sync",
     "version": "sha-e685e9e8b5c6",
     "digest": "6981adc877736f05a41d764b3e42d479d87de3bc2d69a65992dff457b635bd9a",

--- a/skills/exact-cve-audit/README.md
+++ b/skills/exact-cve-audit/README.md
@@ -1,0 +1,56 @@
+# runx exact CVE audit
+
+A governed runx skill that audits exact npm dependency versions against OSV.
+It emits a report, machine-readable evidence, an independent replay
+verification, and a delivery packet.
+
+The checked-in harness covers two immutable targets: the vulnerable OWASP
+NodeGoat commit `c5cb68a7084e4ae7dcc60e6a98768720a81841e8` and a minimal clean
+fixture pinned to commit `83d554f904f9f73bd26ce9c15e3786ba7d62b1de`.
+
+## Local test
+
+```sh
+npm test
+```
+
+## Direct deterministic scan
+
+```sh
+RUNX_INPUTS_JSON='{
+  "target_name": "OWASP NodeGoat",
+  "target_repo": "https://github.com/OWASP/NodeGoat",
+  "target_commit": "c5cb68a7084e4ae7dcc60e6a98768720a81841e8",
+  "lockfile_url": "https://raw.githubusercontent.com/OWASP/NodeGoat/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/package-lock.json",
+  "dependency_scope": "direct-production"
+}' node scan.mjs
+```
+
+## Governed run
+
+```sh
+runx skill . --runner audit \
+  --input "target_name=OWASP NodeGoat" \
+  --input "target_repo=https://github.com/OWASP/NodeGoat" \
+  --input "target_commit=c5cb68a7084e4ae7dcc60e6a98768720a81841e8" \
+  --input "lockfile_url=https://raw.githubusercontent.com/OWASP/NodeGoat/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/package-lock.json" \
+  --input "dependency_scope=direct-production" \
+  --json
+```
+
+The run writes only to `artifacts/` and contacts only the immutable GitHub raw
+lockfile URL and `api.osv.dev`.
+
+## Reproducible evidence
+
+The source repository's
+[`Reproduce sealed CVE audit`](https://github.com/jaasieldelgado131/runx-exact-cve-audit/actions/workflows/evidence.yml)
+GitHub Actions workflow runs the unit tests,
+executes the governed graph on Linux, verifies every emitted runx receipt, and
+publishes the report, JSON evidence, delivery packet, and receipts as one
+workflow artifact. The workflow pins `@runxhq/cli` to `0.6.6`.
+
+Successful real-run outputs and independently verifiable receipts are checked
+into the source repository's
+[`evidence/`](https://github.com/jaasieldelgado131/runx-exact-cve-audit/tree/main/evidence)
+directory for anonymous public review.

--- a/skills/exact-cve-audit/SKILL.md
+++ b/skills/exact-cve-audit/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: exact-cve-audit
+description: Audit exact npm dependency versions against OSV and emit a reproducible evidence packet with zero unverified findings.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - scan.mjs
+    - core.mjs
+  timeout_seconds: 120
+  sandbox:
+    profile: workspace-write
+    cwd_policy: skill-directory
+    network: true
+    writable_paths:
+      - artifacts
+    require_enforcement: false
+inputs:
+  target_name:
+    type: string
+    required: true
+    description: Human-readable name of the audited project.
+  target_repo:
+    type: string
+    required: true
+    description: Public source repository URL.
+  target_commit:
+    type: string
+    required: true
+    description: Full immutable Git commit containing the lockfile.
+  lockfile_url:
+    type: string
+    required: true
+    description: Public HTTPS package-lock.json URL pinned to target_commit.
+  dependency_scope:
+    type: string
+    required: false
+    default: direct-production
+    description: direct-production or all-installed.
+runx:
+  category: security
+  tags:
+    - cve
+    - dependencies
+    - osv
+  artifacts:
+    named_emits:
+      audit_result: audit_result
+      report: report
+      evidence: evidence
+links:
+  source: https://github.com/jaasieldelgado131/runx-exact-cve-audit
+  registry: https://runx.ai/x/jaasieldelgado131/exact-cve-audit
+  advisory_source: https://osv.dev
+---
+
+# Exact CVE Audit
+
+## What this skill does
+
+This skill audits exact npm versions from an immutable `package-lock.json`
+against the public OSV API. It emits a machine-readable audit result,
+`evidence.json`, and a finding-by-finding Markdown report. The governed graph in
+`X.yaml` independently replays every query and seals a delivery packet only
+when the reported and replayed advisory sets match exactly.
+
+It does not install dependencies, execute target code, mutate the target
+repository, repair packages, or publish vulnerability claims.
+
+## When to use this skill
+
+Use it when a reviewer needs checkable evidence for the advisories affecting
+the exact npm versions in a public, immutable lockfile. It is suitable for
+dependency review, release triage, and reproducible security evidence where a
+package-name-only or loose-range match would create false positives.
+
+## When not to use this skill
+
+Do not use it for a mutable branch URL, a manifest without exact installed
+versions, a private lockfile without explicit read authority, non-npm
+ecosystems, exploit development, or claims about transitive coverage when the
+selected scope is `direct-production`. Do not treat missing OSV data as proof
+that a package is safe.
+
+## Inputs
+
+- `target_name`: display name for the audited project.
+- `target_repo`: public HTTPS source repository.
+- `target_commit`: full 40-character immutable Git commit.
+- `lockfile_url`: public HTTPS lockfile URL containing that commit.
+- `dependency_scope`: `direct-production` by default, or `all-installed`.
+
+The caller authorizes only public reads of the pinned lockfile and OSV. No
+credential, token, local project file, or private payload is an accepted input.
+
+## Procedure
+
+1. Validate that the repository and lockfile URLs use HTTPS, the commit is a
+   full Git hash, and the lockfile URL is pinned to that hash.
+2. Fetch the lockfile and record its SHA-256 digest before parsing it.
+3. Extract exact installed versions from lockfile versions 2 or 3. Preserve the
+   requested scope in every artifact.
+4. Query OSV with `{ ecosystem: npm, package, version }` for every inventory
+   entry. Exclude withdrawn advisories.
+5. Record each finding with dependency, exact version, advisory ID, OSV URL,
+   aliases, installed path, and the exact query that produced it.
+6. In the governed graph, replay every exact-version query in a separate step.
+   Fail closed if an advisory is unsupported, omitted, withdrawn, or changed.
+7. Emit the report, evidence, verification, delivery packet, and sealed receipt.
+
+## Edge cases and stop conditions
+
+- Refuse non-HTTPS or mutable lockfile URLs.
+- Refuse abbreviated commits and lockfiles that do not contain the commit.
+- Refuse unsupported lockfile versions or entries without exact versions.
+- Return `needs_input` when the target, commit, or lockfile evidence is not
+  immutable enough to support reproducible review.
+- Stop if OSV times out, returns malformed data, or changes between scan and
+  independent replay.
+- Stop if any false hit or missing hit is detected.
+- Report the selected dependency scope; never imply broader coverage.
+- Keep tokens, credentials, private source, and target code out of artifacts.
+
+## Output schema
+
+The scan emits:
+
+```json
+{
+  "audit_result": {
+    "schema": "runx.security.exact_cve_audit.v1",
+    "target": {
+      "repo": "https://github.com/owner/repo",
+      "commit": "40-character hash",
+      "lockfile_sha256": "64-character digest"
+    },
+    "dependency_scope": "direct-production",
+    "inventory": [],
+    "findings": [],
+    "result": {
+      "exact_dependencies_queried": 0,
+      "advisory_findings": 0,
+      "source": "OSV"
+    }
+  },
+  "report": { "artifact": { "path": "artifacts/report.md" } },
+  "evidence": {
+    "summary": "human-readable audit summary",
+    "observations": [],
+    "artifact": { "path": "artifacts/evidence.json" }
+  }
+}
+```
+
+The graph adds `verification.json`, `delivery.json`, and a sealed
+`runx.receipt.v1` graph receipt with child receipt lineage.
+
+## Worked example
+
+For OWASP NodeGoat at commit
+`c5cb68a7084e4ae7dcc60e6a98768720a81841e8`, the checked-in harness reads the
+pinned lockfile, audits 16 exact direct production versions, reports the OSV
+advisories returned for those versions, and independently requires zero false
+and zero missing hits before sealing.
+
+The second harness case audits the repository's immutable clean fixture at
+commit `83d554f904f9f73bd26ce9c15e3786ba7d62b1de`. It verifies that an exact
+dependency with no OSV advisory produces zero findings while still completing
+the independent replay and sealed-receipt path.
+
+If the same request points at `main/package-lock.json`, validation returns a
+needs-input failure because the lockfile is mutable and does not contain the
+declared immutable commit. No audit or receipt is presented as complete.

--- a/skills/exact-cve-audit/X.yaml
+++ b/skills/exact-cve-audit/X.yaml
@@ -1,0 +1,134 @@
+skill: exact-cve-audit
+version: "0.1.3"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+
+runners:
+  audit:
+    default: true
+    type: graph
+    inputs:
+      target_name:
+        type: string
+        required: true
+        description: Human-readable project name.
+      target_repo:
+        type: string
+        required: true
+        description: Public source repository URL.
+      target_commit:
+        type: string
+        required: true
+        description: Immutable source commit.
+      lockfile_url:
+        type: string
+        required: true
+        description: Raw package-lock.json URL pinned to target_commit.
+      dependency_scope:
+        type: string
+        required: false
+        default: direct-production
+        description: direct-production or all-installed.
+    graph:
+      name: exact-cve-audit
+      steps:
+        - id: scan
+          label: query exact dependency versions
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - scan.mjs
+              - core.mjs
+            timeout_seconds: 120
+            outputs:
+              audit_result: object
+              report: object
+              evidence: object
+            sandbox:
+              profile: workspace-write
+              cwd_policy: skill-directory
+              network: true
+              writable_paths:
+                - artifacts
+              require_enforcement: false
+          scopes:
+            - net:https://raw.githubusercontent.com
+            - net:https://api.osv.dev
+            - fs:artifacts:write
+          artifacts:
+            named_emits:
+              audit_result: audit_result
+              report: report
+              evidence: evidence
+            packets:
+              audit_result: runx.security.exact_cve_audit.v1
+              report: runx.security.exact_cve_report.v1
+              evidence: runx.security.exact_cve_evidence.v1
+
+        - id: verify
+          label: independently replay every exact-version query
+          context:
+            audit_result: scan.audit_result.data
+            evidence: scan.evidence.data
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - verify.mjs
+            timeout_seconds: 120
+            outputs:
+              verification: object
+            sandbox:
+              profile: workspace-write
+              cwd_policy: skill-directory
+              network: true
+              writable_paths:
+                - artifacts
+              require_enforcement: false
+          scopes:
+            - net:https://api.osv.dev
+            - fs:artifacts:write
+          artifacts:
+            named_emits:
+              verification: verification
+            packets:
+              verification: runx.security.exact_cve_verification.v1
+
+        - id: finalize
+          label: seal the recomputable delivery packet
+          context:
+            audit_result: scan.audit_result.data
+            report: scan.report.data
+            evidence: scan.evidence.data
+            verification: verify.verification.data
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - finalize.mjs
+            timeout_seconds: 30
+            outputs:
+              delivery: object
+            sandbox:
+              profile: workspace-write
+              cwd_policy: skill-directory
+              writable_paths:
+                - artifacts
+              require_enforcement: false
+          scopes:
+            - fs:artifacts:write
+          artifacts:
+            named_emits:
+              delivery: delivery
+            packets:
+              delivery: runx.security.exact_cve_delivery.v1
+      policy:
+        guards:
+          - step: finalize
+            field: verify.verification.data.verified
+            equals: true

--- a/skills/exact-cve-audit/core.mjs
+++ b/skills/exact-cve-audit/core.mjs
@@ -1,0 +1,327 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { request } from "node:https";
+import path from "node:path";
+
+export const SCHEMA_VERSION = "runx.security.exact_cve_audit.v1";
+export const SCANNER_VERSION = "0.1.1";
+export const OSV_BASE_URL = "https://api.osv.dev/v1";
+
+export function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function parseInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+export function assertHttpsUrl(value, field) {
+  const url = new URL(String(value || ""));
+  if (url.protocol !== "https:") {
+    throw new Error(`${field} must use HTTPS`);
+  }
+  return url.toString();
+}
+
+export function validateTargetInputs(inputs) {
+  const targetName = String(inputs.target_name || "").trim();
+  const targetRepo = assertHttpsUrl(inputs.target_repo, "target_repo");
+  const targetCommit = String(inputs.target_commit || "").trim();
+  const lockfileUrl = assertHttpsUrl(inputs.lockfile_url, "lockfile_url");
+  const dependencyScope = String(
+    inputs.dependency_scope || "direct-production",
+  );
+
+  if (!targetName) {
+    throw new Error("target_name is required");
+  }
+  if (!/^[0-9a-f]{40}$/i.test(targetCommit)) {
+    throw new Error("target_commit must be a full 40-character Git commit");
+  }
+  if (!["direct-production", "all-installed"].includes(dependencyScope)) {
+    throw new Error(
+      "dependency_scope must be direct-production or all-installed",
+    );
+  }
+  if (!lockfileUrl.includes(targetCommit)) {
+    throw new Error("lockfile_url must be pinned to target_commit");
+  }
+
+  return {
+    targetName,
+    targetRepo,
+    targetCommit,
+    lockfileUrl,
+    dependencyScope,
+  };
+}
+
+function requestText(url, options = {}, redirects = 0) {
+  if (redirects > 3) {
+    throw new Error(`too many redirects while requesting ${url}`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    if (target.protocol !== "https:") {
+      reject(new Error(`refusing non-HTTPS request to ${target}`));
+      return;
+    }
+
+    const req = request(
+      target,
+      {
+        method: options.method || "GET",
+        headers: {
+          accept: "application/json",
+          "user-agent": `runx-exact-cve-audit/${SCANNER_VERSION}`,
+          ...options.headers,
+        },
+      },
+      (response) => {
+        const status = response.statusCode || 0;
+        if (status >= 300 && status < 400 && response.headers.location) {
+          response.resume();
+          resolve(
+            requestText(
+              new URL(response.headers.location, target).toString(),
+              options,
+              redirects + 1,
+            ),
+          );
+          return;
+        }
+
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          resolve({
+            status,
+            ok: status >= 200 && status < 300,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    req.setTimeout(30_000, () => {
+      req.destroy(new Error(`request timed out for ${target}`));
+    });
+    req.on("error", reject);
+    if (options.body) {
+      req.write(options.body);
+    }
+    req.end();
+  });
+}
+
+export async function fetchJson(url, options = {}) {
+  const response = await requestText(url, options);
+  if (!response.ok) {
+    throw new Error(
+      `${url} returned HTTP ${response.status}: ${response.body.slice(0, 300)}`,
+    );
+  }
+  return JSON.parse(response.body);
+}
+
+export async function fetchLockfile(url) {
+  const response = await requestText(url);
+  if (!response.ok) {
+    throw new Error(
+      `lockfile returned HTTP ${response.status}: ${response.body.slice(0, 300)}`,
+    );
+  }
+  return { text: response.body, lockfile: JSON.parse(response.body) };
+}
+
+export function inventoryFromPackageLock(lockfile, scope) {
+  if (![2, 3].includes(lockfile.lockfileVersion)) {
+    throw new Error("only package-lock.json lockfileVersion 2 or 3 is supported");
+  }
+  if (!lockfile.packages || !lockfile.packages[""]) {
+    throw new Error("package-lock.json must contain a packages map and root entry");
+  }
+
+  const entries = [];
+  if (scope === "direct-production") {
+    const names = Object.keys(lockfile.packages[""].dependencies || {}).sort();
+    for (const name of names) {
+      const installed = lockfile.packages[`node_modules/${name}`];
+      if (!installed || typeof installed.version !== "string") {
+        throw new Error(`exact installed version missing for direct dependency ${name}`);
+      }
+      entries.push({
+        name,
+        version: installed.version,
+        path: `node_modules/${name}`,
+        direct: true,
+        development: false,
+      });
+    }
+  } else {
+    for (const [packagePath, installed] of Object.entries(lockfile.packages)) {
+      if (!packagePath || !packagePath.includes("node_modules/")) {
+        continue;
+      }
+      if (!installed || typeof installed.version !== "string" || installed.link) {
+        continue;
+      }
+      const marker = "node_modules/";
+      const name = packagePath.slice(packagePath.lastIndexOf(marker) + marker.length);
+      entries.push({
+        name,
+        version: installed.version,
+        path: packagePath,
+        direct: packagePath === `node_modules/${name}`,
+        development: Boolean(installed.dev),
+      });
+    }
+    entries.sort((a, b) =>
+      `${a.name}@${a.version}:${a.path}`.localeCompare(
+        `${b.name}@${b.version}:${b.path}`,
+      ),
+    );
+  }
+
+  return entries;
+}
+
+export async function queryOsvBatch(inventory) {
+  const queries = inventory.map(({ name, version }) => ({
+    package: { ecosystem: "npm", name },
+    version,
+  }));
+  const results = [];
+  for (let offset = 0; offset < queries.length; offset += 500) {
+    const querySlice = queries.slice(offset, offset + 500);
+    const response = await fetchJson(`${OSV_BASE_URL}/querybatch`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ queries: querySlice }),
+    });
+    if (!Array.isArray(response.results) || response.results.length !== querySlice.length) {
+      throw new Error("OSV querybatch returned an unexpected result shape");
+    }
+    results.push(...response.results);
+  }
+  return { queries, results };
+}
+
+export async function loadAdvisories(ids) {
+  const advisories = new Map();
+  for (const id of [...new Set(ids)].sort()) {
+    const advisory = await fetchJson(
+      `${OSV_BASE_URL}/vulns/${encodeURIComponent(id)}`,
+    );
+    if (advisory.id !== id) {
+      throw new Error(`OSV advisory identity mismatch for ${id}`);
+    }
+    if (!advisory.withdrawn) {
+      advisories.set(id, advisory);
+    }
+  }
+  return advisories;
+}
+
+export function buildFindings(inventory, batchResults, advisories) {
+  const findings = [];
+  inventory.forEach((dependency, index) => {
+    const ids = (batchResults[index]?.vulns || [])
+      .map(({ id }) => id)
+      .filter((id) => advisories.has(id))
+      .sort();
+    for (const id of ids) {
+      const advisory = advisories.get(id);
+      findings.push({
+        dependency: dependency.name,
+        exact_version: dependency.version,
+        dependency_path: dependency.path,
+        direct: dependency.direct,
+        development: dependency.development,
+        advisory_id: id,
+        aliases: [...(advisory.aliases || [])].sort(),
+        summary: advisory.summary || "",
+        modified: advisory.modified || null,
+        published: advisory.published || null,
+        severity: advisory.severity || [],
+        advisory_url: `https://osv.dev/vulnerability/${id}`,
+        references: (advisory.references || [])
+          .map(({ type, url }) => ({ type, url }))
+          .filter(({ url }) => typeof url === "string")
+          .slice(0, 8),
+        exact_query: {
+          package: { ecosystem: "npm", name: dependency.name },
+          version: dependency.version,
+        },
+      });
+    }
+  });
+  return findings.sort((a, b) =>
+    `${a.dependency}@${a.exact_version}:${a.advisory_id}`.localeCompare(
+      `${b.dependency}@${b.exact_version}:${b.advisory_id}`,
+    ),
+  );
+}
+
+export function renderMarkdown(audit) {
+  const lines = [
+    `# Exact CVE audit: ${audit.target.name}`,
+    "",
+    `- Repository: ${audit.target.repo}`,
+    `- Commit: \`${audit.target.commit}\``,
+    `- Lockfile SHA-256: \`${audit.target.lockfile_sha256}\``,
+    `- Dependency scope: \`${audit.dependency_scope}\``,
+    `- Exact dependencies queried: ${audit.inventory.length}`,
+    `- Verified OSV findings: ${audit.findings.length}`,
+    "",
+    "## Method",
+    "",
+    "The scanner reads exact installed versions from the immutable package-lock.json and submits each `{ ecosystem: npm, package, version }` tuple to OSV. It does not infer vulnerability from a loose semver range. Withdrawn advisories are excluded. A separate verification pass replays every exact-version query and requires the reported set to equal OSV's current non-withdrawn result set.",
+    "",
+    "## Findings",
+    "",
+  ];
+
+  if (audit.findings.length === 0) {
+    lines.push("No OSV advisories matched the exact versions in the named scope.");
+  } else {
+    for (const finding of audit.findings) {
+      lines.push(
+        `### ${finding.dependency}@${finding.exact_version} — ${finding.advisory_id}`,
+        "",
+        `- Advisory: ${finding.advisory_url}`,
+        `- Aliases: ${finding.aliases.length ? finding.aliases.join(", ") : "none"}`,
+        `- Installed path: \`${finding.dependency_path}\``,
+        `- Summary: ${finding.summary || "No summary supplied by OSV."}`,
+        "",
+      );
+    }
+  }
+
+  lines.push(
+    "## Scope limits",
+    "",
+    audit.dependency_scope === "direct-production"
+      ? "This report covers direct production dependencies declared by the root package. It does not claim coverage of transitive or development dependencies."
+      : "This report covers exact installed entries present in the package-lock packages map.",
+    "",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+export async function writeArtifact(filename, value, { json = true } = {}) {
+  const directory = path.resolve(process.cwd(), "artifacts");
+  await mkdir(directory, { recursive: true });
+  const target = path.join(directory, filename);
+  const body = json ? `${JSON.stringify(value, null, 2)}\n` : String(value);
+  await writeFile(target, body, "utf8");
+  return {
+    path: `artifacts/${filename}`,
+    sha256: sha256(body),
+    bytes: Buffer.byteLength(body),
+  };
+}
+
+export function stableFindingKey(finding) {
+  return `${finding.dependency}@${finding.exact_version}:${finding.advisory_id}`;
+}

--- a/skills/exact-cve-audit/finalize.mjs
+++ b/skills/exact-cve-audit/finalize.mjs
@@ -1,0 +1,49 @@
+import {
+  parseInputs,
+  sha256,
+  writeArtifact,
+} from "./core.mjs";
+
+const inputs = parseInputs();
+const { audit_result: audit, report, evidence, verification } = inputs;
+
+if (!audit || !report || !evidence || !verification) {
+  throw new Error(
+    "audit_result, report, evidence, and verification context are required",
+  );
+}
+if (verification.verified !== true) {
+  throw new Error("verification did not prove an exact, complete finding set");
+}
+
+const delivery = {
+  schema: "runx.security.exact_cve_delivery.v1",
+  created_at: new Date().toISOString(),
+  target: audit.target,
+  dependency_scope: audit.dependency_scope,
+  result: audit.result,
+  verification: {
+    verified: verification.verified,
+    false_hits: verification.false_hits,
+    missing_hits: verification.missing_hits,
+    exact_dependencies_replayed: verification.exact_dependencies_replayed,
+    verified_findings: verification.verified_findings,
+  },
+  artifacts: {
+    report: report.artifact,
+    evidence: evidence.artifact,
+    audit_result: evidence.audit_artifact,
+    verification: verification.artifact,
+  },
+};
+delivery.delivery_digest = `sha256:${sha256(JSON.stringify(delivery))}`;
+
+const artifact = await writeArtifact("delivery.json", delivery);
+process.stdout.write(
+  JSON.stringify({
+    delivery: {
+      ...delivery,
+      artifact,
+    },
+  }),
+);

--- a/skills/exact-cve-audit/fixtures/clean-fixture-direct-production.yaml
+++ b/skills/exact-cve-audit/fixtures/clean-fixture-direct-production.yaml
@@ -1,0 +1,20 @@
+name: clean-fixture-direct-production
+kind: skill
+target: ..
+runner: audit
+inputs:
+  target_name: Exact CVE Audit clean fixture
+  target_repo: https://github.com/jaasieldelgado131/runx-exact-cve-audit
+  target_commit: 83d554f904f9f73bd26ce9c15e3786ba7d62b1de
+  lockfile_url: https://raw.githubusercontent.com/jaasieldelgado131/runx-exact-cve-audit/83d554f904f9f73bd26ce9c15e3786ba7d62b1de/fixtures/clean/package-lock.json
+  dependency_scope: direct-production
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: exact-cve-audit
+  source_case: clean-fixture-direct-production
+  source: pr-92

--- a/skills/exact-cve-audit/fixtures/clean/package-lock.json
+++ b/skills/exact-cve-audit/fixtures/clean/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "exact-cve-audit-clean-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "exact-cve-audit-clean-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "picocolors": "1.1.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    }
+  }
+}

--- a/skills/exact-cve-audit/fixtures/clean/package.json
+++ b/skills/exact-cve-audit/fixtures/clean/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "exact-cve-audit-clean-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "picocolors": "1.1.1"
+  }
+}

--- a/skills/exact-cve-audit/fixtures/owasp-nodegoat-direct-production.yaml
+++ b/skills/exact-cve-audit/fixtures/owasp-nodegoat-direct-production.yaml
@@ -1,0 +1,20 @@
+name: owasp-nodegoat-direct-production
+kind: skill
+target: ..
+runner: audit
+inputs:
+  target_name: OWASP NodeGoat
+  target_repo: https://github.com/OWASP/NodeGoat
+  target_commit: c5cb68a7084e4ae7dcc60e6a98768720a81841e8
+  lockfile_url: https://raw.githubusercontent.com/OWASP/NodeGoat/c5cb68a7084e4ae7dcc60e6a98768720a81841e8/package-lock.json
+  dependency_scope: direct-production
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: exact-cve-audit
+  source_case: owasp-nodegoat-direct-production
+  source: pr-92

--- a/skills/exact-cve-audit/package.json
+++ b/skills/exact-cve-audit/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "runx-exact-cve-audit",
+  "version": "0.1.3",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "audit": "node scan.mjs",
+    "verify": "node verify.mjs",
+    "test": "node --test tests/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/skills/exact-cve-audit/scan.mjs
+++ b/skills/exact-cve-audit/scan.mjs
@@ -1,0 +1,143 @@
+import {
+  SCANNER_VERSION,
+  SCHEMA_VERSION,
+  buildFindings,
+  fetchLockfile,
+  inventoryFromPackageLock,
+  loadAdvisories,
+  parseInputs,
+  queryOsvBatch,
+  renderMarkdown,
+  sha256,
+  validateTargetInputs,
+  writeArtifact,
+} from "./core.mjs";
+
+const inputs = validateTargetInputs(parseInputs());
+const { text: lockfileText, lockfile } = await fetchLockfile(inputs.lockfileUrl);
+const inventory = inventoryFromPackageLock(
+  lockfile,
+  inputs.dependencyScope,
+);
+const { queries, results } = await queryOsvBatch(inventory);
+const advisoryIds = results.flatMap((result) =>
+  (result.vulns || []).map(({ id }) => id),
+);
+const advisories = await loadAdvisories(advisoryIds);
+const findings = buildFindings(inventory, results, advisories);
+const generatedAt = new Date().toISOString();
+
+const auditResult = {
+  schema: SCHEMA_VERSION,
+  scanner_version: SCANNER_VERSION,
+  generated_at: generatedAt,
+  target: {
+    name: inputs.targetName,
+    repo: inputs.targetRepo,
+    commit: inputs.targetCommit,
+    lockfile_url: inputs.lockfileUrl,
+    lockfile_sha256: sha256(lockfileText),
+    lockfile_version: lockfile.lockfileVersion,
+  },
+  dependency_scope: inputs.dependencyScope,
+  inventory,
+  findings,
+  result: {
+    exact_dependencies_queried: inventory.length,
+    affected_dependencies: new Set(
+      findings.map(({ dependency, exact_version }) => `${dependency}@${exact_version}`),
+    ).size,
+    advisory_findings: findings.length,
+    source: "OSV",
+    source_url: "https://api.osv.dev",
+  },
+};
+
+const reportMarkdown = renderMarkdown(auditResult);
+const evidence = {
+  schema: "runx.security.exact_cve_evidence.v1",
+  generated_at: generatedAt,
+  summary:
+    `Audited ${inventory.length} exact ${inputs.dependencyScope} dependency versions from the pinned ${inputs.targetName} lockfile and found ${findings.length} current OSV advisories with exact-version evidence.`,
+  observations: [
+    {
+      id: "immutable_target",
+      statement: "The audit input is pinned to an immutable repository commit and lockfile digest.",
+      evidence: {
+        commit: auditResult.target.commit,
+        lockfile_sha256: auditResult.target.lockfile_sha256,
+      },
+    },
+    {
+      id: "exact_dependency_inventory",
+      statement: "Every OSV query uses an exact installed dependency version from the requested scope.",
+      evidence: {
+        dependency_scope: auditResult.dependency_scope,
+        exact_dependencies_queried: inventory.length,
+      },
+    },
+    {
+      id: "real_advisory_source",
+      statement: "Advisories are loaded from OSV and withdrawn advisories are excluded.",
+      evidence: {
+        source: auditResult.result.source,
+        source_url: auditResult.result.source_url,
+      },
+    },
+    {
+      id: "traceable_findings",
+      statement: "Every finding records the dependency, exact version, advisory id, advisory URL, and exact query.",
+      evidence: {
+        advisory_findings: findings.length,
+        affected_dependencies: auditResult.result.affected_dependencies,
+      },
+    },
+  ],
+  target: auditResult.target,
+  dependency_scope: auditResult.dependency_scope,
+  method: {
+    inventory_source: "package-lock.json packages map",
+    query_contract: "{ package: { ecosystem: npm, name }, version: exact_version }",
+    advisory_source: "https://api.osv.dev/v1",
+    withdrawn_advisories_excluded: true,
+    false_positive_control:
+      "Each finding must be present in OSV's response for the exact package/version tuple and is replayed by an independent verification step.",
+  },
+  queries: queries.map((query, index) => ({
+    query,
+    returned_advisory_ids: (results[index]?.vulns || [])
+      .map(({ id }) => id)
+      .filter((id) => advisories.has(id))
+      .sort(),
+  })),
+  findings: findings.map((finding) => ({
+    dependency: finding.dependency,
+    exact_version: finding.exact_version,
+    advisory_id: finding.advisory_id,
+    advisory_url: finding.advisory_url,
+    exact_query: finding.exact_query,
+  })),
+};
+
+const reportArtifact = await writeArtifact("report.md", reportMarkdown, {
+  json: false,
+});
+const evidenceArtifact = await writeArtifact("evidence.json", evidence);
+const auditArtifact = await writeArtifact("audit-result.json", auditResult);
+
+process.stdout.write(
+  JSON.stringify({
+    audit_result: auditResult,
+    report: {
+      schema: "runx.security.exact_cve_report.v1",
+      artifact: reportArtifact,
+      finding_count: findings.length,
+      markdown_sha256: reportArtifact.sha256,
+    },
+    evidence: {
+      ...evidence,
+      artifact: evidenceArtifact,
+      audit_artifact: auditArtifact,
+    },
+  }),
+);

--- a/skills/exact-cve-audit/tests/core.test.mjs
+++ b/skills/exact-cve-audit/tests/core.test.mjs
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  inventoryFromPackageLock,
+  renderMarkdown,
+  validateTargetInputs,
+} from "../core.mjs";
+
+test("inventory uses exact direct production versions", () => {
+  const inventory = inventoryFromPackageLock(
+    {
+      lockfileVersion: 3,
+      packages: {
+        "": {
+          dependencies: {
+            alpha: "^1.0.0",
+            "@scope/beta": "~2.0.0",
+          },
+          devDependencies: {
+            gamma: "3.0.0",
+          },
+        },
+        "node_modules/alpha": { version: "1.2.3" },
+        "node_modules/@scope/beta": { version: "2.0.4" },
+        "node_modules/gamma": { version: "3.0.0", dev: true },
+      },
+    },
+    "direct-production",
+  );
+
+  assert.deepEqual(
+    inventory.map(({ name, version }) => ({ name, version })),
+    [
+      { name: "@scope/beta", version: "2.0.4" },
+      { name: "alpha", version: "1.2.3" },
+    ],
+  );
+});
+
+test("target lockfile must be immutable and pinned to the commit", () => {
+  assert.throws(
+    () =>
+      validateTargetInputs({
+        target_name: "Example",
+        target_repo: "https://github.com/example/project",
+        target_commit: "a".repeat(40),
+        lockfile_url:
+          "https://raw.githubusercontent.com/example/project/main/package-lock.json",
+      }),
+    /pinned to target_commit/,
+  );
+});
+
+test("report names exact versions and advisory ids", () => {
+  const report = renderMarkdown({
+    target: {
+      name: "Example",
+      repo: "https://github.com/example/project",
+      commit: "a".repeat(40),
+      lockfile_sha256: "b".repeat(64),
+    },
+    dependency_scope: "direct-production",
+    inventory: [{ name: "alpha", version: "1.2.3" }],
+    findings: [
+      {
+        dependency: "alpha",
+        exact_version: "1.2.3",
+        dependency_path: "node_modules/alpha",
+        advisory_id: "GHSA-aaaa-bbbb-cccc",
+        advisory_url: "https://osv.dev/vulnerability/GHSA-aaaa-bbbb-cccc",
+        aliases: ["CVE-2026-0001"],
+        summary: "Example advisory",
+      },
+    ],
+  });
+
+  assert.match(report, /alpha@1\.2\.3/);
+  assert.match(report, /GHSA-aaaa-bbbb-cccc/);
+  assert.match(report, /direct production dependencies/);
+});

--- a/skills/exact-cve-audit/verify.mjs
+++ b/skills/exact-cve-audit/verify.mjs
@@ -1,0 +1,109 @@
+import {
+  OSV_BASE_URL,
+  fetchJson,
+  parseInputs,
+  stableFindingKey,
+  writeArtifact,
+} from "./core.mjs";
+
+const inputs = parseInputs();
+const audit = inputs.audit_result;
+const evidence = inputs.evidence;
+
+if (!audit || !evidence) {
+  throw new Error("audit_result and evidence context are required");
+}
+
+const expectedByQuery = new Map(
+  evidence.queries.map(({ query, returned_advisory_ids }) => [
+    `${query.package.name}@${query.version}`,
+    [...returned_advisory_ids].sort(),
+  ]),
+);
+const observedKeys = new Set(audit.findings.map(stableFindingKey));
+const replay = [];
+let falseHits = 0;
+let missingHits = 0;
+let withdrawnHits = 0;
+
+for (const dependency of audit.inventory) {
+  const exactQuery = {
+    package: { ecosystem: "npm", name: dependency.name },
+    version: dependency.version,
+  };
+  const response = await fetchJson(`${OSV_BASE_URL}/query`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(exactQuery),
+  });
+  const nonWithdrawnIds = [];
+  for (const item of response.vulns || []) {
+    const advisory = await fetchJson(
+      `${OSV_BASE_URL}/vulns/${encodeURIComponent(item.id)}`,
+    );
+    if (advisory.withdrawn) {
+      withdrawnHits += 1;
+      continue;
+    }
+    nonWithdrawnIds.push(item.id);
+  }
+  nonWithdrawnIds.sort();
+
+  const expected = expectedByQuery.get(
+    `${dependency.name}@${dependency.version}`,
+  ) || [];
+  const observed = audit.findings
+    .filter(
+      ({ dependency: name, exact_version: version }) =>
+        name === dependency.name && version === dependency.version,
+    )
+    .map(({ advisory_id }) => advisory_id)
+    .sort();
+
+  falseHits += observed.filter((id) => !nonWithdrawnIds.includes(id)).length;
+  missingHits += nonWithdrawnIds.filter((id) => !observed.includes(id)).length;
+  if (JSON.stringify(expected) !== JSON.stringify(nonWithdrawnIds)) {
+    throw new Error(
+      `OSV replay changed for ${dependency.name}@${dependency.version}`,
+    );
+  }
+
+  replay.push({
+    dependency: dependency.name,
+    exact_version: dependency.version,
+    reported_advisory_ids: observed,
+    replayed_advisory_ids: nonWithdrawnIds,
+    exact_set_match:
+      JSON.stringify(observed) === JSON.stringify(nonWithdrawnIds),
+  });
+}
+
+for (const finding of audit.findings) {
+  if (!observedKeys.has(stableFindingKey(finding))) {
+    falseHits += 1;
+  }
+}
+
+const verification = {
+  schema: "runx.security.exact_cve_verification.v1",
+  verified_at: new Date().toISOString(),
+  target: audit.target,
+  dependency_scope: audit.dependency_scope,
+  verified: falseHits === 0 && missingHits === 0,
+  exact_dependencies_replayed: replay.length,
+  verified_findings: audit.findings.length,
+  false_hits: falseHits,
+  missing_hits: missingHits,
+  withdrawn_hits_excluded: withdrawnHits,
+  replay,
+};
+
+const artifact = await writeArtifact("verification.json", verification);
+process.stdout.write(
+  JSON.stringify({
+    verification: {
+      ...verification,
+      artifact,
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- port the real exact CVE audit skill payload from #92 onto current main after the force-pushed history changed the original PR diff
- keep the first-party package at `skills/exact-cve-audit` instead of the stale nested `oss/skills/...` path
- move public harness cases into standalone fixtures and refresh official skill lock metadata
- keep generated run artifacts out of the commit
- tighten receipt-signing behavior so raw runtime skill runs fail closed without production signing env, while CLI `runx skill` / `runx harness` inject a shared deterministic local-development signer only when the signer triplet is fully absent

Fixes #91.
Replaces #92.

## Validation
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --manifest-path crates/Cargo.toml --workspace --all-features --no-fail-fast`
- `pnpm verify:fast`
- `node --test skills/exact-cve-audit/tests/*.test.mjs`
- signed `runx harness skills/exact-cve-audit/fixtures/owasp-nodegoat-direct-production.yaml` with issuer `pr92-local-test`
- signed `runx harness skills/exact-cve-audit/fixtures/clean-fixture-direct-production.yaml` with issuer `pr92-local-test`
- `git diff --check`

## Notes
- The original contributor fork branch cannot be updated by maintainers because GitHub denies write permission, so this is the maintainer-owned rebased branch.
- Generated `skills/exact-cve-audit/artifacts/` outputs were intentionally left untracked and excluded.