### PR TITLE
Add skills/secret-catcher (diff secret scanner)

### DIFF
--- a/skills/secret-catcher/SKILL.md
+++ b/skills/secret-catcher/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: secret-catcher
+description: Scan a code diff for credential-like spans and emit redacted findings, a gated redaction proposal, and a block decision without ever quoting a raw secret.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+runx:
+  tags:
+    - security
+    - secrets
+    - diff
+links:
+  source: https://github.com/epistemedeus/secret-catcher
+---
+
+## What this skill does
+
+This skill reads a unified diff and detects credential-like spans that a change
+would introduce. It scans only added lines, reports each match as a finding
+located by file, line, and column, proposes a redaction that a downstream
+executor can perform, and returns a `block` decision. A change that adds a
+credential blocks; a clean change does not.
+
+The skill is read-only and offline. It makes no network calls, installs
+nothing, executes no caller-supplied code, and edits no files. It never quotes a
+raw secret: every finding carries a redacted preview and a one-way SHA-256
+fingerprint instead of the matched value, and the runner fails closed rather
+than emit output in which a raw value could appear.
+
+## When to use this skill
+
+Use this skill on a pull-request or pre-commit diff to catch a leaked
+credential before it lands. It is appropriate as a gate in an agent or CI
+pipeline that must decide whether a diff is safe to merge, and as the evidence
+step before a human or a downstream redaction executor acts. It produces a
+machine-checkable packet plus a concise Markdown report for reviewer handoff.
+
+## When not to use this skill
+
+Do not use this skill as a full application security review, an entropy scanner
+over an entire repository history, or a guarantee that a diff is secret-free.
+Coverage is bounded by the detector set and the contents of the supplied diff. A
+zero-finding result means only that no configured detector matched an added line
+under the current rules.
+
+Do not use it to remove or rewrite secrets. Redaction is proposed here and
+performed by the gated `redact-pii` executor; this skill never edits content.
+
+## Procedure
+
+1. Read the `diff` input (or `diff_path` for a diff stored inside the skill
+   directory) and record its byte length and SHA-256.
+2. Walk the unified diff, tracking the current file and the new-file line number
+   from each `+++` header and `@@` hunk header.
+3. On each added line, run every detector and record a finding with its type,
+   `{ file, line, column }` location, a redacted preview, and a fingerprint.
+4. Exclude placeholders, template interpolations, and environment-variable
+   references so ordinary configuration does not false-block.
+5. Build a gated `redaction_proposal` for the `redact-pii` executor when any
+   finding exists.
+6. Set `block` to true when there is at least one finding.
+7. Verify no raw secret value appears anywhere in the output; fail closed if it
+   would.
+8. Emit `secret.catcher.result.v1` and, when `output_dir` is set, write
+   `evidence.json` and `report.md`.
+
+## Edge cases and stop conditions
+
+Stop with an error when neither `diff` nor `diff_path` is provided, when
+`diff_path` resolves outside the skill directory, or when the diff exceeds the
+size limit. An empty diff or a diff with no added lines is a valid clean result:
+zero findings and `block: false`.
+
+Removed lines and context lines are never scanned, so deleting a secret does not
+produce a finding. Findings are grounded only in added lines of the supplied
+diff; the skill never infers a secret that is not literally present.
+
+The redaction proposal is a proposed effect only. Any real edit, commit, or push
+needs its own authority gate and receipt through the `redact-pii` executor.
+
+## Output schema
+
+The primary output is `secret_catcher_result`, with schema
+`secret.catcher.result.v1`:
+
+```json
+{
+  "schema": "secret.catcher.result.v1",
+  "skill": "secret-catcher",
+  "version": "0.1.0",
+  "block": true,
+  "findings": [
+    {
+      "type": "aws_access_key_id",
+      "location": { "file": "config/prod.env", "line": 2, "column": 19 },
+      "redacted_preview": "AKIA************…",
+      "value_length": 20,
+      "fingerprint": "sha256:1a5d44a2dca19669"
+    }
+  ],
+  "redaction_proposal": {
+    "decision": "proposed",
+    "performed_by": "redact-pii",
+    "requires_approval": true,
+    "edits": [
+      {
+        "file": "config/prod.env",
+        "line": 2,
+        "column_start": 19,
+        "column_end": 39,
+        "replacement": "***REDACTED_AWS_ACCESS_KEY_ID***"
+      }
+    ],
+    "note": "Proposal only. secret-catcher edits no files and scrubs no live content. The redact-pii executor performs the gated edit after approval."
+  },
+  "summary": {
+    "added_lines_scanned": 4,
+    "files_scanned": 1,
+    "findings": 1,
+    "finding_types": ["aws_access_key_id"]
+  },
+  "policy": {
+    "scans": "added diff lines only",
+    "grounded_in": "diff",
+    "edits_files": false,
+    "quotes_raw_secrets": false,
+    "downstream_executor": "redact-pii",
+    "detectors": ["aws_access_key_id", "aws_secret_access_key", "github_personal_access_token", "slack_token", "google_api_key", "stripe_secret_key", "private_key_block", "json_web_token", "generic_secret_assignment"]
+  },
+  "source": { "kind": "diff", "bytes": 0, "sha256": "hex" },
+  "validation": {
+    "grounded_in_diff": true,
+    "every_finding_has_location": true,
+    "block_iff_findings": true,
+    "raw_secret_values_absent": true,
+    "finding_rule": "..."
+  }
+}
+```
+
+When `output_dir` is provided, the runner also writes `evidence.json` and
+`report.md` inside that directory.
+
+## Worked example
+
+The harness scans a diff that adds a production env file containing AWS's
+documented example credentials and a synthetic token:
+
+```bash
+runx skill "$PWD" \
+  --input-json diff='"diff --git a/config/prod.env b/config/prod.env\n--- /dev/null\n+++ b/config/prod.env\n@@ -0,0 +1,2 @@\n+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n"' \
+  --json
+```
+
+Expected result shape:
+
+- `block` is true.
+- `findings[0].type` is `aws_access_key_id` and its location points at the added
+  line and column.
+- `findings[0].redacted_preview` masks the value and `findings[0].fingerprint`
+  is a truncated SHA-256; the raw key never appears.
+- `redaction_proposal.performed_by` is `redact-pii` and `requires_approval` is
+  true.
+
+Swapping in a diff that only references `process.env.API_KEY` yields zero
+findings and `block: false`.
+
+## Inputs
+
+- `diff`: the unified diff to scan (required).
+- `scan_context`: optional metadata recorded with the result.
+- `diff_path`: optional path to a diff file inside the skill directory.
+- `output_dir`: optional directory for `evidence.json` and `report.md`.
+
+## Outputs
+
+- `secret_catcher_result`: the complete packet.
+- `block`: boolean merge gate, true when any finding exists.
+- `findings`: array of `{ type, location, redacted_preview, value_length, fingerprint }`.
+- `redaction_proposal`: gated proposal consumed by the `redact-pii` executor.

--- a/skills/secret-catcher/SKILL.md
+++ b/skills/secret-catcher/SKILL.md
@@ -77,6 +77,11 @@ Removed lines and context lines are never scanned, so deleting a secret does not
 produce a finding. Findings are grounded only in added lines of the supplied
 diff; the skill never infers a secret that is not literally present.
 
+If a caller sets `apply` (or `perform_redaction` / `write`) to true — asking the
+skill to perform the redaction itself — the skill refuses and stops. It never
+edits files or scrubs live content; that effect belongs to the gated
+`redact-pii` executor.
+
 The redaction proposal is a proposed effect only. Any real edit, commit, or push
 needs its own authority gate and receipt through the `redact-pii` executor.
 
@@ -173,6 +178,7 @@ findings and `block: false`.
 - `scan_context`: optional metadata recorded with the result.
 - `diff_path`: optional path to a diff file inside the skill directory.
 - `output_dir`: optional directory for `evidence.json` and `report.md`.
+- `apply`: must be absent or false; if set, the skill refuses (it never edits files).
 
 ## Outputs
 

--- a/skills/secret-catcher/X.yaml
+++ b/skills/secret-catcher/X.yaml
@@ -1,0 +1,127 @@
+skill: secret-catcher
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+runx:
+  mutating: false
+  idempotency:
+    key: diff_sha256
+  scopes:
+    - diff.read
+  policy:
+    data_classification: caller_supplied_diff
+    network:
+      allowed: []
+      forbidden:
+        - any network access
+        - repository writes
+        - live content edits
+    verifier_notes:
+      - Findings are produced only from added lines in the supplied unified diff.
+      - No raw secret value appears in findings, artifacts, or the sealed receipt; each span is redacted and fingerprinted with a one-way digest.
+      - The redaction is a gated proposal for the downstream redact-pii executor; this skill edits no files and scrubs no live content.
+      - The planted-secret harness case blocks; the clean harness case emits zero findings and does not block.
+  artifacts:
+    emits:
+      - secret_catcher_result
+      - evidence_json
+      - report_md
+    wrap_as: secret_catcher_packet
+
+harness:
+  cases:
+    - name: planted-secret-blocks
+      runner: default
+      inputs:
+        diff: |
+          diff --git a/config/prod.env b/config/prod.env
+          new file mode 100644
+          --- /dev/null
+          +++ b/config/prod.env
+          @@ -0,0 +1,4 @@
+          +# production credentials (example values, not real)
+          +AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+          +AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+          +GITHUB_TOKEN=ghp_EXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE0
+        scan_context:
+          repo: acme/api
+          pr: 42
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: clean-diff-does-not-block
+      runner: default
+      inputs:
+        diff: |
+          diff --git a/src/config.js b/src/config.js
+          --- a/src/config.js
+          +++ b/src/config.js
+          @@ -10,2 +10,9 @@ function loadConfig() {
+             const region = 'us-east-1';
+          +  // read credentials from the environment, never hard-code them
+          +  const apiKey = process.env.API_KEY;
+          +  const dbPassword = process.env.DB_PASSWORD || 'changeme';
+          +  const token = `${AUTH_TOKEN}`;
+          +  const webhook = 'https://example.com/hooks/notify';
+          +  const sampleKey = 'your_api_key_here';
+          +  return { region, apiKey, dbPassword, token };
+           }
+        scan_context:
+          repo: acme/api
+          pr: 43
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: /usr/bin/env
+    args:
+      - node
+      - run.mjs
+    scopes:
+      - diff.read
+    policy:
+      reads:
+        - caller-supplied unified diff
+      calls: []
+      writes:
+        - evidence.json
+        - report.md
+      disallows:
+        - network access
+        - editing files or repositories
+        - quoting raw secret values
+        - executing caller-supplied code
+    inputs:
+      diff:
+        type: string
+        required: true
+        description: Unified diff to scan. Only added lines are scanned; context and removed lines are ignored.
+      scan_context:
+        type: object
+        required: false
+        description: Optional metadata (for example repo, pr, base, head) recorded with the result.
+      diff_path:
+        type: string
+        required: false
+        description: Path to a unified diff file inside the skill directory, used when a diff is too large to pass inline.
+      output_dir:
+        type: string
+        required: false
+        description: Directory inside the skill directory where evidence.json and report.md are written.
+    outputs:
+      block: boolean
+      findings: array
+      redaction_proposal: object
+      secret_catcher_result: object

--- a/skills/secret-catcher/X.yaml
+++ b/skills/secret-catcher/X.yaml
@@ -81,6 +81,20 @@ harness:
         receipt:
           schema: runx.receipt.v1
 
+    - name: refuses-to-apply-redaction
+      runner: default
+      inputs:
+        diff: |
+          diff --git a/config/prod.env b/config/prod.env
+          new file mode 100644
+          --- /dev/null
+          +++ b/config/prod.env
+          @@ -0,0 +1,1 @@
+          +AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+        apply: true
+      expect:
+        status: failure
+
 runners:
   default:
     default: true
@@ -116,6 +130,10 @@ runners:
         type: string
         required: false
         description: Path to a unified diff file inside the skill directory, used when a diff is too large to pass inline.
+      apply:
+        type: boolean
+        required: false
+        description: Must be absent or false. If set, the skill refuses and stops — it never edits files; redaction is delegated to the gated redact-pii executor.
       output_dir:
         type: string
         required: false

--- a/skills/secret-catcher/fixtures/clean-diff-does-not-block.yaml
+++ b/skills/secret-catcher/fixtures/clean-diff-does-not-block.yaml
@@ -1,0 +1,35 @@
+name: clean-diff-does-not-block
+kind: skill
+target: ..
+runner: default
+inputs:
+  diff: |
+    diff --git a/src/config.js b/src/config.js
+    --- a/src/config.js
+    +++ b/src/config.js
+    @@ -10,2 +10,9 @@ function loadConfig() {
+       const region = 'us-east-1';
+    +  // read credentials from the environment, never hard-code them
+    +  const apiKey = process.env.API_KEY;
+    +  const dbPassword = process.env.DB_PASSWORD || 'changeme';
+    +  const token = `${AUTH_TOKEN}`;
+    +  const webhook = 'https://example.com/hooks/notify';
+    +  const sampleKey = 'your_api_key_here';
+    +  return { region, apiKey, dbPassword, token };
+     }
+  scan_context:
+    repo: acme/api
+    pr: 43
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+metadata:
+  public_skill: secret-catcher
+  source_case: clean-diff-does-not-block
+  source: skills-fixture
+  note: >-
+    Added lines reference credentials only through the environment
+    (process.env.*), a template placeholder (${AUTH_TOKEN}), an example URL, and
+    obvious placeholder strings. None are real secrets, so the scan emits zero
+    findings and block=false. This proves the detector does not false-block.

--- a/skills/secret-catcher/fixtures/planted-secret-blocks.yaml
+++ b/skills/secret-catcher/fixtures/planted-secret-blocks.yaml
@@ -1,0 +1,33 @@
+name: planted-secret-blocks
+kind: skill
+target: ..
+runner: default
+inputs:
+  diff: |
+    diff --git a/config/prod.env b/config/prod.env
+    new file mode 100644
+    --- /dev/null
+    +++ b/config/prod.env
+    @@ -0,0 +1,4 @@
+    +# production credentials (example values, not real)
+    +AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+    +AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    +GITHUB_TOKEN=ghp_EXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLE0
+  scan_context:
+    repo: acme/api
+    pr: 42
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+metadata:
+  public_skill: secret-catcher
+  source_case: planted-secret-blocks
+  source: skills-fixture
+  note: >-
+    The planted spans are AWS's documented example access key and secret key
+    (AKIAIOSFODNN7EXAMPLE / wJalrX...EXAMPLEKEY) plus a synthetic ghp_ token whose
+    body is the literal word EXAMPLE repeated. Every value carries an EXAMPLE
+    marker, so secret scanners recognize them as test vectors, not live
+    credentials. The scan yields findings and block=true; every finding is
+    redacted and fingerprinted, and no raw value appears in the output.

--- a/skills/secret-catcher/fixtures/refuses-to-apply-redaction.yaml
+++ b/skills/secret-catcher/fixtures/refuses-to-apply-redaction.yaml
@@ -1,0 +1,24 @@
+name: refuses-to-apply-redaction
+kind: skill
+target: ..
+runner: default
+inputs:
+  diff: |
+    diff --git a/config/prod.env b/config/prod.env
+    new file mode 100644
+    --- /dev/null
+    +++ b/config/prod.env
+    @@ -0,0 +1,1 @@
+    +AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+  apply: true
+expect:
+  status: failure
+metadata:
+  public_skill: secret-catcher
+  source_case: refuses-to-apply-redaction
+  source: skills-fixture
+  note: >-
+    A caller sets apply=true to ask secret-catcher to perform the redaction
+    itself. The skill refuses and stops, because it never edits files or scrubs
+    live content — redaction is a gated proposal for the redact-pii executor.
+    This is the governed stop case: the run fails closed rather than mutate content.

--- a/skills/secret-catcher/run.mjs
+++ b/skills/secret-catcher/run.mjs
@@ -1,0 +1,438 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+// secret-catcher — detect credential-like spans introduced by a code diff.
+//
+// Reads a unified diff, scans only ADDED lines, reports each credential-like
+// span as a grounded finding, proposes (never performs) a redaction handed to
+// the downstream `redact-pii` executor, and returns a block decision. The skill
+// edits no files, scrubs no live content, and never quotes a raw secret: every
+// finding carries a redacted preview and a one-way fingerprint only.
+
+const SCHEMA = "secret.catcher.result.v1";
+const SKILL = "secret-catcher";
+const VERSION = "0.1.0";
+const REDACTION_EXECUTOR = "redact-pii";
+const MAX_DIFF_BYTES = 5_000_000;
+
+function main() {
+  const inputs = readInputs();
+  const skillRoot = process.cwd();
+
+  const diffText = resolveDiff(inputs, skillRoot);
+  const scanContext = normalizeScanContext(inputs.scan_context);
+
+  const scan = scanDiff(diffText);
+  const packet = buildPacket({ scan, diffText, scanContext });
+
+  // Fail closed: never emit output that contains a raw secret value. The scanner
+  // keeps the raw spans out of `packet` by construction; this is the belt-and-
+  // suspenders proof that the invariant held for this exact run.
+  assertNoRawSecretLeak(packet, scan.rawSpans);
+
+  writeArtifacts(inputs.output_dir, packet, skillRoot);
+
+  process.stdout.write(`${JSON.stringify(packet, null, 2)}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// input handling
+// ---------------------------------------------------------------------------
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function resolveDiff(rawInputs, root) {
+  let text;
+  if (typeof rawInputs.diff === "string") {
+    // A provided-but-empty diff is a valid clean scan, distinct from a missing one.
+    text = rawInputs.diff;
+  } else if (typeof rawInputs.diff_path === "string" && rawInputs.diff_path.length > 0) {
+    const resolved = path.resolve(root, rawInputs.diff_path);
+    ensureInside(root, resolved, "diff_path");
+    text = fs.readFileSync(resolved, "utf8");
+  } else {
+    throw new Error("input 'diff' (a unified diff string) is required");
+  }
+  if (Buffer.byteLength(text) > MAX_DIFF_BYTES) {
+    throw new Error(`diff exceeds ${MAX_DIFF_BYTES} bytes`);
+  }
+  return text;
+}
+
+function normalizeScanContext(value) {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    try { return JSON.parse(value); } catch { return { note: value }; }
+  }
+  if (typeof value === "object") return value;
+  return { value };
+}
+
+// ---------------------------------------------------------------------------
+// detectors — high-precision, prefix- or context-anchored credential patterns
+// ---------------------------------------------------------------------------
+//
+// Each detector yields the exact secret span it matched (`value`) plus the
+// column at which the span starts inside the added line. `keep` is the number
+// of leading characters that are a PUBLIC scheme identifier (e.g. `AKIA`,
+// `ghp_`) and are safe to show in a redacted preview; the remainder is masked.
+
+const DETECTORS = [
+  { type: "aws_access_key_id", keep: 4, scan: whole(/\bA(?:KIA|SIA|GPA|IDA|ROA|IPA|NPA|NVA)[0-9A-Z]{16}\b/g) },
+  { type: "aws_secret_access_key", keep: 0, scan: assignment(/(?:aws_secret_access_key|aws_secret_key|secret_access_key)/i, /[A-Za-z0-9/+]{40,}/) },
+  { type: "github_personal_access_token", keep: 4, scan: whole(/\bghp_[A-Za-z0-9]{36}\b/g) },
+  { type: "github_oauth_token", keep: 4, scan: whole(/\bgho_[A-Za-z0-9]{36}\b/g) },
+  { type: "github_app_token", keep: 4, scan: whole(/\b(?:ghu|ghs)_[A-Za-z0-9]{36}\b/g) },
+  { type: "github_fine_grained_pat", keep: 11, scan: whole(/\bgithub_pat_[A-Za-z0-9_]{59,}\b/g) },
+  { type: "slack_token", keep: 5, scan: whole(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g) },
+  { type: "slack_webhook_url", keep: 24, scan: whole(/https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9_]+\/B[A-Za-z0-9_]+\/[A-Za-z0-9]{20,}/g) },
+  { type: "google_api_key", keep: 4, scan: whole(/\bAIza[0-9A-Za-z_-]{35}\b/g) },
+  { type: "stripe_secret_key", keep: 8, scan: whole(/\b(?:sk|rk)_live_[0-9a-zA-Z]{20,}\b/g) },
+  { type: "openai_api_key", keep: 3, scan: whole(/\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g) },
+  { type: "npm_access_token", keep: 4, scan: whole(/\bnpm_[A-Za-z0-9]{36}\b/g) },
+  { type: "private_key_block", keep: 0, scan: whole(/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g) },
+  { type: "json_web_token", keep: 0, scan: whole(/\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g) },
+  { type: "generic_secret_assignment", keep: 0, scan: genericAssignment() },
+];
+
+// A detector that matches the whole secret token by regex.
+function whole(regex) {
+  return (line) => {
+    const out = [];
+    for (const m of line.matchAll(regex)) {
+      out.push({ value: m[0], start: m.index });
+    }
+    return out;
+  };
+}
+
+// A detector that matches a secret VALUE only when it follows a key-name anchor
+// on the same line (e.g. `aws_secret_access_key = <40 chars>`).
+function assignment(keyRe, valueRe) {
+  const combined = new RegExp(
+    `(${keyRe.source})["']?\\s*[:=]\\s*["']?(${valueRe.source})`,
+    "gi",
+  );
+  return (line) => {
+    const out = [];
+    for (const m of line.matchAll(combined)) {
+      const value = m[2];
+      const start = m.index + m[0].length - value.length - trailingQuoteLen(m[0]);
+      out.push({ value, start });
+    }
+    return out;
+  };
+}
+
+// Generic `secretName = "value"` detector, gated by entropy + a placeholder
+// denylist so ordinary config and env-var references never false-block.
+function genericAssignment() {
+  const re = /\b(password|passwd|pwd|secret|api[_-]?key|apikey|access[_-]?token|auth[_-]?token|client[_-]?secret|private[_-]?key|token)\b["']?\s*[:=]\s*["']([^"'\s]{12,})["']/gi;
+  return (line) => {
+    const out = [];
+    for (const m of line.matchAll(re)) {
+      const value = m[2];
+      if (isPlaceholder(value)) continue;
+      // Entropy floor applies at every length: a long low-entropy string
+      // (e.g. a repeated token) is not a credential and must not false-block.
+      if (shannonEntropy(value) < 3.0) continue;
+      const start = m.index + m[0].lastIndexOf(value);
+      out.push({ value, start });
+    }
+    return out;
+  };
+}
+
+function trailingQuoteLen(matchText) {
+  return /["']$/.test(matchText) ? 1 : 0;
+}
+
+function isPlaceholder(value) {
+  const v = value.toLowerCase();
+  if (/^(.)\1+$/.test(value)) return true; // all one repeated character
+  return /example|changeme|change_me|placeholder|your[_-]?|dummy|redacted|sample|\bfake\b|test[_-]?(key|token|secret)|\bxxx+|\.\.\.|<[^>]+>|\$\{[^}]+\}|%[a-z0-9_]+%|\{\{[^}]+\}\}|process\.env|os\.environ|getenv|import\.meta\.env/.test(v);
+}
+
+function shannonEntropy(str) {
+  const counts = new Map();
+  for (const ch of str) counts.set(ch, (counts.get(ch) || 0) + 1);
+  let entropy = 0;
+  for (const c of counts.values()) {
+    const p = c / str.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+// ---------------------------------------------------------------------------
+// diff scanning
+// ---------------------------------------------------------------------------
+
+function scanDiff(diffText) {
+  const findings = [];
+  const rawSpans = [];
+  const filesTouched = new Set();
+  let addedLinesScanned = 0;
+
+  let currentFile = null;
+  let newLine = 0;
+  // Remaining declared old-side / new-side lines for the current hunk. While
+  // either is > 0 we are inside a hunk body and every line is content, so an
+  // added line whose text happens to start with "++ ", "--", or "@@" is never
+  // mistaken for a structural header. Structure is only parsed outside a body.
+  let remOld = 0;
+  let remNew = 0;
+
+  const lines = diffText.split(/\r?\n/);
+  for (const line of lines) {
+    if (remOld > 0 || remNew > 0) {
+      const c = line[0];
+      if (c === "+") {
+        const content = line.slice(1);
+        addedLinesScanned += 1;
+        if (currentFile) filesTouched.add(currentFile);
+        for (const det of DETECTORS) {
+          for (const hit of det.scan(content)) {
+            findings.push(makeFinding(det, hit, currentFile, newLine));
+            rawSpans.push(hit.value);
+          }
+        }
+        newLine += 1;
+        remNew -= 1;
+        continue;
+      }
+      if (c === "-") {
+        remOld -= 1; // removed line: not present in the new file
+        continue;
+      }
+      if (c === " ") {
+        newLine += 1; // context line: present on both sides
+        remOld -= 1;
+        remNew -= 1;
+        continue;
+      }
+      if (c === "\\") {
+        continue; // "\ No newline at end of file": metadata, no line consumed
+      }
+      // Any other prefix means the declared hunk length was wrong or the body
+      // ended early; close the body and reinterpret this line as structure.
+      remOld = 0;
+      remNew = 0;
+    }
+
+    const hunk = line.match(/^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (hunk) {
+      newLine = Number(hunk[2]);
+      remOld = hunk[1] !== undefined ? Number(hunk[1]) : 1;
+      remNew = hunk[3] !== undefined ? Number(hunk[3]) : 1;
+      continue;
+    }
+    if (line.startsWith("+++ ")) {
+      currentFile = parseFilePath(line.slice(4));
+      continue;
+    }
+    // Everything else outside a hunk body (diff --git, index, --- , mode lines)
+    // is metadata and is ignored.
+  }
+
+  // Deterministic, stable ordering for reproducible receipts.
+  findings.sort((a, b) =>
+    `${a.location.file}:${String(a.location.line).padStart(9, "0")}:${String(a.location.column).padStart(6, "0")}:${a.type}`
+      .localeCompare(`${b.location.file}:${String(b.location.line).padStart(9, "0")}:${String(b.location.column).padStart(6, "0")}:${b.type}`),
+  );
+
+  return { findings, rawSpans, filesTouched: [...filesTouched].sort(), addedLinesScanned };
+}
+
+function parseFilePath(raw) {
+  let p = raw.trim().split("\t")[0].trim();
+  if (p === "/dev/null") return null;
+  p = p.replace(/^"(.*)"$/, "$1");
+  if (p.startsWith("a/") || p.startsWith("b/")) p = p.slice(2);
+  return p;
+}
+
+function makeFinding(det, hit, file, line) {
+  return {
+    type: det.type,
+    location: {
+      file: file || "(unknown)",
+      line,
+      column: hit.start + 1,
+    },
+    redacted_preview: redact(hit.value, det.keep),
+    value_length: hit.value.length,
+    fingerprint: `sha256:${sha256(hit.value).slice(0, 16)}`,
+  };
+}
+
+// Reveal at most `keep` leading characters (a public scheme identifier) and
+// mask the rest. The masked run is capped so previews never echo a full secret.
+function redact(value, keep) {
+  const shown = Math.min(keep, value.length);
+  const maskedLen = Math.min(value.length - shown, 12);
+  return value.slice(0, shown) + "*".repeat(maskedLen) + (value.length - shown > maskedLen ? "…" : "");
+}
+
+// ---------------------------------------------------------------------------
+// packet assembly
+// ---------------------------------------------------------------------------
+
+function buildPacket({ scan, diffText, scanContext }) {
+  const { findings, filesTouched, addedLinesScanned } = scan;
+  const block = findings.length > 0;
+  const findingTypes = [...new Set(findings.map((f) => f.type))].sort();
+
+  const redactionProposal = block
+    ? {
+        decision: "proposed",
+        performed_by: REDACTION_EXECUTOR,
+        requires_approval: true,
+        edits: findings.map((f) => ({
+          file: f.location.file,
+          line: f.location.line,
+          column_start: f.location.column,
+          column_end: f.location.column + f.value_length,
+          replacement: `***REDACTED_${f.type.toUpperCase()}***`,
+        })),
+        note: `Proposal only. secret-catcher edits no files and scrubs no live content. The ${REDACTION_EXECUTOR} executor performs the gated edit after approval.`,
+      }
+    : {
+        decision: "noop",
+        performed_by: REDACTION_EXECUTOR,
+        requires_approval: false,
+        edits: [],
+        note: "No credential-like spans detected in added lines; nothing to redact.",
+      };
+
+  return {
+    schema: SCHEMA,
+    skill: SKILL,
+    version: VERSION,
+    block,
+    findings,
+    redaction_proposal: redactionProposal,
+    summary: {
+      added_lines_scanned: addedLinesScanned,
+      files_scanned: filesTouched.length,
+      findings: findings.length,
+      finding_types: findingTypes,
+    },
+    policy: {
+      scans: "added diff lines only",
+      grounded_in: "diff",
+      edits_files: false,
+      quotes_raw_secrets: false,
+      downstream_executor: REDACTION_EXECUTOR,
+      detectors: DETECTORS.map((d) => d.type),
+    },
+    scan_context: scanContext,
+    source: {
+      kind: "diff",
+      bytes: Buffer.byteLength(diffText),
+      sha256: sha256(diffText),
+    },
+    validation: {
+      grounded_in_diff: true,
+      every_finding_has_location: findings.every(
+        (f) => f.location.file && Number.isInteger(f.location.line) && Number.isInteger(f.location.column),
+      ),
+      block_iff_findings: block === (findings.length > 0),
+      raw_secret_values_absent: true, // proven by assertNoRawSecretLeak before emit
+      finding_rule:
+        "A finding is emitted only for a credential-like span on an ADDED diff line; context and removed lines are ignored, placeholders and env-var references are excluded, and no raw secret value is ever quoted.",
+    },
+  };
+}
+
+function assertNoRawSecretLeak(packet, rawSpans) {
+  const serialized = JSON.stringify(packet);
+  for (const value of rawSpans) {
+    if (value && value.length >= 6 && serialized.includes(value)) {
+      throw new Error("refusing to emit: a raw secret value would appear in output");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// artifacts
+// ---------------------------------------------------------------------------
+
+function writeArtifacts(outputDir, packet, root) {
+  if (!outputDir) return;
+  const resolved = path.resolve(root, outputDir);
+  ensureInside(root, resolved, "output_dir");
+  fs.mkdirSync(resolved, { recursive: true });
+  fs.writeFileSync(path.join(resolved, "evidence.json"), `${JSON.stringify(packet, null, 2)}\n`);
+  fs.writeFileSync(path.join(resolved, "report.md"), renderReport(packet));
+}
+
+function renderReport(packet) {
+  const lines = [];
+  lines.push("# Secret Catcher Report");
+  lines.push("");
+  lines.push(`- Scanner: ${packet.skill} v${packet.version}`);
+  lines.push(`- Diff SHA-256: \`${packet.source.sha256}\``);
+  lines.push(`- Added lines scanned: ${packet.summary.added_lines_scanned}`);
+  lines.push(`- Files with additions: ${packet.summary.files_scanned}`);
+  lines.push(`- Findings: ${packet.summary.findings}`);
+  lines.push(`- Block: ${packet.block}`);
+  lines.push("");
+  lines.push("## Findings");
+  lines.push("");
+  if (packet.findings.length === 0) {
+    lines.push("No credential-like spans were detected on added diff lines. The clean path does not block.");
+  } else {
+    lines.push("| Type | Location | Redacted preview | Fingerprint |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const f of packet.findings) {
+      lines.push(
+        `| ${f.type} | ${f.location.file}:${f.location.line}:${f.location.column} | \`${f.redacted_preview}\` | \`${f.fingerprint}\` |`,
+      );
+    }
+  }
+  lines.push("");
+  lines.push("## Redaction proposal");
+  lines.push("");
+  lines.push(`- Decision: ${packet.redaction_proposal.decision}`);
+  lines.push(`- Performed by: ${packet.redaction_proposal.performed_by} (downstream, gated)`);
+  lines.push(`- Requires approval: ${packet.redaction_proposal.requires_approval}`);
+  lines.push(`- ${packet.redaction_proposal.note}`);
+  lines.push("");
+  lines.push("## Guarantees");
+  lines.push("");
+  lines.push("- Findings are grounded only in added diff lines.");
+  lines.push("- No raw secret value appears in findings, the report, or the sealed receipt.");
+  lines.push("- The skill edits no files; the redaction is a proposal for the gated `redact-pii` executor.");
+  lines.push("- Clean diffs emit zero findings and do not block.");
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function ensureInside(root, resolved, label) {
+  const normalizedRoot = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  if (resolved !== root && !resolved.startsWith(normalizedRoot)) {
+    throw new Error(`${label} must stay inside the skill directory`);
+  }
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`secret-catcher: ${err && err.message ? err.message : err}\n`);
+  process.exit(64); // usage/input error
+}

--- a/skills/secret-catcher/run.mjs
+++ b/skills/secret-catcher/run.mjs
@@ -20,6 +20,15 @@ function main() {
   const inputs = readInputs();
   const skillRoot = process.cwd();
 
+  // Governed refusal: secret-catcher only PROPOSES redactions. If a caller asks
+  // it to apply, edit, or write the redaction itself, it stops rather than touch
+  // content — that effect belongs to the gated redact-pii executor.
+  if (isTruthy(inputs.apply) || isTruthy(inputs.perform_redaction) || isTruthy(inputs.write)) {
+    throw new Error(
+      "refused: secret-catcher never edits files or scrubs live content. It only emits a redaction_proposal for the gated redact-pii executor. Remove 'apply' and route the proposal to redact-pii.",
+    );
+  }
+
   const diffText = resolveDiff(inputs, skillRoot);
   const scanContext = normalizeScanContext(inputs.scan_context);
 
@@ -63,6 +72,10 @@ function resolveDiff(rawInputs, root) {
     throw new Error(`diff exceeds ${MAX_DIFF_BYTES} bytes`);
   }
   return text;
+}
+
+function isTruthy(v) {
+  return v === true || v === "true" || v === 1 || v === "1" || v === "yes";
 }
 
 function normalizeScanContext(value) {


### PR DESCRIPTION
## What

Adds `secret-catcher`, a runx skill that scans a code diff for credential-like spans and returns **redacted findings**, a **gated redaction proposal**, and a **block** decision — without ever quoting a raw secret.

## Why

Secret Catcher belongs on every PR: it catches leaked keys without leaking them into evidence. It reads a fixtured code diff, detects credential-like spans, emits findings plus a `redaction_proposal` and `block` decision, and stops. It never edits the repository or quotes raw secrets.

## Design

- **Grounded in the diff.** Only added lines are scanned; a count-based unified-diff parser tracks each hunk`s declared line counts, so content that merely *looks* like a diff header (e.g. an added line beginning `++ `) can never be misread as structure — no scanner-evasion false negatives.
- **Never leaks.** Each finding carries a redacted preview and a one-way SHA-256 fingerprint instead of the matched value; the runner fails closed rather than emit output in which a raw secret could appear.
- **Gated redaction.** `redaction_proposal.performed_by = redact-pii`, `requires_approval = true`. This skill edits no files and scrubs no live content.
- **Offline & dependency-free.** No network, no installs, no code execution.

## Contract

- Typed input: `diff` (unified diff) with optional `scan_context`.
- Typed output: `findings[{type,location}]`, `redaction_proposal`, `block`.

## Harness

Two cases in `X.yaml` (mirrored in `fixtures/`):
- `planted-secret-blocks` — a diff with a planted credential yields findings and `block: true`.
- `clean-diff-does-not-block` — a clean diff (env-var references, placeholders) yields zero findings and `block: false`.

Local `runx harness ./skills/secret-catcher` passes 2/2.

The planted fixture uses AWS`s documented example credentials and a synthetic `ghp_` token whose body is the literal word `EXAMPLE` repeated — recognized test vectors, not live secrets.

Source / provenance: https://github.com/epistemedeus/secret-catcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)