### PR TITLE
feat: add answer-from-docs skill (#87)

### DIFF
--- a/skills/answer-from-docs/SKILL.md
+++ b/skills/answer-from-docs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: answer-from-docs
+description: >
+  Answer a question strictly from a bounded corpus. Returns grounded answers
+  with citations or refuses when the corpus lacks coverage.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 15
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  question:
+    type: string
+    required: true
+    description: Natural-language question to answer from the corpus.
+  corpus:
+    type: array
+    required: true
+    description: Bounded set of source documents, each with id and text.
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+outputs:
+  answer:
+    type: object
+    description: Answer packet with text and citations.
+    properties:
+      text:
+        type: string
+      citations:
+        type: array
+        items:
+          type: object
+          properties:
+            source_id:
+              type: string
+            excerpt:
+              type: string
+  kb_gaps:
+    type: array
+    description: Topics present in the question but absent from the corpus.
+    items:
+      type: string
+  grounded:
+    type: boolean
+    description: True when every claim in the answer is supported by a citation.
+runx:
+  input_resolution:
+    required:
+      - question
+      - corpus
+  artifacts:
+    named_emits:
+      answer: answer
+      kb_gaps: kb_gaps
+      grounded: grounded
+---
+
+Answer a question using only the supplied corpus. Every sentence in the answer
+must be traceable to a corpus entry via citation. When the corpus lacks
+sufficient coverage the skill returns grounded: false with kb_gaps describing
+what is missing.

--- a/skills/answer-from-docs/X.yaml
+++ b/skills/answer-from-docs/X.yaml
@@ -1,0 +1,71 @@
+skill: answer-from-docs
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: grounded-answer
+      runner: default
+      inputs:
+        question: "What is the runx harness?"
+        corpus:
+          - id: doc1
+            text: "runx harness replays skill fixtures and seals signed receipts for every case."
+          - id: doc2
+            text: "runx registry publish uploads skills and verifies them server-side."
+          - id: doc3
+            text: "runx receipts provide auditable evidence of execution with cryptographic signatures."
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+    - name: unanswered-question
+      runner: default
+      inputs:
+        question: "What is the meaning of life?"
+        corpus:
+          - id: doc1
+            text: "runx is a governed execution platform for AI agents."
+          - id: doc2
+            text: "Skills are portable, typed execution units with harness fixtures."
+      expect:
+        status: failure
+        reason_code: no_answer_found
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    artifacts:
+      named_emits:
+        answer: answer
+        kb_gaps: kb_gaps
+        grounded: grounded
+    inputs:
+      question:
+        type: string
+        required: true
+        description: Natural-language question to answer from the corpus.
+      corpus:
+        type: array
+        required: true
+        description: Bounded set of source documents, each with id and text.
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+            text:
+              type: string

--- a/skills/answer-from-docs/run.mjs
+++ b/skills/answer-from-docs/run.mjs
@@ -1,0 +1,41 @@
+const question = process.env.RUNX_INPUT_QUESTION || "";
+const corpusRaw = process.env.RUNX_INPUT_CORPUS || "[]";
+const corpus = JSON.parse(corpusRaw);
+
+const questionTerms = question.toLowerCase().split(/\s+/).filter(t => t.length > 3);
+
+const citations = [];
+const kbGaps = [];
+
+for (const doc of corpus) {
+  const docText = doc.text.toLowerCase();
+  const matchedTerms = questionTerms.filter(t => docText.includes(t));
+  if (matchedTerms.length > 0) {
+    citations.push({
+      source_id: doc.id,
+      excerpt: doc.text.substring(0, 200)
+    });
+  }
+}
+
+if (citations.length > 0) {
+  const citedTexts = citations.map(c => c.excerpt);
+  process.stdout.write(JSON.stringify({
+    answer: {
+      text: citedTexts.join(" "),
+      citations
+    },
+    kb_gaps: [],
+    grounded: true
+  }) + "\n");
+} else {
+  const gapTerms = questionTerms.filter(t =>
+    !corpus.some(d => d.text.toLowerCase().includes(t))
+  );
+  process.stdout.write(JSON.stringify({
+    answer: null,
+    kb_gaps: gapTerms,
+    grounded: false
+  }) + "\n");
+  process.exit(3);
+}


### PR DESCRIPTION
## Summary

Adds answer-from-docs skill for Frantic bounty #87.

Answers questions strictly from a bounded corpus with citations. Returns grounded: false with kb_gaps when corpus lacks coverage.

## Changes

- skills/answer-from-docs/SKILL.md
- skills/answer-from-docs/X.yaml
- skills/answer-from-docs/run.mjs

## Verification

- Local harness: 2/2 cases passed
- Remote registry: umbtest03/answer-from-docs@sha-1ee1c7040328 published to api.runx.ai