### PR TITLE
[codex] Add answer-from-docs runx skill

### DIFF
--- a/skills/answer-from-docs/SKILL.md
+++ b/skills/answer-from-docs/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: answer-from-docs
+description: Answer a question strictly from a bounded corpus and refuse unsupported questions with explicit knowledge-base gaps.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 10
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  question:
+    type: string
+    required: true
+    description: Question to answer from the provided corpus only.
+  corpus:
+    type: json
+    required: true
+    description: Array of bounded corpus items. Each item may be a string or an object with id, title, text, or content.
+runx:
+  input_resolution:
+    required:
+      - question
+      - corpus
+  artifacts:
+    wrap_as: answer_from_docs_packet
+---
+
+# Answer From Docs
+
+Answer From Docs turns a bounded `corpus[]` fixture into a grounded answer packet.
+It performs no retrieval, network access, mutation, or hidden knowledge lookup. It
+only uses the corpus supplied in the input.
+
+## Behavior
+
+1. Normalize the question and each corpus item.
+2. Split corpus text into sentence-sized evidence candidates.
+3. Score candidates by overlap with meaningful question terms.
+4. Return a concise answer only when the selected evidence clears the grounding
+   threshold.
+5. Attach citations to every answer sentence using the source corpus item id.
+6. Refuse uncovered questions by returning `grounded: false` and explicit
+   `kb_gaps`.
+
+## Inputs
+
+- `question` (required): a non-empty question.
+- `corpus` (required): an array of strings or objects. Object items can provide
+  `id`, `title`, `text`, `content`, `body`, or `markdown`.
+
+## Output
+
+```yaml
+answer:
+  text: string
+  citations:
+    - sentence: string
+      source_id: string
+      source_title: string | null
+      evidence: string
+kb_gaps:
+  - string
+grounded: boolean
+```
+
+## Refusal Rules
+
+- Refuse when `corpus[]` is empty or has no readable text.
+- Refuse when the best evidence does not overlap enough meaningful question
+  terms.
+- Refuse instead of answering from general model knowledge.
+- Refuse rather than inventing citations.
+
+## Verification Notes
+
+A valid harness includes one grounded case and one refused case. The grounded
+case must return at least one citation, and the refused case must set
+`grounded: false` with a non-empty `kb_gaps[]`.

--- a/skills/answer-from-docs/X.yaml
+++ b/skills/answer-from-docs/X.yaml
@@ -1,0 +1,84 @@
+skill: answer-from-docs
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: local-input
+      method: READ
+      scope: runx:input:read
+  deny:
+    - network
+    - network_mutation
+    - credential_material
+    - private_user_data
+
+emits:
+  - name: answer_from_docs_packet
+    packet: runx.answer_from_docs.v1
+
+harness:
+  cases:
+    - name: grounded-policy-answer
+      runner: answer
+      inputs:
+        question: "What must an Acme Cloud password contain?"
+        corpus:
+          - id: acme-password-policy
+            title: Acme Cloud password policy
+            text: "Acme Cloud passwords must contain at least twelve characters, one number, and one symbol. Administrators must rotate emergency access keys every ninety days."
+          - id: acme-support-policy
+            title: Acme Cloud support policy
+            text: "Support tickets are triaged during business hours unless the account has a critical incident plan."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: refused-uncovered-question
+      runner: answer
+      inputs:
+        question: "What is the company travel reimbursement limit?"
+        corpus:
+          - id: acme-password-policy
+            title: Acme Cloud password policy
+            text: "Acme Cloud passwords must contain at least twelve characters, one number, and one symbol."
+          - id: acme-support-policy
+            title: Acme Cloud support policy
+            text: "Support tickets are triaged during business hours unless the account has a critical incident plan."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  answer:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      answer: object
+      kb_gaps: array
+      grounded: boolean
+    artifacts:
+      wrap_as: answer_from_docs_packet
+      packet: runx.answer_from_docs.v1
+    inputs:
+      question:
+        type: string
+        required: true
+        description: Question to answer from the provided corpus only.
+      corpus:
+        type: json
+        required: true
+        description: Array of bounded corpus items. Each item may be a string or an object with id, title, text, or content.

--- a/skills/answer-from-docs/fixtures/evidence.json
+++ b/skills/answer-from-docs/fixtures/evidence.json
@@ -1,0 +1,97 @@
+{
+  "schema": "runx.answer_from_docs.evidence.v1",
+  "package": "answer-from-docs",
+  "version": "0.1.0",
+  "artifact_summary": "Deterministic read-only runx skill that answers strictly from input corpus items and refuses uncovered questions with kb_gaps.",
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "value": "runx-cli 0.6.16"
+    },
+    {
+      "name": "package_name",
+      "value": "answer-from-docs"
+    },
+    {
+      "name": "typed_inputs",
+      "value": [
+        "question",
+        "corpus"
+      ]
+    },
+    {
+      "name": "typed_outputs",
+      "value": [
+        "answer",
+        "kb_gaps",
+        "grounded"
+      ]
+    },
+    {
+      "name": "grounded_verdict",
+      "value": "grounded-policy-answer returns grounded true with a citation to acme-password-policy."
+    },
+    {
+      "name": "refusal_verdict",
+      "value": "refused-uncovered-question returns grounded false with non-empty kb_gaps."
+    },
+    {
+      "name": "citation_mapping",
+      "value": [
+        {
+          "answer_sentence": "Acme Cloud passwords must contain at least twelve characters, one number, and one symbol.",
+          "source_id": "acme-password-policy"
+        }
+      ]
+    },
+    {
+      "name": "harness_case_names",
+      "value": [
+        "grounded-policy-answer",
+        "refused-uncovered-question"
+      ]
+    },
+    {
+      "name": "harness_status",
+      "value": "passed"
+    },
+    {
+      "name": "dogfood_command",
+      "value": "runx skill skills/answer-from-docs --receipt-dir $HOME/runx-answer-dogfood -i \"question=What must an Acme Cloud password contain?\" --input-json corpus='[...]' -j"
+    },
+    {
+      "name": "receipt_id",
+      "value": "sha256:bcb85e5dbe78616efff4231821534b56ee640e8c3b44dfa0e2822dcfdd3bf770"
+    },
+    {
+      "name": "verify_verdict",
+      "value": "valid"
+    },
+    {
+      "name": "runtime_boundary",
+      "value": "No live retrieval, external fetch, mutation, or credential access. The runner reads RUNX input JSON only."
+    }
+  ],
+  "dogfood": {
+    "package": "answer-from-docs@0.1.0",
+    "input": {
+      "question": "What must an Acme Cloud password contain?",
+      "corpus_ids": [
+        "acme-password-policy"
+      ]
+    },
+    "command": "runx skill skills/answer-from-docs --receipt-dir $HOME/runx-answer-dogfood -i \"question=What must an Acme Cloud password contain?\" --input-json corpus='[...]' -j",
+    "receipt_ref": "sha256:bcb85e5dbe78616efff4231821534b56ee640e8c3b44dfa0e2822dcfdd3bf770",
+    "verify_verdict": "valid",
+    "harness_cases": [
+      {
+        "name": "grounded-policy-answer",
+        "status": "sealed"
+      },
+      {
+        "name": "refused-uncovered-question",
+        "status": "sealed"
+      }
+    ]
+  }
+}

--- a/skills/answer-from-docs/fixtures/grounded-policy-answer.yaml
+++ b/skills/answer-from-docs/fixtures/grounded-policy-answer.yaml
@@ -1,0 +1,23 @@
+name: grounded-policy-answer
+kind: skill
+target: ..
+runner: answer
+inputs:
+  question: "What must an Acme Cloud password contain?"
+  corpus:
+    - id: acme-password-policy
+      title: Acme Cloud password policy
+      text: "Acme Cloud passwords must contain at least twelve characters, one number, and one symbol. Administrators must rotate emergency access keys every ninety days."
+    - id: acme-support-policy
+      title: Acme Cloud support policy
+      text: "Support tickets are triaged during business hours unless the account has a critical incident plan."
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: answer-from-docs
+  source_case: grounded-policy-answer
+  source: frantic-bounty-87

--- a/skills/answer-from-docs/fixtures/harness-summary.json
+++ b/skills/answer-from-docs/fixtures/harness-summary.json
@@ -1,0 +1,15 @@
+{
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "assertion_errors": [],
+  "case_names": [
+    "grounded-policy-answer",
+    "refused-uncovered-question"
+  ],
+  "receipt_ids": [
+    "sha256:9e22acdd756e742d7931a04bb2bb8f11d812c68c6ca1c0a409dfac485053acdf",
+    "sha256:349afc2b1ff20c06375b6fc2075fc03daf664cffde2eb99406c1420d0c3717dd"
+  ],
+  "graph_case_count": 0
+}

--- a/skills/answer-from-docs/fixtures/refused-uncovered-question.yaml
+++ b/skills/answer-from-docs/fixtures/refused-uncovered-question.yaml
@@ -1,0 +1,23 @@
+name: refused-uncovered-question
+kind: skill
+target: ..
+runner: answer
+inputs:
+  question: "What is the company travel reimbursement limit?"
+  corpus:
+    - id: acme-password-policy
+      title: Acme Cloud password policy
+      text: "Acme Cloud passwords must contain at least twelve characters, one number, and one symbol."
+    - id: acme-support-policy
+      title: Acme Cloud support policy
+      text: "Support tickets are triaged during business hours unless the account has a critical incident plan."
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  public_skill: answer-from-docs
+  source_case: refused-uncovered-question
+  source: frantic-bounty-87

--- a/skills/answer-from-docs/fixtures/report.md
+++ b/skills/answer-from-docs/fixtures/report.md
@@ -1,0 +1,20 @@
+# answer-from-docs Report
+
+- Package: `answer-from-docs@0.1.0`.
+- CLI: `runx-cli 0.6.16`.
+- Local harness: passed with `grounded-policy-answer` and `refused-uncovered-question`.
+- Dogfood receipt: `sha256:bcb85e5dbe78616efff4231821534b56ee640e8c3b44dfa0e2822dcfdd3bf770`.
+- Verification: `runx verify` returned `valid: true` for the dogfood receipt with local-development signatures.
+- Inputs: `question` and `corpus[]`.
+- Outputs: `answer`, `kb_gaps[]`, and `grounded`.
+- Grounded behavior: the password-policy question returns the cited corpus sentence from `acme-password-policy`.
+- Refusal behavior: the travel-reimbursement question returns `grounded: false` and names missing evidence in `kb_gaps[]`.
+- Boundary: the runner only reads supplied runx inputs and performs no network access, live retrieval, external fetch, mutation, or credential access.
+
+## Commands
+
+```sh
+npx --yes @runxhq/cli@0.6.16 harness skills/answer-from-docs -R "$HOME/runx-answer-receipts" -j
+npx --yes @runxhq/cli@0.6.16 skill skills/answer-from-docs --receipt-dir "$HOME/runx-answer-dogfood" -i "question=What must an Acme Cloud password contain?" --input-json corpus='[{"id":"acme-password-policy","title":"Acme Cloud password policy","text":"Acme Cloud passwords must contain at least twelve characters, one number, and one symbol. Administrators must rotate emergency access keys every ninety days."}]' -j
+npx --yes @runxhq/cli@0.6.16 verify sha256:bcb85e5dbe78616efff4231821534b56ee640e8c3b44dfa0e2822dcfdd3bf770 --receipt-dir "$HOME/runx-answer-dogfood" --allow-local-development-signatures -j
+```

--- a/skills/answer-from-docs/fixtures/verification.json
+++ b/skills/answer-from-docs/fixtures/verification.json
@@ -1,0 +1,27 @@
+{
+  "schema": "runx.answer_from_docs.verification.v1",
+  "package": "answer-from-docs",
+  "version": "0.1.0",
+  "runx_cli_version": "runx-cli 0.6.16",
+  "local_harness": {
+    "status": "passed",
+    "case_count": 2,
+    "case_names": [
+      "grounded-policy-answer",
+      "refused-uncovered-question"
+    ],
+    "receipt_ids": [
+      "sha256:9e22acdd756e742d7931a04bb2bb8f11d812c68c6ca1c0a409dfac485053acdf",
+      "sha256:349afc2b1ff20c06375b6fc2075fc03daf664cffde2eb99406c1420d0c3717dd"
+    ]
+  },
+  "dogfood": {
+    "status": "sealed",
+    "receipt_id": "sha256:bcb85e5dbe78616efff4231821534b56ee640e8c3b44dfa0e2822dcfdd3bf770",
+    "verify": {
+      "valid": true,
+      "signature_mode": "local-development",
+      "receipt_count": 1
+    }
+  }
+}

--- a/skills/answer-from-docs/run.mjs
+++ b/skills/answer-from-docs/run.mjs
@@ -1,0 +1,206 @@
+import fs from "node:fs";
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "can",
+  "contain",
+  "contains",
+  "do",
+  "does",
+  "for",
+  "from",
+  "has",
+  "have",
+  "how",
+  "in",
+  "is",
+  "it",
+  "must",
+  "of",
+  "on",
+  "or",
+  "should",
+  "the",
+  "to",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+]);
+
+const inputs = readInputs();
+const question = stringValue(inputs.question);
+const corpus = normalizeCorpus(inputs.corpus);
+
+if (!question) {
+  throw new Error("question must be a non-empty string");
+}
+
+const questionTerms = tokenize(question);
+const candidates = corpus.flatMap((item) => splitSentences(item.text).map((sentence) => ({ ...item, sentence })));
+const ranked = candidates
+  .map((candidate) => ({ ...candidate, score: scoreCandidate(questionTerms, candidate.sentence) }))
+  .filter((candidate) => candidate.score.matches > 0)
+  .sort((left, right) => {
+    if (right.score.coverage !== left.score.coverage) return right.score.coverage - left.score.coverage;
+    if (right.score.matches !== left.score.matches) return right.score.matches - left.score.matches;
+    return left.sentence.length - right.sentence.length;
+  });
+
+const best = ranked[0];
+const grounded = Boolean(best && best.score.coverage >= 0.35 && best.score.matches >= Math.min(2, questionTerms.length));
+
+const result = grounded
+  ? groundedAnswer(question, best)
+  : refusedAnswer(question, corpus, questionTerms, best);
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function normalizeCorpus(value) {
+  if (!Array.isArray(value)) {
+    throw new Error("corpus must be an array");
+  }
+  return value
+    .map((entry, index) => normalizeCorpusItem(entry, index))
+    .filter((entry) => entry.text.length > 0);
+}
+
+function normalizeCorpusItem(entry, index) {
+  if (typeof entry === "string") {
+    return {
+      id: `corpus-${index + 1}`,
+      title: null,
+      text: entry.trim(),
+    };
+  }
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return {
+      id: `corpus-${index + 1}`,
+      title: null,
+      text: "",
+    };
+  }
+  const id = stringValue(entry.id) || stringValue(entry.source_id) || `corpus-${index + 1}`;
+  const title = stringValue(entry.title) || stringValue(entry.name);
+  const text = [
+    stringValue(entry.text),
+    stringValue(entry.content),
+    stringValue(entry.body),
+    stringValue(entry.markdown),
+  ].find(Boolean) || "";
+  return { id, title, text };
+}
+
+function splitSentences(text) {
+  return text
+    .replace(/\s+/g, " ")
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+}
+
+function tokenize(text) {
+  const terms = text
+    .toLowerCase()
+    .match(/[a-z0-9]+/g) || [];
+  const meaningful = terms.map(normalizeTerm).filter((term) => term.length > 2 && !STOP_WORDS.has(term));
+  return [...new Set(meaningful)];
+}
+
+function normalizeTerm(term) {
+  if (term.length > 4 && term.endsWith("ies")) {
+    return `${term.slice(0, -3)}y`;
+  }
+  if (term.length > 4 && term.endsWith("s")) {
+    return term.slice(0, -1);
+  }
+  return term;
+}
+
+function scoreCandidate(questionTerms, sentence) {
+  const sentenceTerms = new Set(tokenize(sentence));
+  const matches = questionTerms.filter((term) => sentenceTerms.has(term));
+  return {
+    matches: matches.length,
+    coverage: questionTerms.length === 0 ? 0 : matches.length / questionTerms.length,
+    matched_terms: matches,
+  };
+}
+
+function groundedAnswer(question, candidate) {
+  const answerText = candidate.sentence;
+  return {
+    answer: {
+      text: answerText,
+      citations: [
+        {
+          sentence: answerText,
+          source_id: candidate.id,
+          source_title: candidate.title,
+          evidence: candidate.sentence,
+        },
+      ],
+    },
+    kb_gaps: [],
+    grounded: true,
+    observations: {
+      question,
+      grounding: "selected sentence met overlap threshold against supplied corpus",
+      citation_mapping: [
+        {
+          answer_sentence: answerText,
+          source_id: candidate.id,
+          matched_terms: candidate.score.matched_terms,
+        },
+      ],
+    },
+  };
+}
+
+function refusedAnswer(question, corpus, questionTerms, best) {
+  const readableSources = corpus.map((entry) => entry.id);
+  return {
+    answer: {
+      text: "",
+      citations: [],
+    },
+    kb_gaps: [
+      `No supplied corpus item sufficiently supports answering: ${question}`,
+      `Needed evidence terms not grounded in corpus: ${questionTerms.join(", ") || "question terms"}`,
+    ],
+    grounded: false,
+    observations: {
+      question,
+      grounding: "refused because supplied corpus did not meet overlap threshold",
+      readable_sources: readableSources,
+      best_candidate: best
+        ? {
+            source_id: best.id,
+            coverage: best.score.coverage,
+            matched_terms: best.score.matched_terms,
+          }
+        : null,
+    },
+  };
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}


### PR DESCRIPTION
## Summary

Adds a new `answer-from-docs` runx skill package for Frantic bounty #87.

The skill answers only from supplied `corpus[]` inputs, emits `answer`, `kb_gaps[]`, and `grounded`, and refuses unsupported questions instead of using external knowledge.

## Validation

- `npx --yes @runxhq/cli@0.6.16 skill inspect skills/answer-from-docs -j`
- WSL/Linux: `npx --yes @runxhq/cli@0.6.16 harness skills/answer-from-docs -R "$HOME/runx-answer-receipts" -j`
- WSL/Linux: `npx --yes @runxhq/cli@0.6.16 skill skills/answer-from-docs --receipt-dir "$HOME/runx-answer-dogfood" ... -j`
- WSL/Linux: `npx --yes @runxhq/cli@0.6.16 verify sha256:bcb85e5dbe78616efff4231821534b56ee640e8c3b44dfa0e2822dcfdd3bf770 --receipt-dir "$HOME/runx-answer-dogfood" --allow-local-development-signatures -j`

## Notes

Windows `runx` receipt writes currently hit `Access is denied` when syncing the receipt directory; the same harness and verify path passed under WSL/Linux.
