### PR TITLE
[codex] Add support firewatch skill

### DIFF
--- a/skills/support-firewatch/SKILL.md
+++ b/skills/support-firewatch/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: support-firewatch
+version: 0.1.0
+description: Detect support threads that need human escalation from bounded thread and SLA policy inputs without paging anyone or changing tickets.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 10
+inputs:
+  thread:
+    type: json
+    required: true
+    description: Support thread turns with author, timestamp, role, and body fields.
+  sla_policy:
+    type: json
+    required: true
+    description: SLA clock and threshold policy used to decide whether a response is breached.
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - thread
+      - sla_policy
+---
+
+# Support Firewatch
+
+Support Firewatch reviews a bounded customer support thread and an explicit SLA
+policy, then emits signals and a human-approval escalation packet only when the
+supplied evidence warrants one.
+
+It never sends messages, pages an engineer, reassigns a ticket, changes account
+state, or notifies a customer. The output is a decision packet for a human inbox
+or a later governed workflow.
+
+## Inputs
+
+- `thread`: an array of support turns. Each turn may include `id`, `role`,
+  `author`, `timestamp`, and `body`.
+- `sla_policy`: an object with `now`, `first_response_minutes`, and
+  `next_response_minutes`.
+
+## Output
+
+```yaml
+signals:
+  sentiment:
+    label: positive | neutral | negative
+    score: number
+    evidence: array
+  sla_breach:
+    breached: boolean
+    elapsed_minutes: number | null
+    threshold_minutes: number | null
+    evidence: object | null
+  churn_risk:
+    level: low | medium | high
+    evidence: array
+escalation:
+  needed: boolean
+  priority: null | normal | urgent
+  context:
+    reason: string
+    approval_inbox: string
+    no_side_effects: true
+```
+
+## Behavior
+
+1. Normalize only the supplied thread turns.
+2. Score sentiment from explicit words in customer turns.
+3. Compare the latest unanswered customer turn with the supplied SLA clock.
+4. Detect churn-risk signals such as cancellation, refund, legal, social, or
+   executive-escalation language.
+5. Emit `escalation.needed = true` only for breached, strongly negative, or
+   high-churn-risk threads.
+6. Emit `escalation.needed = false` for healthy threads and explain why.
+
+## Refusal Rules
+
+- Refuse invalid or empty thread inputs.
+- Refuse missing or unparsable SLA policy clocks.
+- Do not infer account state, customer value, private billing status, or actual
+  customer identity beyond the supplied text.
+- Do not page, assign, notify, send, or mutate anything.
+
+## Verification Notes
+
+The harness includes one escalation case with a negative breached thread and one
+healthy no-escalation case. Both cases are sealed local runs; neither performs
+external side effects.

--- a/skills/support-firewatch/X.yaml
+++ b/skills/support-firewatch/X.yaml
@@ -1,0 +1,95 @@
+skill: support-firewatch
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: local-input
+      method: READ
+      scope: runx:input:read
+  deny:
+    - network
+    - network_mutation
+    - credential_material
+    - private_user_data
+
+harness:
+  cases:
+    - name: breached-negative-thread-escalates
+      runner: firewatch
+      inputs:
+        thread:
+          - id: turn-1
+            role: customer
+            author: Maya
+            timestamp: "2026-07-05T09:00:00Z"
+            body: "This outage is still broken and nobody has replied. We are going to cancel if this is ignored."
+          - id: turn-2
+            role: agent
+            author: Support
+            timestamp: "2026-07-05T09:10:00Z"
+            body: "We are looking into it."
+          - id: turn-3
+            role: customer
+            author: Maya
+            timestamp: "2026-07-05T10:00:00Z"
+            body: "This is unacceptable. I need an update now or I will ask for a refund."
+        sla_policy:
+          now: "2026-07-05T11:10:00Z"
+          first_response_minutes: 30
+          next_response_minutes: 45
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: healthy-thread-no-escalation
+      runner: firewatch
+      inputs:
+        thread:
+          - id: turn-1
+            role: customer
+            author: Owen
+            timestamp: "2026-07-05T10:00:00Z"
+            body: "Thanks for the setup guide. The domain verification looks good now."
+          - id: turn-2
+            role: agent
+            author: Support
+            timestamp: "2026-07-05T10:08:00Z"
+            body: "Great, glad it worked. Let us know if anything else comes up."
+        sla_policy:
+          now: "2026-07-05T10:15:00Z"
+          first_response_minutes: 30
+          next_response_minutes: 45
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  firewatch:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      signals: object
+      escalation: object
+    inputs:
+      thread:
+        type: json
+        required: true
+        description: Support thread turns.
+      sla_policy:
+        type: json
+        required: true
+        description: SLA policy and clock.

--- a/skills/support-firewatch/fixtures/breached-negative-thread.json
+++ b/skills/support-firewatch/fixtures/breached-negative-thread.json
@@ -1,0 +1,30 @@
+{
+  "thread": [
+    {
+      "id": "turn-1",
+      "role": "customer",
+      "author": "Maya",
+      "timestamp": "2026-07-05T09:00:00Z",
+      "body": "This outage is still broken and nobody has replied. We are going to cancel if this is ignored."
+    },
+    {
+      "id": "turn-2",
+      "role": "agent",
+      "author": "Support",
+      "timestamp": "2026-07-05T09:10:00Z",
+      "body": "We are looking into it."
+    },
+    {
+      "id": "turn-3",
+      "role": "customer",
+      "author": "Maya",
+      "timestamp": "2026-07-05T10:00:00Z",
+      "body": "This is unacceptable. I need an update now or I will ask for a refund."
+    }
+  ],
+  "sla_policy": {
+    "now": "2026-07-05T11:10:00Z",
+    "first_response_minutes": 30,
+    "next_response_minutes": 45
+  }
+}

--- a/skills/support-firewatch/fixtures/harness-evidence.json
+++ b/skills/support-firewatch/fixtures/harness-evidence.json
@@ -1,0 +1,16 @@
+{
+  "runx_version": "runx-cli 0.6.16",
+  "command": "npx -y @runxhq/cli harness -R /tmp/runx-support-firewatch-receipts-linux ./skills/support-firewatch -j",
+  "environment_note": "Run from WSL with a temporary Linux Node 20.11.1 runtime to avoid the Windows receipt-store access issue.",
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "case_names": [
+    "breached-negative-thread-escalates",
+    "healthy-thread-no-escalation"
+  ],
+  "receipt_ids": [
+    "sha256:ac483df858f8c1cf45ba36bf72908eb19d2c4fbe476eb3f104be6854491ded4b",
+    "sha256:1313d7665c09784300938e8fdef703b425cf5eb99a12fadaa0fdb3635b8bfaf0"
+  ]
+}

--- a/skills/support-firewatch/fixtures/healthy-thread.json
+++ b/skills/support-firewatch/fixtures/healthy-thread.json
@@ -1,0 +1,23 @@
+{
+  "thread": [
+    {
+      "id": "turn-1",
+      "role": "customer",
+      "author": "Owen",
+      "timestamp": "2026-07-05T10:00:00Z",
+      "body": "Thanks for the setup guide. The domain verification looks good now."
+    },
+    {
+      "id": "turn-2",
+      "role": "agent",
+      "author": "Support",
+      "timestamp": "2026-07-05T10:08:00Z",
+      "body": "Great, glad it worked. Let us know if anything else comes up."
+    }
+  ],
+  "sla_policy": {
+    "now": "2026-07-05T10:15:00Z",
+    "first_response_minutes": 30,
+    "next_response_minutes": 45
+  }
+}

--- a/skills/support-firewatch/run.mjs
+++ b/skills/support-firewatch/run.mjs
@@ -1,0 +1,201 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const thread = arrayValue(inputs.thread, "thread");
+const policy = objectValue(inputs.sla_policy, "sla_policy");
+
+const now = parseDate(policy.now, "sla_policy.now");
+const firstResponseMinutes = positiveNumber(policy.first_response_minutes, "sla_policy.first_response_minutes");
+const nextResponseMinutes = positiveNumber(policy.next_response_minutes, "sla_policy.next_response_minutes");
+
+const turns = thread.map(normalizeTurn);
+if (turns.length === 0) {
+  fail("thread must contain at least one turn");
+}
+
+const customerTurns = turns.filter((turn) => turn.role === "customer");
+if (customerTurns.length === 0) {
+  fail("thread must contain at least one customer turn");
+}
+
+const sentiment = sentimentSignal(customerTurns);
+const slaBreach = slaBreachSignal(turns, now, firstResponseMinutes, nextResponseMinutes);
+const churnRisk = churnRiskSignal(customerTurns);
+const escalation = escalationDecision({ sentiment, slaBreach, churnRisk });
+
+process.stdout.write(JSON.stringify({
+  signals: {
+    sentiment,
+    sla_breach: slaBreach,
+    churn_risk: churnRisk,
+  },
+  escalation,
+}, null, 2));
+process.stdout.write("\n");
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    thread: parseInputValue(process.env.RUNX_INPUT_THREAD),
+    sla_policy: parseInputValue(process.env.RUNX_INPUT_SLA_POLICY),
+  };
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function normalizeTurn(turn, index) {
+  const item = objectValue(turn, `thread[${index}]`);
+  const body = stringValue(item.body, `thread[${index}].body`);
+  const timestamp = parseDate(item.timestamp, `thread[${index}].timestamp`);
+  const rawRole = stringValue(item.role ?? item.kind ?? item.author_role, `thread[${index}].role`).toLowerCase();
+  const role = ["customer", "user", "requester"].includes(rawRole) ? "customer" : "agent";
+  return {
+    id: stringOptional(item.id) ?? `turn-${index + 1}`,
+    role,
+    author: stringOptional(item.author) ?? role,
+    timestamp,
+    body,
+    normalized: normalizeText(body),
+  };
+}
+
+function sentimentSignal(customerTurns) {
+  const negativeWords = ["angry", "unacceptable", "ignored", "broken", "outage", "failed", "cancel", "refund", "terrible", "escalate"];
+  const positiveWords = ["thanks", "great", "good", "resolved", "worked", "appreciate"];
+  const negativeEvidence = evidenceForWords(customerTurns, negativeWords);
+  const positiveEvidence = evidenceForWords(customerTurns, positiveWords);
+  const score = clamp((positiveEvidence.length * 0.3) - (negativeEvidence.length * 0.35), -1, 1);
+  const label = score <= -0.35 ? "negative" : score >= 0.35 ? "positive" : "neutral";
+  return {
+    label,
+    score: Number(score.toFixed(2)),
+    evidence: label === "negative" ? negativeEvidence : positiveEvidence,
+  };
+}
+
+function slaBreachSignal(turns, now, firstResponseMinutes, nextResponseMinutes) {
+  const latestCustomer = [...turns].reverse().find((turn) => turn.role === "customer");
+  const hasPriorAgent = turns.some((turn) => turn.role === "agent" && turn.timestamp < latestCustomer.timestamp);
+  const threshold = hasPriorAgent ? nextResponseMinutes : firstResponseMinutes;
+  const elapsed = Math.floor((now.getTime() - latestCustomer.timestamp.getTime()) / 60000);
+  const breached = elapsed > threshold;
+  return {
+    breached,
+    elapsed_minutes: elapsed,
+    threshold_minutes: threshold,
+    evidence: {
+      turn_id: latestCustomer.id,
+      turn_timestamp: latestCustomer.timestamp.toISOString(),
+      policy_clock: now.toISOString(),
+      policy: hasPriorAgent ? "next_response_minutes" : "first_response_minutes",
+    },
+  };
+}
+
+function churnRiskSignal(customerTurns) {
+  const highRiskWords = ["cancel", "refund", "legal", "lawyer", "chargeback", "tweet", "linkedin", "competitor"];
+  const mediumRiskWords = ["unacceptable", "ignored", "angry", "escalate", "manager", "outage"];
+  const high = evidenceForWords(customerTurns, highRiskWords);
+  const medium = evidenceForWords(customerTurns, mediumRiskWords);
+  const level = high.length > 0 ? "high" : medium.length > 0 ? "medium" : "low";
+  return {
+    level,
+    evidence: high.length > 0 ? high : medium,
+  };
+}
+
+function escalationDecision({ sentiment, slaBreach, churnRisk }) {
+  const reasons = [];
+  if (slaBreach.breached) reasons.push(`SLA breach: ${slaBreach.elapsed_minutes} minutes elapsed against ${slaBreach.threshold_minutes} minute policy`);
+  if (sentiment.label === "negative") reasons.push("negative customer sentiment grounded in thread text");
+  if (churnRisk.level === "high") reasons.push("high churn-risk language present");
+  const needed = reasons.length > 0;
+  return {
+    needed,
+    priority: churnRisk.level === "high" || (needed && slaBreach.breached) ? "urgent" : needed ? "normal" : null,
+    context: {
+      reason: needed ? reasons.join("; ") : "No SLA breach, strong negative sentiment, or churn-risk signal found in the supplied thread.",
+      approval_inbox: "human_support_escalation",
+      no_side_effects: true,
+    },
+  };
+}
+
+function evidenceForWords(turns, words) {
+  const evidence = [];
+  for (const turn of turns) {
+    const matched = words.filter((word) => turn.normalized.includes(word));
+    if (matched.length > 0) {
+      evidence.push({
+        turn_id: turn.id,
+        author: turn.author,
+        timestamp: turn.timestamp.toISOString(),
+        matched,
+        excerpt: excerpt(turn.body),
+      });
+    }
+  }
+  return evidence;
+}
+
+function arrayValue(value, name) {
+  if (!Array.isArray(value)) fail(`${name} must be an array`);
+  return value;
+}
+
+function objectValue(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${name} must be an object`);
+  return value;
+}
+
+function positiveNumber(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) fail(`${name} must be a positive number`);
+  return number;
+}
+
+function parseDate(value, name) {
+  const raw = stringValue(value, name);
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) fail(`${name} must be an ISO timestamp`);
+  return date;
+}
+
+function stringValue(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) fail(`${name} must be a non-empty string`);
+  return value.trim();
+}
+
+function stringOptional(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function normalizeText(value) {
+  return String(value).toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function excerpt(value) {
+  const text = String(value).replace(/\s+/g, " ").trim();
+  return text.length > 180 ? `${text.slice(0, 177)}...` : text;
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(64);
+}


### PR DESCRIPTION
## Summary

Adds `support-firewatch`, a dependency-free runx skill that reviews a bounded support thread and SLA policy, then emits grounded sentiment, SLA breach, churn-risk, and escalation signals.

The skill does not page anyone, notify customers, reassign tickets, or mutate state. It only produces a human-approval escalation packet.

## Files

- `skills/support-firewatch/SKILL.md`
- `skills/support-firewatch/X.yaml`
- `skills/support-firewatch/run.mjs`
- `skills/support-firewatch/fixtures/breached-negative-thread.json`
- `skills/support-firewatch/fixtures/healthy-thread.json`
- `skills/support-firewatch/fixtures/harness-evidence.json`

## Validation

- `npx -y @runxhq/cli --version` -> `runx-cli 0.6.16`
- `npx -y @runxhq/cli harness -R /tmp/runx-support-firewatch-receipts-linux ./skills/support-firewatch -j` -> passed, 2 cases
- `node ./skills/support-firewatch/run.mjs` with the breached fixture -> `escalation.needed=true`, `priority=urgent`
- `node ./skills/support-firewatch/run.mjs` with the healthy fixture -> `escalation.needed=false`
- `git diff --check` -> clean

Note: on native Windows, both this skill and the existing `examples/hello-world` currently hit `receipt store is unreadable: Access is denied`; I used WSL with a temporary Linux Node 20.11.1 runtime for the runx 0.6.16 harness evidence.