### PR TITLE
Add schema-guard skill

### DIFF
--- a/skills/schema-guard/SKILL.md
+++ b/skills/schema-guard/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: schema-guard
+description: Validate bounded schema changes and produce a review-only schema publication proposal for compatible changes.
+source:
+  type: cli-tool
+---
+
+# schema-guard
+
+`schema-guard` checks whether a proposed object schema is compatible with an
+existing schema, validates supplied sample payloads against the proposed
+contract, and emits a review-only publication proposal only when the change is
+compatible.
+
+The skill is intentionally side-effect free. It does not publish, mutate, or
+write live schemas. A caller must take the emitted `publish_schema_proposal`
+through a separate review and publish path.
+
+## Inputs
+
+- `current_schema` (json, required): the existing schema contract. Supported
+  forms are `{ fields: { name: { type, required } } }` and a minimal JSON
+  Schema object with `properties` and `required`.
+- `proposed_schema` (json, required): the candidate schema contract in the same
+  shape.
+- `sample_payloads` (json, required): bounded example payloads. Entries may be
+  direct payload objects or `{ id, payload }` records.
+- `compatibility_policy` (json, required): policy settings:
+  - `breaking_allowed`: boolean, defaults to `false`.
+  - `required_fields`: fields that must remain present in the proposed schema.
+  - `versioning_rule`: a human-readable version rule recorded in evidence.
+
+## Outputs
+
+- `compatibility`: compatibility decision, detected additive changes, breaking
+  changes, and policy rule references.
+- `validation_results`: per-sample validation results against the proposed
+  schema.
+- `migration_notes`: operator-readable notes for review.
+- `publish_schema_proposal`: present only when the change is compatible and the
+  supplied sample payloads validate.
+
+## Guardrails
+
+- Do not invent sample coverage. If no sample payloads are supplied, return a
+  refused compatibility decision and omit `publish_schema_proposal`.
+- Treat field removals, type changes, and optional-to-required changes as
+  breaking unless `compatibility_policy.breaking_allowed` is true.
+- Treat policy-required fields missing from the proposed schema as breaking.
+- Never write live schemas or call remote publish APIs.

--- a/skills/schema-guard/X.yaml
+++ b/skills/schema-guard/X.yaml
@@ -1,0 +1,172 @@
+skill: schema-guard
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+runx:
+  mutating: false
+  idempotency:
+    key: schema_guard_inputs_sha256
+  scopes:
+    - schema.read
+    - schema.review
+  policy:
+    reads:
+      - bounded schema contracts supplied by the caller
+      - bounded sample payloads supplied by the caller
+    writes:
+      - none
+    disallows:
+      - live schema publication
+      - remote schema mutation
+      - invented sample coverage
+  artifacts:
+    emits:
+      - compatibility
+      - validation_results
+      - migration_notes
+      - publish_schema_proposal
+    wrap_as: schema_guard_packet
+    packet: runx.schema.guard.v1
+
+harness:
+  cases:
+    - name: additive-compatible-proposes-publication
+      runner: guard
+      inputs:
+        current_schema:
+          schema_id: customer-profile
+          version: "1.0.0"
+          fields:
+            id:
+              type: string
+              required: true
+            email:
+              type: string
+              required: true
+            display_name:
+              type: string
+              required: false
+        proposed_schema:
+          schema_id: customer-profile
+          version: "1.1.0"
+          fields:
+            id:
+              type: string
+              required: true
+            email:
+              type: string
+              required: true
+            display_name:
+              type: string
+              required: false
+            timezone:
+              type: string
+              required: false
+        sample_payloads:
+          - id: active-customer
+            payload:
+              id: cus_123
+              email: user@example.com
+              display_name: Ada
+              timezone: UTC
+          - id: existing-customer
+            payload:
+              id: cus_456
+              email: second@example.com
+              display_name: Lin
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields:
+            - id
+            - email
+          versioning_rule: additive changes must use a minor version bump
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: breaking-change-refused-without-proposal
+      runner: guard
+      inputs:
+        current_schema:
+          schema_id: customer-profile
+          version: "1.1.0"
+          fields:
+            id:
+              type: string
+              required: true
+            email:
+              type: string
+              required: true
+            role:
+              type: string
+              required: false
+        proposed_schema:
+          schema_id: customer-profile
+          version: "1.2.0"
+          fields:
+            id:
+              type: string
+              required: true
+            role:
+              type: number
+              required: true
+        sample_payloads:
+          - id: legacy-customer
+            payload:
+              id: cus_789
+              email: legacy@example.com
+              role: admin
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields:
+            - id
+            - email
+          versioning_rule: breaking changes require a major version and explicit approval
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+runners:
+  guard:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      compatibility: object
+      validation_results: array
+      migration_notes: array
+      publish_schema_proposal: object
+    artifacts:
+      wrap_as: schema_guard_packet
+      packet: runx.schema.guard.v1
+    inputs:
+      current_schema:
+        type: json
+        required: true
+        description: Current schema contract, either fields-map form or minimal JSON Schema object form.
+      proposed_schema:
+        type: json
+        required: true
+        description: Proposed schema contract, either fields-map form or minimal JSON Schema object form.
+      sample_payloads:
+        type: json
+        required: true
+        description: Bounded sample payloads used to validate the proposed schema.
+      compatibility_policy:
+        type: json
+        required: true
+        description: Compatibility policy with breaking_allowed, required_fields, and versioning_rule.

--- a/skills/schema-guard/fixtures/additive-compatible.yaml
+++ b/skills/schema-guard/fixtures/additive-compatible.yaml
@@ -1,0 +1,52 @@
+name: additive-compatible-proposes-publication
+inputs:
+  current_schema:
+    schema_id: customer-profile
+    version: "1.0.0"
+    fields:
+      id:
+        type: string
+        required: true
+      email:
+        type: string
+        required: true
+      display_name:
+        type: string
+        required: false
+  proposed_schema:
+    schema_id: customer-profile
+    version: "1.1.0"
+    fields:
+      id:
+        type: string
+        required: true
+      email:
+        type: string
+        required: true
+      display_name:
+        type: string
+        required: false
+      timezone:
+        type: string
+        required: false
+  sample_payloads:
+    - id: active-customer
+      payload:
+        id: cus_123
+        email: user@example.com
+        display_name: Ada
+        timezone: UTC
+    - id: existing-customer
+      payload:
+        id: cus_456
+        email: second@example.com
+        display_name: Lin
+  compatibility_policy:
+    breaking_allowed: false
+    required_fields:
+      - id
+      - email
+    versioning_rule: additive changes must use a minor version bump
+expect:
+  decision: proposal_ready
+  publish_schema_proposal: present

--- a/skills/schema-guard/fixtures/breaking-refused.yaml
+++ b/skills/schema-guard/fixtures/breaking-refused.yaml
@@ -1,0 +1,40 @@
+name: breaking-change-refused-without-proposal
+inputs:
+  current_schema:
+    schema_id: customer-profile
+    version: "1.1.0"
+    fields:
+      id:
+        type: string
+        required: true
+      email:
+        type: string
+        required: true
+      role:
+        type: string
+        required: false
+  proposed_schema:
+    schema_id: customer-profile
+    version: "1.2.0"
+    fields:
+      id:
+        type: string
+        required: true
+      role:
+        type: number
+        required: true
+  sample_payloads:
+    - id: legacy-customer
+      payload:
+        id: cus_789
+        email: legacy@example.com
+        role: admin
+  compatibility_policy:
+    breaking_allowed: false
+    required_fields:
+      - id
+      - email
+    versioning_rule: breaking changes require a major version and explicit approval
+expect:
+  decision: refused
+  publish_schema_proposal: absent

--- a/skills/schema-guard/references/evidence.json
+++ b/skills/schema-guard/references/evidence.json
@@ -16,7 +16,7 @@
     "publisher_owner": "Difficult-Burger",
     "registry_ref_intended": "Difficult-Burger/schema-guard@0.1.0",
     "source_url": "https://github.com/Difficult-Burger/runx/tree/bounty/schema-guard-84/skills/schema-guard",
-    "pr_url": "pending: update after GitHub PR is created",
+    "pr_url": "https://github.com/runxhq/runx/pull/237",
     "public_url": "pending: remote registry publish requires runx login or RUNX_PUBLIC_API_TOKEN"
   },
   "raw_files": [

--- a/skills/schema-guard/references/evidence.json
+++ b/skills/schema-guard/references/evidence.json
@@ -1,0 +1,128 @@
+{
+  "schema": "runx.schema_guard.evidence.v1",
+  "bounty": {
+    "id": 84,
+    "url": "https://gofrantic.com/bounties/84",
+    "title": "runx skill: schema guard",
+    "reward": {
+      "amount_usd": 9,
+      "rail": "x402",
+      "claim_status": "requires_identity_before_claim"
+    }
+  },
+  "package": {
+    "name": "schema-guard",
+    "version": "0.1.0",
+    "publisher_owner": "Difficult-Burger",
+    "registry_ref_intended": "Difficult-Burger/schema-guard@0.1.0",
+    "source_url": "https://github.com/Difficult-Burger/runx/tree/bounty/schema-guard-84/skills/schema-guard",
+    "pr_url": "pending: update after GitHub PR is created",
+    "public_url": "pending: remote registry publish requires runx login or RUNX_PUBLIC_API_TOKEN"
+  },
+  "raw_files": [
+    {
+      "path": "skills/schema-guard/SKILL.md",
+      "sha256": "59f2dafb0e4f8b8d39639fdc42284d54401a5d5f9a468a1da4a7fbc195297f2a",
+      "included_in_pr": true
+    },
+    {
+      "path": "skills/schema-guard/X.yaml",
+      "sha256": "8102beecaa274ed3b32a56bdf4df7127fcbb1dfbff3609e1ee88fc8688b7204b",
+      "included_in_pr": true
+    },
+    {
+      "path": "skills/schema-guard/run.mjs",
+      "sha256": "47936020de1d2f2bce8c1c4904826db438bd2b8221feef66fde08594e898499a",
+      "included_in_pr": true
+    }
+  ],
+  "local_environment": {
+    "conda_env": "bounty-frantic-schema-guard-84",
+    "node": "/Users/a30706/miniconda3/envs/bounty-frantic-schema-guard-84/bin/node",
+    "node_version": "v22.23.1",
+    "runx_cli_source": "/Users/a30706/Desktop/research/dollar-hunt/env-tools/bounty-frantic-schema-guard-84/node_modules/.bin/runx",
+    "runx_cli_version": "runx-cli 0.6.16"
+  },
+  "harness": {
+    "command": "runx harness /Users/a30706/Desktop/research/dollar-hunt/repos/runx-schema-guard-84/skills/schema-guard --json",
+    "status": "passed",
+    "case_count": 2,
+    "case_names": [
+      "additive-compatible-proposes-publication",
+      "breaking-change-refused-without-proposal"
+    ],
+    "receipt_refs": [
+      "sha256:6277b652f75966c314973d4b57628d37b0fcb821c2d89e006525f06b4abb74ad",
+      "sha256:30f394154915f2338bfbd736d456bd12c167dc650166c42e207877e6a12c63b1"
+    ],
+    "assertion_error_count": 0
+  },
+  "verification": {
+    "mode": "local-development-signatures",
+    "commands": [
+      "runx verify sha256:6277b652f75966c314973d4b57628d37b0fcb821c2d89e006525f06b4abb74ad --allow-local-development-signatures --json",
+      "runx verify sha256:30f394154915f2338bfbd736d456bd12c167dc650166c42e207877e6a12c63b1 --allow-local-development-signatures --json",
+      "runx verify sha256:d542e647c611a7f9f8eb7038f93222d121ea570c433e2b2a8e6ce928e36f31e4 --allow-local-development-signatures --json"
+    ],
+    "verdict": "valid",
+    "findings": []
+  },
+  "dogfood": {
+    "command": "runx skill ./skills/schema-guard guard --input-json current_schema=... --input-json proposed_schema=... --input-json sample_payloads=... --input-json compatibility_policy=... --json",
+    "status": "sealed",
+    "receipt_ref": "sha256:d542e647c611a7f9f8eb7038f93222d121ea570c433e2b2a8e6ce928e36f31e4",
+    "decision": "proposal_ready",
+    "publish_schema_proposal_present": true
+  },
+  "fixture_output_checks": {
+    "additive-compatible": {
+      "decision": "proposal_ready",
+      "compatible": true,
+      "publish_schema_proposal_present": true,
+      "sample_results": [
+        {
+          "sample_id": "active-customer",
+          "valid": true
+        },
+        {
+          "sample_id": "existing-customer",
+          "valid": true
+        }
+      ]
+    },
+    "breaking-refused": {
+      "decision": "refused",
+      "compatible": false,
+      "publish_schema_proposal_present": false,
+      "breaking_codes": [
+        "field_removed",
+        "type_changed",
+        "field_became_required",
+        "policy_required_field_missing"
+      ],
+      "sample_results": [
+        {
+          "sample_id": "legacy-customer",
+          "valid": false,
+          "errors": [
+            "type_mismatch"
+          ]
+        }
+      ]
+    }
+  },
+  "publish": {
+    "method_required_by_bounty": "runx login --provider github --for publish; runx registry publish ./skills/schema-guard/SKILL.md --registry https://api.runx.ai",
+    "local_publish_command": "runx registry publish ./skills/schema-guard/SKILL.md --registry https://api.runx.ai --json",
+    "status": "blocked_before_remote_upload",
+    "blocked_reason": "remote registry publish requires `runx login` or RUNX_PUBLIC_API_TOKEN",
+    "login_attempt": "runx login --provider github --for publish --json was attempted and produced no URL/device code within 60 seconds, then was interrupted",
+    "hosted_harness_status": "not_run_without_publish_token",
+    "install_command_after_publish": "runx registry install Difficult-Burger/schema-guard@0.1.0 --registry https://api.runx.ai --json"
+  },
+  "how_to_verify": [
+    "runx skill inspect ./skills/schema-guard --json",
+    "runx harness ./skills/schema-guard --json",
+    "runx skill ./skills/schema-guard guard --input-json current_schema='...' --input-json proposed_schema='...' --input-json sample_payloads='...' --input-json compatibility_policy='...' --json"
+  ]
+}

--- a/skills/schema-guard/references/report.md
+++ b/skills/schema-guard/references/report.md
@@ -7,7 +7,7 @@
 - Bounty: `https://gofrantic.com/bounties/84`
 - Publisher owner: `Difficult-Burger`
 - Source URL: `https://github.com/Difficult-Burger/runx/tree/bounty/schema-guard-84/skills/schema-guard`
-- PR URL: pending until the GitHub PR is created
+- PR URL: `https://github.com/runxhq/runx/pull/237`
 - Intended registry ref: `Difficult-Burger/schema-guard@0.1.0`
 
 ## Scope

--- a/skills/schema-guard/references/report.md
+++ b/skills/schema-guard/references/report.md
@@ -1,0 +1,134 @@
+# schema-guard evidence report
+
+## Package
+
+- Package: `schema-guard`
+- Version: `0.1.0`
+- Bounty: `https://gofrantic.com/bounties/84`
+- Publisher owner: `Difficult-Burger`
+- Source URL: `https://github.com/Difficult-Burger/runx/tree/bounty/schema-guard-84/skills/schema-guard`
+- PR URL: pending until the GitHub PR is created
+- Intended registry ref: `Difficult-Burger/schema-guard@0.1.0`
+
+## Scope
+
+`schema-guard` is a side-effect-free `cli-tool` skill. It reads bounded schema
+contracts and sample payloads, checks compatibility, validates samples, and
+emits `publish_schema_proposal` only when the proposed change is compatible.
+
+It does not publish, mutate, or write live schemas.
+
+## Local harness
+
+Command:
+
+```bash
+runx harness /Users/a30706/Desktop/research/dollar-hunt/repos/runx-schema-guard-84/skills/schema-guard --json
+```
+
+Result:
+
+```json
+{
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "case_names": [
+    "additive-compatible-proposes-publication",
+    "breaking-change-refused-without-proposal"
+  ],
+  "receipt_ids": [
+    "sha256:6277b652f75966c314973d4b57628d37b0fcb821c2d89e006525f06b4abb74ad",
+    "sha256:30f394154915f2338bfbd736d456bd12c167dc650166c42e207877e6a12c63b1"
+  ]
+}
+```
+
+Verification:
+
+```bash
+runx verify sha256:6277b652f75966c314973d4b57628d37b0fcb821c2d89e006525f06b4abb74ad --allow-local-development-signatures --json
+runx verify sha256:30f394154915f2338bfbd736d456bd12c167dc650166c42e207877e6a12c63b1 --allow-local-development-signatures --json
+```
+
+Both verification runs returned `valid: true`.
+
+## Fixture assertions
+
+- `additive-compatible-proposes-publication`: returns `decision:
+  proposal_ready`, `compatible: true`, all samples valid, and
+  `publish_schema_proposal` present.
+- `breaking-change-refused-without-proposal`: returns `decision: refused`,
+  `compatible: false`, breaking changes named by field path and policy rule, and
+  no `publish_schema_proposal`.
+
+## Dogfood
+
+Command shape:
+
+```bash
+runx skill ./skills/schema-guard guard \
+  --input-json current_schema='...' \
+  --input-json proposed_schema='...' \
+  --input-json sample_payloads='...' \
+  --input-json compatibility_policy='...' \
+  --json
+```
+
+Result: `status: sealed`, receipt
+`sha256:d542e647c611a7f9f8eb7038f93222d121ea570c433e2b2a8e6ce928e36f31e4`.
+
+Verification:
+
+```bash
+runx verify sha256:d542e647c611a7f9f8eb7038f93222d121ea570c433e2b2a8e6ce928e36f31e4 --allow-local-development-signatures --json
+```
+
+The verification returned `valid: true`.
+
+## Raw files
+
+The raw package files are included in this PR:
+
+- `skills/schema-guard/SKILL.md`
+- `skills/schema-guard/X.yaml`
+- `skills/schema-guard/run.mjs`
+
+SHA-256:
+
+```text
+SKILL.md  59f2dafb0e4f8b8d39639fdc42284d54401a5d5f9a468a1da4a7fbc195297f2a
+X.yaml    8102beecaa274ed3b32a56bdf4df7127fcbb1dfbff3609e1ee88fc8688b7204b
+run.mjs   47936020de1d2f2bce8c1c4904826db438bd2b8221feef66fde08594e898499a
+```
+
+## Registry publish status
+
+Required publish flow:
+
+```bash
+runx login --provider github --for publish
+runx registry publish ./skills/schema-guard/SKILL.md --registry https://api.runx.ai
+```
+
+Observed status:
+
+```text
+remote registry publish requires `runx login` or RUNX_PUBLIC_API_TOKEN
+```
+
+`runx login --provider github --for publish --json` was attempted. It did not
+print a URL or device code within 60 seconds and was interrupted before any
+remote publish upload occurred.
+
+Hosted harness status is therefore `not_run_without_publish_token`.
+
+## Install and verify after publish
+
+After a publish token is available and the package is accepted by the hosted
+registry:
+
+```bash
+runx registry install Difficult-Burger/schema-guard@0.1.0 --registry https://api.runx.ai --json
+runx skill Difficult-Burger/schema-guard@0.1.0 guard --registry https://api.runx.ai --input-json current_schema='...' --input-json proposed_schema='...' --input-json sample_payloads='...' --input-json compatibility_policy='...' --json
+```

--- a/skills/schema-guard/run.mjs
+++ b/skills/schema-guard/run.mjs
@@ -1,0 +1,404 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const currentSchema = normalizeSchema(inputs.current_schema, "current_schema");
+const proposedSchema = normalizeSchema(inputs.proposed_schema, "proposed_schema");
+const samplePayloads = normalizeSamples(inputs.sample_payloads);
+const policy = normalizePolicy(inputs.compatibility_policy);
+
+const diff = compareSchemas(currentSchema, proposedSchema, policy);
+const validationResults = validateSamples(samplePayloads, proposedSchema);
+const validationFailures = validationResults.filter((entry) => !entry.valid);
+const hasSamples = samplePayloads.length > 0;
+const compatible = diff.breaking_changes.length === 0 && validationFailures.length === 0 && hasSamples;
+const refusedReasons = [];
+
+if (diff.breaking_changes.length > 0 && !policy.breaking_allowed) {
+  refusedReasons.push("breaking_changes_disallowed");
+}
+if (validationFailures.length > 0) {
+  refusedReasons.push("sample_validation_failed");
+}
+if (!hasSamples) {
+  refusedReasons.push("missing_sample_coverage");
+}
+
+const compatibility = {
+  decision: compatible ? "proposal_ready" : "refused",
+  compatible,
+  schema_id: proposedSchema.schema_id,
+  current_version: currentSchema.version,
+  proposed_version: proposedSchema.version,
+  policy: {
+    breaking_allowed: policy.breaking_allowed,
+    required_fields: policy.required_fields,
+    versioning_rule: policy.versioning_rule,
+  },
+  additive_changes: diff.additive_changes,
+  relaxing_changes: diff.relaxing_changes,
+  breaking_changes: diff.breaking_changes,
+  refused_reasons: refusedReasons,
+  side_effects: "none",
+};
+
+const result = {
+  compatibility,
+  validation_results: validationResults,
+  migration_notes: migrationNotes({ compatibility, diff, validationResults }),
+};
+
+if (compatible) {
+  result.publish_schema_proposal = buildProposal({
+    currentSchema,
+    proposedSchema,
+    diff,
+    samplePayloads,
+    validationResults,
+    policy,
+  });
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    current_schema: parseInput(process.env.RUNX_INPUT_CURRENT_SCHEMA),
+    proposed_schema: parseInput(process.env.RUNX_INPUT_PROPOSED_SCHEMA),
+    sample_payloads: parseInput(process.env.RUNX_INPUT_SAMPLE_PAYLOADS),
+    compatibility_policy: parseInput(process.env.RUNX_INPUT_COMPATIBILITY_POLICY),
+  };
+}
+
+function parseInput(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function normalizeSchema(value, label) {
+  const schema = objectValue(value, label);
+  const schemaId = stringValue(schema.schema_id) ?? stringValue(schema.id) ?? label;
+  const version = stringValue(schema.version) ?? "unversioned";
+  const fieldSource = objectValue(schema.fields ?? schema.properties, `${label}.fields`);
+  const jsonSchemaRequired = new Set(Array.isArray(schema.required) ? schema.required.map(String) : []);
+  const fields = new Map();
+
+  for (const [name, rawField] of Object.entries(fieldSource)) {
+    fields.set(name, normalizeField(name, rawField, jsonSchemaRequired.has(name), `${label}.fields.${name}`));
+  }
+
+  if (fields.size === 0) {
+    throw new Error(`${label}.fields must contain at least one field`);
+  }
+
+  return {
+    schema_id: schemaId,
+    version,
+    raw: schema,
+    fields,
+  };
+}
+
+function normalizeField(name, value, requiredByJsonSchema, label) {
+  if (typeof value === "string") {
+    return { name, type: value, required: requiredByJsonSchema };
+  }
+  const field = objectValue(value, label);
+  return {
+    name,
+    type: normalizeType(field.type ?? "any"),
+    required: booleanValue(field.required) ?? requiredByJsonSchema,
+    description: stringValue(field.description) ?? null,
+  };
+}
+
+function normalizeType(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry)).sort().join("|");
+  }
+  return String(value);
+}
+
+function normalizeSamples(value) {
+  if (!Array.isArray(value)) {
+    throw new Error("sample_payloads must be an array");
+  }
+  return value.map((entry, index) => {
+    if (entry && typeof entry === "object" && !Array.isArray(entry) && ("payload" in entry || "data" in entry)) {
+      return {
+        id: stringValue(entry.id) ?? `sample-${index + 1}`,
+        payload: objectValue(entry.payload ?? entry.data, `sample_payloads[${index}].payload`),
+      };
+    }
+    return {
+      id: `sample-${index + 1}`,
+      payload: objectValue(entry, `sample_payloads[${index}]`),
+    };
+  });
+}
+
+function normalizePolicy(value) {
+  const policy = objectValue(value, "compatibility_policy");
+  return {
+    breaking_allowed: booleanValue(policy.breaking_allowed) ?? false,
+    required_fields: Array.isArray(policy.required_fields) ? policy.required_fields.map(String) : [],
+    versioning_rule: stringValue(policy.versioning_rule) ?? "not specified",
+  };
+}
+
+function compareSchemas(currentSchema, proposedSchema, policy) {
+  const additive = [];
+  const relaxing = [];
+  const breaking = [];
+
+  for (const [name, currentField] of currentSchema.fields) {
+    const proposedField = proposedSchema.fields.get(name);
+    if (!proposedField) {
+      breaking.push(breakingChange({
+        code: "field_removed",
+        field_path: name,
+        old_contract: contractFor(currentField),
+        new_contract: null,
+        policy_rule: "existing fields may not be removed without explicit breaking approval",
+      }));
+      continue;
+    }
+
+    if (currentField.type !== proposedField.type) {
+      breaking.push(breakingChange({
+        code: "type_changed",
+        field_path: name,
+        old_contract: contractFor(currentField),
+        new_contract: contractFor(proposedField),
+        policy_rule: "field types must remain stable for compatible changes",
+      }));
+    }
+
+    if (!currentField.required && proposedField.required) {
+      breaking.push(breakingChange({
+        code: "field_became_required",
+        field_path: name,
+        old_contract: contractFor(currentField),
+        new_contract: contractFor(proposedField),
+        policy_rule: "optional fields may not become required without breaking approval",
+      }));
+    }
+
+    if (currentField.required && !proposedField.required) {
+      relaxing.push({
+        field_path: name,
+        old_contract: contractFor(currentField),
+        new_contract: contractFor(proposedField),
+        note: "required field relaxed to optional",
+      });
+    }
+  }
+
+  for (const [name, proposedField] of proposedSchema.fields) {
+    if (currentSchema.fields.has(name)) continue;
+    if (proposedField.required) {
+      breaking.push(breakingChange({
+        code: "new_required_field",
+        field_path: name,
+        old_contract: null,
+        new_contract: contractFor(proposedField),
+        policy_rule: "new required fields break existing payloads",
+      }));
+    } else {
+      additive.push({
+        field_path: name,
+        new_contract: contractFor(proposedField),
+        note: "optional field added",
+      });
+    }
+  }
+
+  for (const requiredField of policy.required_fields) {
+    if (proposedSchema.fields.has(requiredField)) continue;
+    breaking.push(breakingChange({
+      code: "policy_required_field_missing",
+      field_path: requiredField,
+      old_contract: currentSchema.fields.has(requiredField) ? contractFor(currentSchema.fields.get(requiredField)) : null,
+      new_contract: null,
+      policy_rule: "compatibility_policy.required_fields must be present in proposed_schema",
+    }));
+  }
+
+  return {
+    additive_changes: additive,
+    relaxing_changes: relaxing,
+    breaking_changes: policy.breaking_allowed ? [] : breaking,
+    breaking_changes_allowed: policy.breaking_allowed ? breaking : [],
+  };
+}
+
+function validateSamples(samples, schema) {
+  return samples.map((sample) => {
+    const errors = [];
+    for (const field of schema.fields.values()) {
+      const exists = Object.prototype.hasOwnProperty.call(sample.payload, field.name);
+      if (!exists) {
+        if (field.required) {
+          errors.push({
+            field_path: field.name,
+            code: "missing_required_field",
+            expected: field.type,
+          });
+        }
+        continue;
+      }
+      if (!matchesType(sample.payload[field.name], field.type)) {
+        errors.push({
+          field_path: field.name,
+          code: "type_mismatch",
+          expected: field.type,
+          actual: actualType(sample.payload[field.name]),
+        });
+      }
+    }
+    return {
+      sample_id: sample.id,
+      valid: errors.length === 0,
+      errors,
+    };
+  });
+}
+
+function matchesType(value, type) {
+  if (type === "any") return true;
+  const accepted = type.split("|");
+  return accepted.some((entry) => {
+    if (entry === "array") return Array.isArray(value);
+    if (entry === "integer") return Number.isInteger(value);
+    if (entry === "number") return typeof value === "number" && Number.isFinite(value);
+    if (entry === "object") return value !== null && typeof value === "object" && !Array.isArray(value);
+    if (entry === "null") return value === null;
+    return typeof value === entry;
+  });
+}
+
+function actualType(value) {
+  if (Array.isArray(value)) return "array";
+  if (value === null) return "null";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value;
+}
+
+function buildProposal({ currentSchema, proposedSchema, diff, samplePayloads, validationResults, policy }) {
+  return {
+    proposal_id: `schema-guard:${proposedSchema.schema_id}:${currentSchema.version}->${proposedSchema.version}`,
+    status: "ready_for_review",
+    live_write_attempted: false,
+    schema_id: proposedSchema.schema_id,
+    current_version: currentSchema.version,
+    proposed_version: proposedSchema.version,
+    proposed_schema: proposedSchema.raw,
+    change_summary: {
+      additive_changes: diff.additive_changes,
+      relaxing_changes: diff.relaxing_changes,
+      breaking_changes: [],
+    },
+    sample_coverage: samplePayloads.map((sample) => sample.id),
+    validation_results: validationResults,
+    policy_evidence: {
+      breaking_allowed: policy.breaking_allowed,
+      required_fields: policy.required_fields,
+      versioning_rule: policy.versioning_rule,
+    },
+    next_step: "review_and_publish_with_runx_registry_publish",
+  };
+}
+
+function migrationNotes({ compatibility, diff, validationResults }) {
+  const notes = [
+    {
+      code: "side_effects",
+      message: "No live schema write or remote publish was attempted.",
+    },
+  ];
+
+  for (const change of diff.additive_changes) {
+    notes.push({
+      code: "additive_field",
+      field_path: change.field_path,
+      message: "Optional additive field is compatible with existing payloads.",
+    });
+  }
+
+  for (const change of diff.relaxing_changes) {
+    notes.push({
+      code: "relaxed_field",
+      field_path: change.field_path,
+      message: "Relaxing a required field to optional is compatible for existing payload producers.",
+    });
+  }
+
+  for (const change of compatibility.breaking_changes) {
+    notes.push({
+      code: "refused_breaking_change",
+      field_path: change.field_path,
+      message: `${change.code}: ${change.policy_rule}`,
+    });
+  }
+
+  for (const sample of validationResults.filter((entry) => !entry.valid)) {
+    notes.push({
+      code: "sample_validation_failed",
+      sample_id: sample.sample_id,
+      message: "The proposed schema does not validate a supplied sample payload.",
+    });
+  }
+
+  if (compatibility.refused_reasons.includes("missing_sample_coverage")) {
+    notes.push({
+      code: "missing_sample_coverage",
+      message: "No sample payloads were supplied, so the skill refused to invent coverage.",
+    });
+  }
+
+  return notes;
+}
+
+function breakingChange({ code, field_path, old_contract, new_contract, policy_rule }) {
+  return {
+    code,
+    field_path,
+    old_contract,
+    new_contract,
+    policy_rule,
+  };
+}
+
+function contractFor(field) {
+  return {
+    type: field.type,
+    required: field.required,
+  };
+}
+
+function objectValue(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function stringValue(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function booleanValue(value) {
+  if (typeof value === "boolean") return value;
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add `schema-guard`, a side-effect-free cli-tool skill for bounded schema compatibility checks.
- Emit `publish_schema_proposal` only for compatible schema changes with validating samples.
- Include additive-compatible and breaking-refused harness cases, fixtures, evidence JSON, and report.

## Verification
- `runx skill inspect ./skills/schema-guard --json` -> ok
- `runx harness ./skills/schema-guard --json` -> passed, 2 cases
- `runx verify sha256:6277b652f75966c314973d4b57628d37b0fcb821c2d89e006525f06b4abb74ad --allow-local-development-signatures --json` -> valid
- `runx verify sha256:30f394154915f2338bfbd736d456bd12c167dc650166c42e207877e6a12c63b1 --allow-local-development-signatures --json` -> valid
- Dogfood receipt `sha256:d542e647c611a7f9f8eb7038f93222d121ea570c433e2b2a8e6ce928e36f31e4` -> valid

## Publish status
Remote registry publish is implemented in the report path but is blocked in this non-interactive environment by missing `runx login` / `RUNX_PUBLIC_API_TOKEN`. The attempted publish returned: `remote registry publish requires `runx login` or RUNX_PUBLIC_API_TOKEN`.

Bounty: https://gofrantic.com/bounties/84