### PR TITLE
Add schema-guard skill

### DIFF
--- a/skills/schema-guard/SKILL.md
+++ b/skills/schema-guard/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: schema-guard
+description: Check API or data schema changes against sample payloads and a compatibility policy before a schema proposal is published.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 15
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  current_schema:
+    type: json
+    required: true
+    description: Current JSON-schema-like object contract.
+  proposed_schema:
+    type: json
+    required: true
+    description: Proposed JSON-schema-like object contract.
+  sample_payloads:
+    type: json
+    required: true
+    description: Array of real sample payloads to validate against the proposed schema.
+  compatibility_policy:
+    type: json
+    required: true
+    description: Policy object with breaking_allowed, required_fields, and versioning_rule.
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - current_schema
+      - proposed_schema
+      - sample_payloads
+      - compatibility_policy
+  artifacts:
+    named_emits:
+      compatibility: runx.schema_guard.compatibility.v1
+      validation_results: runx.schema_guard.validation_results.v1
+      migration_notes: runx.schema_guard.migration_notes.v1
+      publish_schema_proposal: runx.schema_guard.publish_schema_proposal.v1
+---
+
+# Schema Guard
+
+`schema-guard` checks whether a proposed API or data contract can move forward
+without silently breaking callers. It reads the current schema, proposed schema,
+real sample payloads, and a compatibility policy. It reports breaking changes,
+validates samples against the proposed contract, and emits a
+`publish_schema_proposal` only when the change is allowed by policy.
+
+The skill never writes a live schema. Its proposal is a gated handoff for a
+human schema approver or a separate schema-publisher executor.
+
+## Use This Skill When
+
+- A migration, API version, or event contract is about to land.
+- A maintainer needs a deterministic compatibility report before publishing.
+- A workflow needs a receipt showing why a schema proposal was allowed or held.
+
+## Do Not Use This Skill For
+
+- Live schema writes or registry publication.
+- Inventing sample coverage. If a sample does not cover a path, the report says
+  that directly.
+- Broad API design review. This skill only checks the supplied contract delta,
+  policy, and payload samples.
+
+## Inputs
+
+- `current_schema`: JSON-schema-like object contract currently in force.
+- `proposed_schema`: JSON-schema-like object contract being reviewed.
+- `sample_payloads`: array of real sample payload objects.
+- `compatibility_policy`: object with:
+  - `breaking_allowed`: boolean.
+  - `required_fields`: array of field paths that must remain present.
+  - `versioning_rule`: string such as `minor_allows_additive_only`.
+
+## Outputs
+
+- `compatibility`: object with `status`, `breaking_changes`, and policy result.
+- `validation_results`: array of sample validation results against the proposed
+  schema.
+- `migration_notes`: array of notes about additive, removed, or changed fields
+  and sample coverage.
+- `publish_schema_proposal`: emitted only when the proposal is compatible under
+  the supplied policy. It is a proposal, not a live schema write.
+
+## Procedure
+
+1. Normalize both schemas into field paths.
+2. Compare field paths, required status, type, enum, and object shape.
+3. Mark removals, type changes, enum narrowing, newly required fields, and
+   required policy-field removals as breaking changes.
+4. Validate every supplied sample payload against the proposed schema.
+5. Record sample coverage by field path without inventing missing coverage.
+6. Emit `publish_schema_proposal` only when policy permits the change and all
+   samples validate.
+
+## Refusal Conditions
+
+- `breaking_allowed` is false and at least one breaking change is found.
+- Any sample payload fails the proposed schema.
+- A field named in `compatibility_policy.required_fields` is absent from the
+  proposed schema.
+- Inputs are malformed or `sample_payloads` is not an array.

--- a/skills/schema-guard/X.yaml
+++ b/skills/schema-guard/X.yaml
@@ -1,0 +1,181 @@
+skill: schema-guard
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: local-schema
+      method: READ
+      scope: runx:schema:read
+  deny:
+    - network_mutation
+    - credential_material
+    - live_schema_write
+
+emits:
+  - name: compatibility
+    packet: runx.schema_guard.compatibility.v1
+  - name: validation_results
+    packet: runx.schema_guard.validation_results.v1
+  - name: migration_notes
+    packet: runx.schema_guard.migration_notes.v1
+  - name: publish_schema_proposal
+    packet: runx.schema_guard.publish_schema_proposal.v1
+
+harness:
+  cases:
+    - name: schema-guard-additive-compatible
+      runner: default
+      inputs:
+        current_schema:
+          type: object
+          title: OrderEvent
+          version: "1.2.0"
+          required:
+            - order_id
+            - status
+          properties:
+            order_id:
+              type: string
+            status:
+              type: string
+              enum:
+                - pending
+                - paid
+            total_cents:
+              type: integer
+        proposed_schema:
+          type: object
+          title: OrderEvent
+          version: "1.3.0"
+          required:
+            - order_id
+            - status
+          properties:
+            order_id:
+              type: string
+            status:
+              type: string
+              enum:
+                - pending
+                - paid
+                - refunded
+            total_cents:
+              type: integer
+            coupon_code:
+              type: string
+        sample_payloads:
+          - order_id: ord_1001
+            status: paid
+            total_cents: 2599
+          - order_id: ord_1002
+            status: refunded
+            total_cents: 1200
+            coupon_code: WELCOME10
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields:
+            - order_id
+            - status
+          versioning_rule: minor_allows_additive_only
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: schema-guard-breaking-refused
+      runner: default
+      inputs:
+        current_schema:
+          type: object
+          title: OrderEvent
+          version: "1.2.0"
+          required:
+            - order_id
+            - status
+          properties:
+            order_id:
+              type: string
+            status:
+              type: string
+              enum:
+                - pending
+                - paid
+            total_cents:
+              type: integer
+        proposed_schema:
+          type: object
+          title: OrderEvent
+          version: "2.0.0"
+          required:
+            - order_id
+            - status
+            - currency
+          properties:
+            order_id:
+              type: integer
+            status:
+              type: string
+              enum:
+                - paid
+            currency:
+              type: string
+        sample_payloads:
+          - order_id: ord_2001
+            status: pending
+            total_cents: 500
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields:
+            - order_id
+            - status
+          versioning_rule: major_required_for_breaking
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 15
+    sandbox:
+      profile: readonly
+      cwd_policy: skill-directory
+      require_enforcement: false
+    artifacts:
+      named_emits:
+        compatibility: runx.schema_guard.compatibility.v1
+        validation_results: runx.schema_guard.validation_results.v1
+        migration_notes: runx.schema_guard.migration_notes.v1
+        publish_schema_proposal: runx.schema_guard.publish_schema_proposal.v1
+    inputs:
+      current_schema:
+        type: json
+        required: true
+        description: Current JSON-schema-like object contract.
+      proposed_schema:
+        type: json
+        required: true
+        description: Proposed JSON-schema-like object contract.
+      sample_payloads:
+        type: json
+        required: true
+        description: Array of real sample payloads to validate against the proposed schema.
+      compatibility_policy:
+        type: json
+        required: true
+        description: Policy object with breaking_allowed, required_fields, and versioning_rule.

--- a/skills/schema-guard/fixtures/additive-compatible.json
+++ b/skills/schema-guard/fixtures/additive-compatible.json
@@ -1,0 +1,7 @@
+{
+  "case": "schema-guard-additive-compatible",
+  "expected": {
+    "compatibility.status": "compatible",
+    "publish_schema_proposal": "present"
+  }
+}

--- a/skills/schema-guard/fixtures/breaking-refused.json
+++ b/skills/schema-guard/fixtures/breaking-refused.json
@@ -1,0 +1,7 @@
+{
+  "case": "schema-guard-breaking-refused",
+  "expected": {
+    "compatibility.status": "refused",
+    "publish_schema_proposal": "absent"
+  }
+}

--- a/skills/schema-guard/run.mjs
+++ b/skills/schema-guard/run.mjs
@@ -1,0 +1,327 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  const parsed = JSON.parse(raw);
+  return {
+    current_schema: parseMaybeJson(parsed.current_schema),
+    proposed_schema: parseMaybeJson(parsed.proposed_schema),
+    sample_payloads: parseMaybeJson(parsed.sample_payloads),
+    compatibility_policy: parseMaybeJson(parsed.compatibility_policy),
+  };
+}
+
+function parseMaybeJson(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !/^[\[{"]/.test(trimmed)) {
+    return value;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function sha256(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeSchema(schema, basePath = "$", inheritedRequired = []) {
+  if (!schema || typeof schema !== "object") {
+    return new Map();
+  }
+  const fields = new Map();
+  const properties = schema.properties && typeof schema.properties === "object" ? schema.properties : {};
+  const required = new Set(asArray(schema.required));
+
+  for (const [name, child] of Object.entries(properties)) {
+    const path = basePath === "$" ? `$.${name}` : `${basePath}.${name}`;
+    const childRequired = required.has(name) || inheritedRequired.includes(path);
+    fields.set(path, contractFor(child, childRequired));
+    if (child && typeof child === "object" && child.type === "object") {
+      for (const [nestedPath, nestedContract] of normalizeSchema(child, path).entries()) {
+        fields.set(nestedPath, nestedContract);
+      }
+    }
+  }
+  return fields;
+}
+
+function contractFor(node, required) {
+  const schema = node && typeof node === "object" ? node : {};
+  return {
+    type: Array.isArray(schema.type) ? schema.type.join("|") : schema.type || "any",
+    required,
+    enum: Array.isArray(schema.enum) ? [...schema.enum] : null,
+    additionalProperties: schema.additionalProperties,
+  };
+}
+
+function describeContract(contract) {
+  if (!contract) {
+    return "absent";
+  }
+  const parts = [`type=${contract.type}`, `required=${contract.required}`];
+  if (contract.enum) {
+    parts.push(`enum=[${contract.enum.map(String).join(",")}]`);
+  }
+  if (contract.additionalProperties !== undefined) {
+    parts.push(`additionalProperties=${contract.additionalProperties}`);
+  }
+  return parts.join("; ");
+}
+
+function compareSchemas(currentSchema, proposedSchema, policy) {
+  const current = normalizeSchema(currentSchema);
+  const proposed = normalizeSchema(proposedSchema);
+  const breaking = [];
+  const notes = [];
+  const paths = new Set([...current.keys(), ...proposed.keys()]);
+
+  for (const path of [...paths].sort()) {
+    const oldContract = current.get(path);
+    const newContract = proposed.get(path);
+    if (oldContract && !newContract) {
+      breaking.push(change(path, oldContract, newContract, "field_removed"));
+      continue;
+    }
+    if (!oldContract && newContract) {
+      notes.push({
+        path,
+        kind: newContract.required ? "new_required_field" : "new_optional_field",
+        note: newContract.required
+          ? "New required field can break existing callers."
+          : "Additive optional field.",
+      });
+      if (newContract.required) {
+        breaking.push(change(path, oldContract, newContract, "new_required_field"));
+      }
+      continue;
+    }
+    if (!oldContract || !newContract) {
+      continue;
+    }
+    if (oldContract.type !== newContract.type) {
+      breaking.push(change(path, oldContract, newContract, "type_changed"));
+    }
+    if (!oldContract.required && newContract.required) {
+      breaking.push(change(path, oldContract, newContract, "field_became_required"));
+    }
+    if (enumNarrowed(oldContract.enum, newContract.enum)) {
+      breaking.push(change(path, oldContract, newContract, "enum_narrowed"));
+    } else if (enumExpanded(oldContract.enum, newContract.enum)) {
+      notes.push({ path, kind: "enum_expanded", note: "Enum was expanded without removing existing values." });
+    }
+  }
+
+  for (const requiredPath of asArray(policy.required_fields).map(normalizePolicyPath)) {
+    if (!proposed.has(requiredPath)) {
+      breaking.push({
+        path: requiredPath,
+        old_contract: describeContract(current.get(requiredPath)),
+        new_contract: "absent",
+        policy_rule: "policy_required_field_missing",
+      });
+    }
+  }
+
+  return { current, proposed, breaking, notes };
+}
+
+function normalizePolicyPath(path) {
+  const value = String(path || "").trim();
+  if (!value) {
+    return "$";
+  }
+  return value.startsWith("$.") ? value : `$.${value.replace(/^\./, "")}`;
+}
+
+function change(path, oldContract, newContract, policyRule) {
+  return {
+    path,
+    old_contract: describeContract(oldContract),
+    new_contract: describeContract(newContract),
+    policy_rule: policyRule,
+  };
+}
+
+function enumNarrowed(oldEnum, newEnum) {
+  if (!oldEnum || !newEnum) {
+    return false;
+  }
+  return oldEnum.some((value) => !newEnum.includes(value));
+}
+
+function enumExpanded(oldEnum, newEnum) {
+  if (!oldEnum || !newEnum) {
+    return false;
+  }
+  return newEnum.some((value) => !oldEnum.includes(value)) && oldEnum.every((value) => newEnum.includes(value));
+}
+
+function typeOfValue(value) {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (Number.isInteger(value)) {
+    return "integer";
+  }
+  return typeof value;
+}
+
+function validateSample(sample, schema, pointer = "$") {
+  const errors = [];
+  const expectedType = schema?.type;
+  if (expectedType) {
+    const expected = Array.isArray(expectedType) ? expectedType : [expectedType];
+    const actual = typeOfValue(sample);
+    if (!expected.includes(actual)) {
+      return [`${pointer} expected ${expected.join("|")}, got ${actual}`];
+    }
+  }
+
+  if (Array.isArray(schema?.enum) && !schema.enum.includes(sample)) {
+    errors.push(`${pointer} expected one of ${schema.enum.map(String).join(", ")}`);
+  }
+
+  if (schema?.type === "object") {
+    const properties = schema.properties || {};
+    for (const field of asArray(schema.required)) {
+      if (!sample || typeof sample !== "object" || !(field in sample)) {
+        errors.push(`${pointer}.${field} is required`);
+      }
+    }
+    if (sample && typeof sample === "object" && !Array.isArray(sample)) {
+      for (const [field, value] of Object.entries(sample)) {
+        if (properties[field]) {
+          errors.push(...validateSample(value, properties[field], `${pointer}.${field}`));
+        } else if (schema.additionalProperties === false) {
+          errors.push(`${pointer}.${field} is not allowed`);
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+function coveredPaths(sample, basePath = "$") {
+  if (!sample || typeof sample !== "object" || Array.isArray(sample)) {
+    return new Set();
+  }
+  const paths = new Set();
+  for (const [field, value] of Object.entries(sample)) {
+    const path = `${basePath}.${field}`;
+    paths.add(path);
+    for (const nested of coveredPaths(value, path)) {
+      paths.add(nested);
+    }
+  }
+  return paths;
+}
+
+function buildCoverageNotes(samplePayloads, proposedFields) {
+  const covered = new Set();
+  for (const sample of samplePayloads) {
+    for (const path of coveredPaths(sample)) {
+      covered.add(path);
+    }
+  }
+  return [...proposedFields.keys()].sort().map((path) => ({
+    path,
+    kind: covered.has(path) ? "sample_covered" : "sample_not_covered",
+    note: covered.has(path)
+      ? "At least one supplied sample includes this path."
+      : "No supplied sample covers this path; coverage was not invented.",
+  }));
+}
+
+function main() {
+  const { current_schema, proposed_schema, sample_payloads, compatibility_policy } = readInputs();
+  if (!Array.isArray(sample_payloads)) {
+    throw new Error("sample_payloads must be an array");
+  }
+  const policy = compatibility_policy && typeof compatibility_policy === "object" ? compatibility_policy : {};
+  const { proposed, breaking, notes } = compareSchemas(current_schema, proposed_schema, policy);
+  const validation_results = sample_payloads.map((sample, index) => {
+    const errors = validateSample(sample, proposed_schema);
+    return {
+      sample_index: index,
+      valid: errors.length === 0,
+      errors,
+      sample_digest: sha256(sample),
+    };
+  });
+  const coverageNotes = buildCoverageNotes(sample_payloads, proposed);
+  const samplesValid = validation_results.every((result) => result.valid);
+  const policyAllows = Boolean(policy.breaking_allowed) || breaking.length === 0;
+  const compatible = policyAllows && samplesValid;
+  const compatibility = {
+    status: compatible ? "compatible" : "refused",
+    compatible,
+    policy_result: policyAllows ? "allowed" : "blocked_by_policy",
+    versioning_rule: policy.versioning_rule || "unspecified",
+    breaking_allowed: Boolean(policy.breaking_allowed),
+    breaking_changes: breaking,
+  };
+  const migration_notes = [
+    ...notes,
+    ...coverageNotes,
+    ...(samplesValid ? [] : [{ kind: "sample_validation_failed", note: "One or more samples failed proposed schema validation." }]),
+  ];
+  const output = {
+    compatibility,
+    validation_results,
+    migration_notes,
+  };
+  if (compatible) {
+    output.publish_schema_proposal = {
+      status: "proposed",
+      gate: "schema-publisher-or-human-approver",
+      live_write_performed: false,
+      current_schema_digest: sha256(current_schema),
+      proposed_schema_digest: sha256(proposed_schema),
+      changed_paths: [...new Set([...notes.map((note) => note.path).filter(Boolean)])].sort(),
+    };
+  }
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stdout.write(`${JSON.stringify({
+    compatibility: {
+      status: "refused",
+      compatible: false,
+      policy_result: "invalid_input",
+      breaking_changes: [{ path: "$", old_contract: "unknown", new_contract: "unknown", policy_rule: message }],
+    },
+    validation_results: [],
+    migration_notes: [{ kind: "invalid_input", note: message }],
+  })}\n`);
+}


### PR DESCRIPTION
## Summary
- Add a deterministic schema-guard runx skill package under skills/schema-guard.
- The skill compares current/proposed JSON-schema-like contracts, validates real sample payloads, reports breaking changes with field path/old contract/new contract/policy rule, and emits publish_schema_proposal only when policy allows the change.
- Includes X.yaml harness cases for an additive compatible proposal and a breaking refused proposal, plus fixtures documenting the expected case outcomes.

## Verification
- npx runx --version -> runx-cli 0.6.16
- env RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local npx runx harness runx/skills/schema-guard --json -> passed, 2 cases
- npx runx verify --receipt .runx/receipts/sha256-96e45b867af43f2203461415e30b42c9e9a5b8728921de7d679ab60768125ff2.json --allow-local-development-signatures --json -> valid
- env RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local npx runx registry publish runx/skills/schema-guard/SKILL.md --registry-dir .runx/registry/local --json -> published local/schema-guard@sha-d99e5d4007bc
- npx runx add local/schema-guard@sha-d99e5d4007bc --registry .runx/registry/local --to .runx/install-check/schema-guard --json -> installed
- env RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local npx runx skill .runx/install-check/schema-guard/local/schema-guard/sha-d99e5d4007bc ... --json -> sealed dogfood run

Note: local runs used RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local because this macOS environment reports sandbox-exec: sandbox_apply: Operation not permitted. Hosted harness should enforce its normal sandbox policy.