### PR TITLE
feat(skills): add support firewatch

### DIFF
--- a/skills/support-firewatch/SKILL.md
+++ b/skills/support-firewatch/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: support-firewatch
+version: 0.1.0
+description: Watch a bounded support thread for SLA breach, negative sentiment, and churn risk, then emit a governed escalation proposal only when the evidence supports it.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+links:
+  source: https://github.com/Difficult-Burger/runx/tree/bounty/support-firewatch-80/skills/support-firewatch
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - thread
+      - sla_policy
+---
+
+## What this skill does
+
+Support Firewatch evaluates one bounded support thread against an explicit SLA
+policy. It emits receipt-backed signals for sentiment, SLA breach, and churn
+risk, then proposes an escalation only when the thread is overdue, strongly
+negative, or commercially risky.
+
+The skill never sends messages, opens tickets, changes account state, or pages a
+human directly. It produces a packet that a separate governed workflow can
+review and act on.
+
+## When to use this skill
+
+Use this skill when an agent has already collected a support conversation and
+needs a deterministic first-pass firewatch decision: no escalation, normal
+escalation, urgent escalation, or critical escalation.
+
+It is useful for support queue monitoring, customer-success triage, and
+governed handoff workflows where escalation requires clear evidence.
+
+## When not to use this skill
+
+Do not use this skill as a helpdesk transport, pager, refund authority, account
+recovery workflow, or abuse/legal/security decision maker. If the input lacks a
+thread or SLA policy, stop and request those inputs instead of guessing.
+
+Do not submit private account data, credentials, full inbox exports, or
+unredacted customer secrets as inputs.
+
+## Procedure
+
+1. Require `thread` and `sla_policy` objects.
+2. Normalize message text and timestamps.
+3. Determine whether the support response SLA is breached.
+4. Score sentiment from concrete negative and positive signals.
+5. Estimate churn risk from cancellation, refund, contract, tier, and breach
+   signals.
+6. Emit `signals{sentiment,sla_breach,churn_risk}`.
+7. Emit `escalation{needed,priority,context}` only when evidence supports it.
+8. Record matched signals, timing evidence, and limitations.
+
+## Output schema
+
+The runner emits `runx.support.firewatch.v1`:
+
+```json
+{
+  "signals": {
+    "sentiment": "strong_negative | negative | neutral | positive",
+    "sla_breach": {
+      "breached": true,
+      "age_hours": 31.5,
+      "threshold_hours": 12,
+      "last_customer_message_at": "2026-07-05T08:30:00Z"
+    },
+    "churn_risk": {
+      "level": "high",
+      "score": 0.86,
+      "drivers": ["cancel", "enterprise", "sla_breach"]
+    }
+  },
+  "escalation": {
+    "needed": true,
+    "priority": "urgent",
+    "context": "Enterprise thread is 31.5h old against a 12h SLA and contains cancellation language."
+  },
+  "evidence": {
+    "source": "fixture:enterprise-overdue",
+    "matched_signals": ["cancel", "refund", "no response"],
+    "message_count": 3,
+    "policy_name": "standard-support-sla",
+    "side_effects": "none"
+  }
+}
+```
+
+## Inputs
+
+- `thread`: object with `messages[]`, optional `subject`, optional
+  `customer_tier`, optional `source`, and optional `current_time`.
+- `thread.messages[]`: objects with `author`, `role`, `body`, and
+  `created_at`. Roles can be `customer`, `agent`, or `system`.
+- `sla_policy`: object with `response_hours`, optional
+  `vip_response_hours`, optional `critical_terms`, optional `churn_terms`, and
+  optional `policy_name`.
+
+## Outputs
+
+- `signals.sentiment`: thread sentiment derived from matched language.
+- `signals.sla_breach`: SLA timing evidence.
+- `signals.churn_risk`: level, score, and concrete drivers.
+- `escalation`: whether to escalate, priority, and reviewer context.
+- `evidence`: source summary, matched signals, limitations, and proof that this
+  skill made no external side effects.

--- a/skills/support-firewatch/X.yaml
+++ b/skills/support-firewatch/X.yaml
@@ -1,0 +1,91 @@
+skill: support-firewatch
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: enterprise-overdue-escalates
+      runner: firewatch
+      inputs:
+        thread:
+          source: fixture:enterprise-overdue
+          customer_tier: enterprise
+          current_time: "2026-07-05T20:00:00Z"
+          subject: Production export is still blocked
+          messages:
+            - role: customer
+              author: Mira
+              created_at: "2026-07-04T12:30:00Z"
+              body: We have had no response for a day. The export is still broken and this is blocking renewal.
+            - role: customer
+              author: Mira
+              created_at: "2026-07-05T07:10:00Z"
+              body: This is unacceptable. If we cannot get an answer today we need to cancel and request a refund.
+        sla_policy:
+          policy_name: standard-support-sla
+          response_hours: 24
+          vip_response_hours: 12
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: healthy-thread-no-escalation
+      runner: firewatch
+      inputs:
+        thread:
+          source: fixture:healthy-thread
+          customer_tier: starter
+          current_time: "2026-07-05T20:00:00Z"
+          subject: Question about CSV import
+          messages:
+            - role: customer
+              author: Theo
+              created_at: "2026-07-05T18:45:00Z"
+              body: Thanks for the quick help earlier. I have one follow-up question about mapping CSV columns.
+            - role: agent
+              author: Support
+              created_at: "2026-07-05T19:05:00Z"
+              body: Happy to help. The column mapper is under Settings, and we can review a sample file if needed.
+        sla_policy:
+          policy_name: standard-support-sla
+          response_hours: 24
+          vip_response_hours: 12
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+runners:
+  firewatch:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      signals: object
+      escalation: object
+      evidence: object
+    artifacts:
+      wrap_as: support_firewatch_packet
+      packet: runx.support.firewatch.v1
+    inputs:
+      thread:
+        type: json
+        required: true
+        description: Bounded support thread with messages, timestamps, and optional customer context.
+      sla_policy:
+        type: json
+        required: true
+        description: SLA thresholds and escalation policy for the support queue.

--- a/skills/support-firewatch/fixtures/enterprise-overdue-escalates.yaml
+++ b/skills/support-firewatch/fixtures/enterprise-overdue-escalates.yaml
@@ -1,0 +1,34 @@
+name: enterprise-overdue-escalates
+kind: skill
+target: ..
+runner: firewatch
+inputs:
+  thread:
+    source: fixture:enterprise-overdue
+    customer_tier: enterprise
+    current_time: "2026-07-05T20:00:00Z"
+    subject: Production export is still blocked
+    messages:
+      - role: customer
+        author: Mira
+        created_at: "2026-07-04T12:30:00Z"
+        body: We have had no response for a day. The export is still broken and this is blocking renewal.
+      - role: customer
+        author: Mira
+        created_at: "2026-07-05T07:10:00Z"
+        body: This is unacceptable. If we cannot get an answer today we need to cancel and request a refund.
+  sla_policy:
+    policy_name: standard-support-sla
+    response_hours: 24
+    vip_response_hours: 12
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+    reason_code: process_closed
+metadata:
+  public_skill: support-firewatch
+  source_case: enterprise-overdue-escalates
+  source: skills-fixture

--- a/skills/support-firewatch/fixtures/healthy-thread-no-escalation.yaml
+++ b/skills/support-firewatch/fixtures/healthy-thread-no-escalation.yaml
@@ -1,0 +1,34 @@
+name: healthy-thread-no-escalation
+kind: skill
+target: ..
+runner: firewatch
+inputs:
+  thread:
+    source: fixture:healthy-thread
+    customer_tier: starter
+    current_time: "2026-07-05T20:00:00Z"
+    subject: Question about CSV import
+    messages:
+      - role: customer
+        author: Theo
+        created_at: "2026-07-05T18:45:00Z"
+        body: Thanks for the quick help earlier. I have one follow-up question about mapping CSV columns.
+      - role: agent
+        author: Support
+        created_at: "2026-07-05T19:05:00Z"
+        body: Happy to help. The column mapper is under Settings, and we can review a sample file if needed.
+  sla_policy:
+    policy_name: standard-support-sla
+    response_hours: 24
+    vip_response_hours: 12
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+    reason_code: process_closed
+metadata:
+  public_skill: support-firewatch
+  source_case: healthy-thread-no-escalation
+  source: skills-fixture

--- a/skills/support-firewatch/references/local-harness.json
+++ b/skills/support-firewatch/references/local-harness.json
@@ -1,0 +1,25 @@
+{
+  "runx_version": "runx-cli 0.6.16",
+  "command": "runx harness skills/support-firewatch --json",
+  "signing_profile": "local demo receipt signer",
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "graph_case_count": 0,
+  "cases": [
+    {
+      "fixture": "enterprise-overdue-escalates",
+      "status": "sealed",
+      "disposition": "closed",
+      "reason_code": "process_closed",
+      "receipt_id": "sha256:8b2dbd7c3dfe4a68d2ba0d52e294e61072e13cb52c0cc1793b26d8f3e1b64d9c"
+    },
+    {
+      "fixture": "healthy-thread-no-escalation",
+      "status": "sealed",
+      "disposition": "closed",
+      "reason_code": "process_closed",
+      "receipt_id": "sha256:a8f95ffef81896106ffd2c658429fd8e2a4094086ec0bc69ba8a35b2650cd598"
+    }
+  ]
+}

--- a/skills/support-firewatch/run.mjs
+++ b/skills/support-firewatch/run.mjs
@@ -1,0 +1,303 @@
+import fs from "node:fs";
+
+const negativeSignals = [
+  "angry",
+  "frustrated",
+  "unacceptable",
+  "no response",
+  "ignored",
+  "blocked",
+  "broken",
+  "down",
+  "failed",
+  "failure",
+  "escalate",
+];
+
+const positiveSignals = [
+  "thanks",
+  "thank you",
+  "resolved",
+  "works now",
+  "appreciate",
+  "helpful",
+];
+
+const churnSignals = [
+  "cancel",
+  "cancellation",
+  "refund",
+  "chargeback",
+  "switch vendor",
+  "competitor",
+  "contract",
+  "renewal",
+  "downgrade",
+  "enterprise",
+  "churn",
+];
+
+const inputs = readInputs();
+const thread = objectValue(inputs.thread, "thread");
+const policy = objectValue(inputs.sla_policy, "sla_policy");
+const messages = normalizeMessages(thread.messages);
+
+if (messages.length === 0 && !stringValue(thread.subject) && !stringValue(thread.body)) {
+  fail("thread.messages, thread.subject, or thread.body is required");
+}
+
+const currentTime = parseDate(thread.current_time ?? policy.current_time) ?? new Date();
+const text = normalize([
+  thread.subject,
+  thread.body,
+  ...messages.map((message) => message.body),
+].filter(Boolean).join("\n"));
+const lastCustomerMessage = lastMessageByRole(messages, "customer");
+const lastAgentMessage = lastMessageByRole(messages, "agent");
+const thresholdHours = thresholdFor(thread, policy);
+const ageHours = lastCustomerMessage
+  ? hoursBetween(lastCustomerMessage.created_at, currentTime)
+  : null;
+const agentRespondedAfterCustomer = Boolean(
+  lastCustomerMessage
+    && lastAgentMessage
+    && lastAgentMessage.created_at > lastCustomerMessage.created_at,
+);
+const slaBreached = Boolean(
+  lastCustomerMessage
+    && !agentRespondedAfterCustomer
+    && ageHours !== null
+    && ageHours > thresholdHours,
+);
+
+const sentiment = sentimentFor(text);
+const churnRisk = churnRiskFor({ text, thread, sentiment, slaBreached });
+const escalation = escalationFor({ slaBreached, churnRisk, sentiment, ageHours, thresholdHours, thread });
+const matchedSignals = [
+  ...signalsFor(text, negativeSignals),
+  ...signalsFor(text, churnSignals),
+  ...(slaBreached ? ["sla_breach"] : []),
+  ...(isVip(thread) ? ["vip_customer"] : []),
+];
+
+const result = {
+  signals: {
+    sentiment,
+    sla_breach: {
+      breached: slaBreached,
+      age_hours: ageHours === null ? null : round(ageHours),
+      threshold_hours: thresholdHours,
+      last_customer_message_at: lastCustomerMessage?.created_at.toISOString() ?? null,
+      agent_responded_after_customer: agentRespondedAfterCustomer,
+    },
+    churn_risk: churnRisk,
+  },
+  escalation,
+  evidence: {
+    source: stringValue(thread.source) ?? "inline_support_thread",
+    source_summary: summarize(thread.subject, messages),
+    matched_signals: [...new Set(matchedSignals)],
+    message_count: messages.length,
+    customer_tier: stringValue(thread.customer_tier) ?? null,
+    policy_name: stringValue(policy.policy_name) ?? "support-firewatch-policy",
+    limitations: limitationsFor({ messages, lastCustomerMessage, thresholdHours }),
+    side_effects: "none",
+  },
+};
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    thread: parseInput(process.env.RUNX_INPUT_THREAD),
+    sla_policy: parseInput(process.env.RUNX_INPUT_SLA_POLICY),
+  };
+}
+
+function parseInput(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function normalizeMessages(value) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) fail("thread.messages must be an array when provided");
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      fail(`thread.messages[${index}] must be an object`);
+    }
+    const body = stringValue(entry.body);
+    if (!body) fail(`thread.messages[${index}].body is required`);
+    return {
+      author: stringValue(entry.author) ?? "unknown",
+      role: normalizeRole(entry.role),
+      body,
+      created_at: parseDate(entry.created_at) ?? new Date(0),
+    };
+  });
+}
+
+function normalizeRole(value) {
+  const role = stringValue(value)?.toLowerCase();
+  if (role === "customer" || role === "agent" || role === "system") return role;
+  return "customer";
+}
+
+function parseDate(value) {
+  const raw = stringValue(value);
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function thresholdFor(threadValue, policyValue) {
+  const base = positiveNumber(policyValue.response_hours) ?? 24;
+  const vip = positiveNumber(policyValue.vip_response_hours);
+  return isVip(threadValue) && vip ? vip : base;
+}
+
+function isVip(threadValue) {
+  return matches(normalize(threadValue.customer_tier), ["enterprise", "vip", "strategic", "paid"]);
+}
+
+function sentimentFor(text) {
+  const negative = signalsFor(text, negativeSignals).length;
+  const positive = signalsFor(text, positiveSignals).length;
+  if (negative >= 3) return "strong_negative";
+  if (negative > positive) return "negative";
+  if (positive > negative) return "positive";
+  return "neutral";
+}
+
+function churnRiskFor({ text, thread: threadValue, sentiment, slaBreached }) {
+  const drivers = [];
+  const churnMatches = signalsFor(text, churnSignals);
+  drivers.push(...churnMatches);
+  if (isVip(threadValue)) drivers.push("vip_customer");
+  if (slaBreached) drivers.push("sla_breach");
+  if (sentiment === "strong_negative") drivers.push("strong_negative_sentiment");
+
+  let score = 0;
+  score += Math.min(churnMatches.length * 0.18, 0.54);
+  if (isVip(threadValue)) score += 0.18;
+  if (slaBreached) score += 0.22;
+  if (sentiment === "strong_negative") score += 0.18;
+  if (sentiment === "negative") score += 0.1;
+  score = Math.min(score, 0.99);
+
+  return {
+    level: score >= 0.7 ? "high" : score >= 0.35 ? "medium" : "low",
+    score: round(score),
+    drivers: [...new Set(drivers)],
+  };
+}
+
+function escalationFor({ slaBreached, churnRisk, sentiment, ageHours, thresholdHours, thread: threadValue }) {
+  const needed = slaBreached || churnRisk.level === "high" || sentiment === "strong_negative";
+  if (!needed) {
+    return {
+      needed: false,
+      priority: "none",
+      context: "No SLA breach, high churn risk, or strongly negative sentiment was found.",
+    };
+  }
+
+  const priority = churnRisk.level === "high" && slaBreached
+    ? "urgent"
+    : churnRisk.level === "high" || sentiment === "strong_negative"
+      ? "high"
+      : "normal";
+  const parts = [];
+  if (slaBreached) {
+    parts.push(`thread is ${round(ageHours)}h old against a ${thresholdHours}h SLA`);
+  }
+  if (churnRisk.drivers.length > 0) {
+    parts.push(`risk drivers: ${churnRisk.drivers.join(", ")}`);
+  }
+  if (isVip(threadValue)) {
+    parts.push("customer tier is escalated");
+  }
+  return {
+    needed: true,
+    priority,
+    context: sentence(parts),
+  };
+}
+
+function limitationsFor({ messages, lastCustomerMessage, thresholdHours }) {
+  const limitations = [];
+  if (messages.length === 0) limitations.push("No structured messages were provided.");
+  if (!lastCustomerMessage) limitations.push("No customer-authored message timestamp was available.");
+  if (!thresholdHours) limitations.push("SLA threshold fell back to the default.");
+  return limitations;
+}
+
+function lastMessageByRole(messages, role) {
+  return messages
+    .filter((message) => message.role === role)
+    .sort((a, b) => a.created_at - b.created_at)
+    .at(-1) ?? null;
+}
+
+function hoursBetween(start, end) {
+  return Math.max(0, (end.getTime() - start.getTime()) / 3_600_000);
+}
+
+function summarize(subject, messages) {
+  const candidate = stringValue(subject) ?? messages[0]?.body ?? "support thread";
+  const oneLine = String(candidate).replace(/\s+/g, " ").trim();
+  return oneLine.length > 160 ? `${oneLine.slice(0, 157)}...` : oneLine;
+}
+
+function signalsFor(text, dictionary) {
+  return dictionary.filter((signal) => text.includes(signal));
+}
+
+function matches(text, needles) {
+  return needles.some((needle) => text.includes(needle));
+}
+
+function normalize(value) {
+  return String(value ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function positiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}
+
+function round(value) {
+  return Math.round(Number(value) * 100) / 100;
+}
+
+function sentence(parts) {
+  if (parts.length === 0) return "Escalation is needed based on the supplied thread.";
+  const text = parts.join("; ");
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}.`;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function objectValue(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  return value;
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(64);
+}


### PR DESCRIPTION
## Summary
- Add the `support-firewatch` runx skill package.
- Detect support-thread sentiment, SLA breach, and churn risk from bounded inputs.
- Emit a governed escalation proposal without paging, reassigning, notifying customers, or mutating support systems.

## Frantic bounty
This is for Frantic bounty #80, `runx skill: support firewatch`.

## Validation
- `runx harness skills/support-firewatch --json`
- Result: passed, 2 cases, 0 assertion errors.
- Harness cases: `enterprise-overdue-escalates`, `healthy-thread-no-escalation`.
