### PR TITLE
Add skills/schema-guard (JSON Schema compatibility gate)

### DIFF
--- a/skills/schema-guard/SKILL.md
+++ b/skills/schema-guard/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: schema-guard
+description: Check a proposed JSON Schema against the current one for breaking changes, validate sample payloads, and emit a gated publish proposal only when the change is compatible — never writing a live schema.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+runx:
+  tags:
+    - schema
+    - compatibility
+    - migration
+links:
+  source: https://github.com/epistemedeus/schema-guard
+---
+
+## What this skill does
+
+This skill catches silent API and data-contract breakage before a migration
+lands. It reads a `current_schema`, a `proposed_schema`, optional
+`sample_payloads`, and a `compatibility_policy`. It reports every breaking change
+by field path (with the old contract, the new contract, and the policy rule it
+trips), validates each sample payload against the proposed schema, writes
+migration notes, and emits a `publish_schema_proposal` **only** when the change
+is compatible under the policy.
+
+The skill is read-only and offline. It makes no network calls and never writes,
+publishes, or mutates a live schema. Publishing a schema is the gated
+`schema-publisher` executor's effect, performed only after approval.
+
+## When to use this skill
+
+Use this skill in a pull-request or migration pipeline to decide whether a schema
+change is safe to ship. It is appropriate as a gate before a schema registry
+update, an API version bump, or a database migration, and as the evidence step
+before a human or the `schema-publisher` executor applies the change.
+
+## When not to use this skill
+
+Do not use it to apply or publish a schema — it only proposes. Do not treat a
+compatible result as a guarantee of correctness beyond the declared policy and
+the supplied samples: coverage is bounded by the schemas and payloads provided.
+It checks a JSON-Schema subset (object properties, required, type, enum, nested
+objects); it is not a full JSON-Schema validator for every keyword.
+
+## Procedure
+
+1. Read `current_schema` and `proposed_schema`; record a stable digest of each.
+2. Diff the schemas field by field: a removed field, a narrowed type, a removed
+   enum value, a newly required field, or a field made required is a breaking
+   change; an added optional field or a relaxed requirement is additive.
+3. Apply the `compatibility_policy`: `required_fields` must remain (violations
+   always block), and `breaking_allowed` decides whether other breaking changes
+   are permitted; `versioning_rule` is recorded.
+4. Validate each `sample_payloads` entry against the proposed schema; a failing
+   sample means the change breaks existing data.
+5. Set `compatibility.compatible` true only when there are no policy violations,
+   no failing samples, and either no breaking changes or `breaking_allowed`.
+6. Emit `publish_schema_proposal` only when compatible; otherwise withhold it and
+   write migration notes.
+7. If a caller sets `apply`/`publish`/`write`, refuse and stop.
+
+## Edge cases and stop conditions
+
+Stop with an error when `current_schema` or `proposed_schema` is missing or is
+not a JSON object. If a caller asks the skill to `apply`, `publish`, or `write`
+the schema, it refuses and stops — that effect belongs to the gated
+`schema-publisher` executor.
+
+`block` is `true` whenever the change is not compatible (the migration should be
+held); it is `false` when compatible. Breaking changes never silently pass:
+each is reported with its field path and the policy rule it trips.
+
+## Output schema
+
+The primary output is `schema_guard_result`, with schema `schema.guard.result.v1`:
+
+A compatible (additive) change — proposal emitted:
+
+```json
+{
+  "schema": "schema.guard.result.v1",
+  "skill": "schema-guard",
+  "version": "0.1.0",
+  "block": false,
+  "compatibility": {
+    "compatible": true,
+    "breaking_changes": [],
+    "breaking_allowed": false,
+    "versioning_rule": "additive-only",
+    "required_fields": ["id"],
+    "policy_violations": []
+  },
+  "validation_results": [{ "payload_index": 0, "valid": true, "errors": [] }],
+  "migration_notes": ["Additive-only change (1 field(s) added or relaxed); existing consumers remain valid."],
+  "publish_schema_proposal": {
+    "decision": "proposed",
+    "performed_by": "schema-publisher",
+    "requires_approval": true,
+    "to_schema_digest": "sha256:...",
+    "versioning_rule": "additive-only",
+    "note": "Proposal only. schema-guard performs no live schema write..."
+  },
+  "summary": {
+    "breaking_count": 0,
+    "additive_count": 1,
+    "policy_violation_count": 0,
+    "samples_validated": 1,
+    "samples_failed": 0,
+    "proposal_status": "proposed"
+  }
+}
+```
+
+A breaking change withholds the proposal: `compatibility.compatible` is `false`,
+`block` is `true`, `publish_schema_proposal` is `null`, `proposal_status` is
+`withheld`, and each breaking change is listed with its `field_path`, `kind`,
+`old_contract`, `new_contract`, and `policy_rule`.
+
+When `output_dir` is provided, the runner also writes `evidence.json` and
+`report.md` inside that directory.
+
+## Worked example
+
+An additive change adds an optional `email` field. The harness confirms it is
+compatible and emits a proposal:
+
+```bash
+runx skill "$PWD" \
+  --input-json current_schema='{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}' \
+  --input-json proposed_schema='{"type":"object","properties":{"id":{"type":"integer"},"email":{"type":"string"}},"required":["id"]}' \
+  --input-json sample_payloads='[{"id":1}]' \
+  --input-json compatibility_policy='{"breaking_allowed":false,"required_fields":["id"],"versioning_rule":"additive-only"}' \
+  --json
+```
+
+Expected: `compatibility.compatible` is true, `publish_schema_proposal.performed_by`
+is `schema-publisher`. Removing the required `id` field instead makes
+`compatible` false, withholds the proposal, and lists the breaking change.
+
+## Inputs
+
+- `current_schema`: the current JSON Schema (required).
+- `proposed_schema`: the proposed JSON Schema (required).
+- `sample_payloads`: representative payloads validated against the proposed schema.
+- `compatibility_policy`: `{ breaking_allowed, required_fields[], versioning_rule }`.
+- `apply`: must be absent or false; if set, the skill refuses (it never writes a schema).
+- `output_dir`: optional directory for `evidence.json` and `report.md`.
+
+## Outputs
+
+- `schema_guard_result`: the complete packet.
+- `block`: boolean migration gate, true when the change is not compatible.
+- `compatibility`: `{ compatible, breaking_changes[], ... }`.
+- `validation_results`: per-sample validation against the proposed schema.
+- `migration_notes`: human-readable guidance for each breaking change.
+- `publish_schema_proposal`: gated proposal for the `schema-publisher` executor (only when compatible).

--- a/skills/schema-guard/X.yaml
+++ b/skills/schema-guard/X.yaml
@@ -1,0 +1,170 @@
+skill: schema-guard
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+runx:
+  mutating: false
+  idempotency:
+    key: proposed_schema_sha256
+  scopes:
+    - schema.read
+  policy:
+    data_classification: caller_supplied_schema
+    network:
+      allowed: []
+      forbidden:
+        - any network access
+        - live schema writes
+        - registry or database mutation
+    verifier_notes:
+      - Breaking changes are grounded only in the current vs proposed schema diff, identified by field path with old and new contract and the policy rule.
+      - A publish_schema_proposal is emitted only when the change is compatible under the policy; a breaking or policy-violating change withholds the proposal.
+      - The proposal is gated for the schema-publisher executor; this skill performs no live schema write.
+      - The compatible harness case seals with a proposal; the breaking case seals with no proposal; the apply case is the governed stop case.
+  artifacts:
+    emits:
+      - schema_guard_result
+      - evidence_json
+      - report_md
+    wrap_as: schema_guard_packet
+
+harness:
+  cases:
+    - name: additive-change-compatible-yields-proposal
+      runner: default
+      inputs:
+        current_schema:
+          type: object
+          properties:
+            id: { type: integer }
+            name: { type: string }
+          required: [id]
+        proposed_schema:
+          type: object
+          properties:
+            id: { type: integer }
+            name: { type: string }
+            email: { type: string }
+          required: [id]
+        sample_payloads:
+          - { id: 1, name: "ada" }
+          - { id: 2, name: "grace", email: "grace@example.com" }
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields: [id]
+          versioning_rule: additive-only
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+        output:
+          block: false
+          compatibility:
+            compatible: true
+          publish_schema_proposal:
+            performed_by: schema-publisher
+
+    - name: breaking-change-withholds-proposal
+      runner: default
+      inputs:
+        current_schema:
+          type: object
+          properties:
+            id: { type: integer }
+            name: { type: string }
+          required: [id, name]
+        proposed_schema:
+          type: object
+          properties:
+            id: { type: string }
+          required: [id]
+        sample_payloads:
+          - { id: 1, name: "ada" }
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields: [id]
+          versioning_rule: additive-only
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+        output:
+          block: true
+          compatibility:
+            compatible: false
+          publish_schema_proposal: null
+
+    - name: refuses-to-apply-schema
+      runner: default
+      inputs:
+        current_schema:
+          type: object
+          properties:
+            id: { type: integer }
+        proposed_schema:
+          type: object
+          properties:
+            id: { type: integer }
+            email: { type: string }
+        apply: true
+      expect:
+        status: failure
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: /usr/bin/env
+    args:
+      - node
+      - run.mjs
+    scopes:
+      - schema.read
+    policy:
+      reads:
+        - caller-supplied current and proposed schemas and sample payloads
+      calls: []
+      writes:
+        - evidence.json
+        - report.md
+      disallows:
+        - network access
+        - writing or publishing a live schema
+        - executing caller-supplied code
+    inputs:
+      current_schema:
+        type: object
+        required: true
+        description: The current JSON Schema (the contract in force).
+      proposed_schema:
+        type: object
+        required: true
+        description: The proposed JSON Schema to check for compatibility.
+      sample_payloads:
+        type: array
+        required: false
+        description: Representative payloads validated against the proposed schema.
+      compatibility_policy:
+        type: object
+        required: false
+        description: "{ breaking_allowed, required_fields[], versioning_rule } governing whether breaking changes are permitted."
+      apply:
+        type: boolean
+        required: false
+        description: Must be absent or false. If set, the skill refuses and stops — it never writes a live schema.
+      output_dir:
+        type: string
+        required: false
+        description: Directory inside the skill directory where evidence.json and report.md are written.
+    outputs:
+      block: boolean
+      compatibility: object
+      validation_results: array
+      migration_notes: array
+      publish_schema_proposal: object
+      schema_guard_result: object

--- a/skills/schema-guard/fixtures/additive-change-compatible-yields-proposal.yaml
+++ b/skills/schema-guard/fixtures/additive-change-compatible-yields-proposal.yaml
@@ -1,0 +1,43 @@
+name: additive-change-compatible-yields-proposal
+kind: skill
+target: ..
+runner: default
+inputs:
+  current_schema:
+    type: object
+    properties:
+      id: { type: integer }
+      name: { type: string }
+    required: [id]
+  proposed_schema:
+    type: object
+    properties:
+      id: { type: integer }
+      name: { type: string }
+      email: { type: string }
+    required: [id]
+  sample_payloads:
+    - { id: 1, name: "ada" }
+    - { id: 2, name: "grace", email: "grace@example.com" }
+  compatibility_policy:
+    breaking_allowed: false
+    required_fields: [id]
+    versioning_rule: additive-only
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+  output:
+    block: false
+    compatibility:
+      compatible: true
+    publish_schema_proposal:
+      performed_by: schema-publisher
+metadata:
+  public_skill: schema-guard
+  source_case: additive-change-compatible-yields-proposal
+  source: skills-fixture
+  note: >-
+    An optional 'email' field is added; all samples still validate. The change is
+    compatible under the additive-only policy, so compatibility.compatible=true,
+    block=false, and a gated publish_schema_proposal is emitted.

--- a/skills/schema-guard/fixtures/breaking-change-withholds-proposal.yaml
+++ b/skills/schema-guard/fixtures/breaking-change-withholds-proposal.yaml
@@ -1,0 +1,40 @@
+name: breaking-change-withholds-proposal
+kind: skill
+target: ..
+runner: default
+inputs:
+  current_schema:
+    type: object
+    properties:
+      id: { type: integer }
+      name: { type: string }
+    required: [id, name]
+  proposed_schema:
+    type: object
+    properties:
+      id: { type: string }
+    required: [id]
+  sample_payloads:
+    - { id: 1, name: "ada" }
+  compatibility_policy:
+    breaking_allowed: false
+    required_fields: [id]
+    versioning_rule: additive-only
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+  output:
+    block: true
+    compatibility:
+      compatible: false
+    publish_schema_proposal: null
+metadata:
+  public_skill: schema-guard
+  source_case: breaking-change-withholds-proposal
+  source: skills-fixture
+  note: >-
+    The required 'name' field is removed and 'id' changes type integer->string; a
+    sample fails against the proposed schema. The change is breaking under the
+    policy, so compatibility.compatible=false, block=true, and NO proposal is
+    emitted. The run still seals — a provable, gated refusal to propose.

--- a/skills/schema-guard/fixtures/refuses-to-apply-schema.yaml
+++ b/skills/schema-guard/fixtures/refuses-to-apply-schema.yaml
@@ -1,0 +1,25 @@
+name: refuses-to-apply-schema
+kind: skill
+target: ..
+runner: default
+inputs:
+  current_schema:
+    type: object
+    properties:
+      id: { type: integer }
+  proposed_schema:
+    type: object
+    properties:
+      id: { type: integer }
+      email: { type: string }
+  apply: true
+expect:
+  status: failure
+metadata:
+  public_skill: schema-guard
+  source_case: refuses-to-apply-schema
+  source: skills-fixture
+  note: >-
+    A caller sets apply=true to ask schema-guard to write the schema itself. The
+    skill refuses and stops, because it never writes or publishes a live schema —
+    that is the gated schema-publisher executor's effect. The governed stop case.

--- a/skills/schema-guard/run.mjs
+++ b/skills/schema-guard/run.mjs
@@ -1,0 +1,471 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+// schema-guard — catch silent API and data-contract breakage before a migration.
+//
+// Reads a current schema, a proposed schema, sample payloads, and a compatibility
+// policy. Reports breaking changes by field path (old contract, new contract,
+// policy rule), validates the samples against the proposed schema, and emits a
+// gated publish_schema_proposal ONLY when the change is compatible. It never
+// writes a live schema; publishing is the gated schema-publisher executor's job.
+
+const SCHEMA = "schema.guard.result.v1";
+const SKILL = "schema-guard";
+const VERSION = "0.1.0";
+const PUBLISH_EXECUTOR = "schema-publisher";
+const MAX_DEPTH = 64;
+
+function main() {
+  const inputs = readInputs();
+  const skillRoot = process.cwd();
+
+  // Governed refusal: schema-guard only analyzes and PROPOSES. If asked to apply,
+  // write, or publish the schema itself, it stops — that effect belongs to the
+  // gated schema-publisher executor.
+  if (isTruthy(inputs.apply) || isTruthy(inputs.publish) || isTruthy(inputs.write)) {
+    throw new Error(
+      `refused: schema-guard never writes or publishes a live schema. It only emits a publish_schema_proposal for the gated ${PUBLISH_EXECUTOR} executor. Remove 'apply' and route the proposal to ${PUBLISH_EXECUTOR}.`,
+    );
+  }
+
+  const current = requireObject(inputs.current_schema, "current_schema");
+  const proposed = requireObject(inputs.proposed_schema, "proposed_schema");
+  const samples = normalizeSamples(inputs.sample_payloads);
+  const policy = normalizePolicy(inputs.compatibility_policy);
+
+  const { breaking, additive } = diffSchemas(current, proposed, policy);
+  const validationResults = samples.map((p, i) => {
+    const { valid, errors } = validatePayload(p, proposed);
+    return { payload_index: i, valid, errors };
+  });
+
+  const packet = buildPacket({ current, proposed, breaking, additive, validationResults, policy });
+  writeArtifacts(inputs.output_dir, packet, skillRoot);
+  process.stdout.write(`${JSON.stringify(packet, null, 2)}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// input handling
+// ---------------------------------------------------------------------------
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function isTruthy(v) {
+  return v === true || v === "true" || v === 1 || v === "1" || v === "yes";
+}
+
+function isPlainObject(v) {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+function asObject(v) {
+  return isPlainObject(v) ? v : {};
+}
+
+function propertiesOf(schema) {
+  return isPlainObject(schema.properties) ? schema.properties : {};
+}
+
+function requiredSet(schema) {
+  return new Set(Array.isArray(schema.required) ? schema.required.map(String) : []);
+}
+
+function hasProperties(schema) {
+  return isPlainObject(schema) && isPlainObject(schema.properties);
+}
+
+function requireObject(v, name) {
+  const parsed = typeof v === "string" ? tryParse(v) : v;
+  if (!isPlainObject(parsed)) {
+    throw new Error(`input '${name}' is required and must be a JSON Schema object`);
+  }
+  return parsed;
+}
+
+function tryParse(s) {
+  try { return JSON.parse(s); } catch { return undefined; }
+}
+
+function normalizeSamples(v) {
+  if (v == null) return [];
+  const parsed = typeof v === "string" ? tryParse(v) : v;
+  if (Array.isArray(parsed)) return parsed;
+  if (isPlainObject(parsed)) return [parsed];
+  return [];
+}
+
+function normalizePolicy(v) {
+  const p = asObject(typeof v === "string" ? tryParse(v) : v);
+  return {
+    breaking_allowed: p.breaking_allowed === true,
+    required_fields: Array.isArray(p.required_fields) ? p.required_fields.map(String) : [],
+    versioning_rule: typeof p.versioning_rule === "string" ? p.versioning_rule : "additive-only",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// schema diff
+// ---------------------------------------------------------------------------
+
+// integer is a subset of number, so integer -> number widens the contract and is
+// not breaking. Everything else that changes a declared type is breaking.
+function isWidening(oldType, newType) {
+  return oldType === "integer" && newType === "number";
+}
+
+function policyRuleFor(fieldPath, policy) {
+  if (policy.required_fields.includes(fieldPath)) {
+    return `required_fields policy: '${fieldPath}' must remain present and required`;
+  }
+  return policy.breaking_allowed
+    ? "breaking_allowed=true (flagged, permitted by policy)"
+    : `versioning_rule '${policy.versioning_rule}' forbids breaking changes`;
+}
+
+function diffSchemas(current, proposed, policy, prefix = "", depth = 0) {
+  if (depth > MAX_DEPTH) throw new Error(`schema nesting exceeds ${MAX_DEPTH} levels`);
+  const breaking = [];
+  const additive = [];
+  const curProps = propertiesOf(current);
+  const propProps = propertiesOf(proposed);
+  const curReq = requiredSet(current);
+  const propReq = requiredSet(proposed);
+
+  for (const key of Object.keys(curProps)) {
+    const fieldPath = prefix ? `${prefix}.${key}` : key;
+    const cur = asObject(curProps[key]);
+
+    if (propProps[key] === undefined) {
+      breaking.push({
+        field_path: fieldPath,
+        kind: "field_removed",
+        old_contract: describeField(cur, curReq.has(key)),
+        new_contract: "(absent)",
+        policy_rule: policyRuleFor(fieldPath, policy),
+      });
+      continue;
+    }
+    const prop = asObject(propProps[key]);
+
+    if (cur.type && prop.type && cur.type !== prop.type && !isWidening(cur.type, prop.type)) {
+      breaking.push({
+        field_path: fieldPath,
+        kind: "type_changed",
+        old_contract: `type=${cur.type}`,
+        new_contract: `type=${prop.type}`,
+        policy_rule: policyRuleFor(fieldPath, policy),
+      });
+    }
+
+    if (Array.isArray(cur.enum) && Array.isArray(prop.enum)) {
+      const propEnum = new Set(prop.enum.map(canonical));
+      const removed = cur.enum.filter((v) => !propEnum.has(canonical(v)));
+      if (removed.length > 0) {
+        breaking.push({
+          field_path: fieldPath,
+          kind: "enum_values_removed",
+          old_contract: `enum ${JSON.stringify(cur.enum)}`,
+          new_contract: `enum ${JSON.stringify(prop.enum)}`,
+          policy_rule: policyRuleFor(fieldPath, policy),
+        });
+      }
+    }
+
+    if (!curReq.has(key) && propReq.has(key)) {
+      breaking.push({
+        field_path: fieldPath,
+        kind: "field_made_required",
+        old_contract: "optional",
+        new_contract: "required",
+        policy_rule: policyRuleFor(fieldPath, policy),
+      });
+    } else if (curReq.has(key) && !propReq.has(key)) {
+      additive.push({ field_path: fieldPath, kind: "field_made_optional" });
+    }
+
+    // Recurse whenever either side declares nested properties, whether or not a
+    // `type: object` keyword is present (JSON Schema does not require it).
+    if (hasProperties(cur) || hasProperties(prop)) {
+      const nested = diffSchemas(cur, prop, policy, fieldPath, depth + 1);
+      breaking.push(...nested.breaking);
+      additive.push(...nested.additive);
+    }
+  }
+
+  for (const key of Object.keys(propProps)) {
+    if (curProps[key] !== undefined) continue;
+    const fieldPath = prefix ? `${prefix}.${key}` : key;
+    const prop = asObject(propProps[key]);
+    if (propReq.has(key) && prop.default === undefined) {
+      breaking.push({
+        field_path: fieldPath,
+        kind: "required_field_added",
+        old_contract: "(absent)",
+        new_contract: `required ${prop.type || "field"}`,
+        policy_rule: policyRuleFor(fieldPath, policy),
+      });
+    } else {
+      additive.push({ field_path: fieldPath, kind: "optional_field_added" });
+    }
+  }
+
+  return { breaking, additive };
+}
+
+function describeField(field, required) {
+  const t = field && field.type ? `type=${field.type}` : "field";
+  return required ? `required ${t}` : `optional ${t}`;
+}
+
+// A required_fields entry must remain present AND required in the proposed schema.
+// This is checked independently of the breaking list so a required->optional
+// demotion (which is otherwise a widening) still blocks when the field is pinned.
+function requiredFieldViolations(proposed, requiredFields) {
+  const violations = [];
+  for (const fieldPath of requiredFields) {
+    const state = resolveFieldState(proposed, String(fieldPath));
+    if (!state.present || !state.required) violations.push(fieldPath);
+  }
+  return violations;
+}
+
+function resolveFieldState(schema, dottedPath) {
+  const parts = dottedPath.split(".");
+  let node = schema;
+  for (let i = 0; i < parts.length; i++) {
+    const props = propertiesOf(node);
+    const key = parts[i];
+    if (!(key in props)) return { present: false, required: false };
+    if (i === parts.length - 1) {
+      return { present: true, required: requiredSet(node).has(key) };
+    }
+    node = asObject(props[key]);
+  }
+  return { present: false, required: false };
+}
+
+// ---------------------------------------------------------------------------
+// payload validation (minimal, deterministic JSON-Schema subset)
+// ---------------------------------------------------------------------------
+
+function validatePayload(payload, schema, prefix = "", depth = 0) {
+  if (depth > MAX_DEPTH) throw new Error(`payload nesting exceeds ${MAX_DEPTH} levels`);
+  const errors = [];
+  if (!isPlainObject(payload)) {
+    return { valid: false, errors: [`${prefix || "payload"} is not an object`] };
+  }
+  const props = propertiesOf(schema);
+  for (const req of Array.isArray(schema.required) ? schema.required : []) {
+    if (payload[req] === undefined) {
+      errors.push(`missing required field '${prefix ? prefix + "." : ""}${req}'`);
+    }
+  }
+  for (const [key, val] of Object.entries(payload)) {
+    const spec = props[key];
+    if (!isPlainObject(spec)) continue;
+    const fp = prefix ? `${prefix}.${key}` : key;
+    if (spec.type && !typeMatches(val, spec.type)) {
+      errors.push(`field '${fp}' expected type ${spec.type}, got ${jsonType(val)}`);
+    }
+    if (Array.isArray(spec.enum) && !spec.enum.some((e) => canonical(e) === canonical(val))) {
+      errors.push(`field '${fp}' value ${JSON.stringify(val)} not in enum ${JSON.stringify(spec.enum)}`);
+    }
+    if (hasProperties(spec) && isPlainObject(val)) {
+      errors.push(...validatePayload(val, spec, fp, depth + 1).errors);
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+function jsonType(v) {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  if (Number.isInteger(v)) return "integer";
+  return typeof v;
+}
+
+function typeMatches(v, type) {
+  switch (type) {
+    case "integer": return Number.isInteger(v);
+    case "number": return typeof v === "number";
+    case "string": return typeof v === "string";
+    case "boolean": return typeof v === "boolean";
+    case "object": return isPlainObject(v);
+    case "array": return Array.isArray(v);
+    case "null": return v === null;
+    default: return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// packet assembly
+// ---------------------------------------------------------------------------
+
+function buildPacket({ current, proposed, breaking, additive, validationResults, policy }) {
+  const policyViolations = requiredFieldViolations(proposed, policy.required_fields);
+  const sampleFailures = validationResults.filter((r) => !r.valid);
+
+  const compatible =
+    policyViolations.length === 0 &&
+    sampleFailures.length === 0 &&
+    (breaking.length === 0 || policy.breaking_allowed === true);
+
+  const migrationNotes = [];
+  for (const b of breaking) {
+    migrationNotes.push(`${b.kind} at '${b.field_path}': ${b.old_contract} -> ${b.new_contract}. ${b.policy_rule}.`);
+  }
+  for (const fp of policyViolations) {
+    migrationNotes.push(`required_fields policy: '${fp}' must remain present and required in the proposed schema, but it is removed or relaxed.`);
+  }
+  for (const r of sampleFailures) {
+    migrationNotes.push(`sample_payloads[${r.payload_index}] fails against the proposed schema: ${r.errors.join("; ")}`);
+  }
+  if (compatible && additive.length > 0) {
+    migrationNotes.push(`Additive-only change (${additive.length} field(s) added or relaxed); existing consumers remain valid.`);
+  }
+
+  const proposedDigest = `sha256:${sha256(canonical(proposed))}`;
+  const publishProposal = compatible
+    ? {
+        decision: "proposed",
+        performed_by: PUBLISH_EXECUTOR,
+        requires_approval: true,
+        to_schema_digest: proposedDigest,
+        versioning_rule: policy.versioning_rule,
+        note: `Proposal only. schema-guard performs no live schema write; the ${PUBLISH_EXECUTOR} executor applies the schema after approval.`,
+      }
+    : null;
+
+  return {
+    schema: SCHEMA,
+    skill: SKILL,
+    version: VERSION,
+    block: !compatible,
+    compatibility: {
+      compatible,
+      breaking_changes: breaking,
+      breaking_allowed: policy.breaking_allowed,
+      versioning_rule: policy.versioning_rule,
+      required_fields: policy.required_fields,
+      policy_violations: policyViolations,
+    },
+    validation_results: validationResults,
+    migration_notes: migrationNotes,
+    publish_schema_proposal: publishProposal,
+    summary: {
+      breaking_count: breaking.length,
+      additive_count: additive.length,
+      policy_violation_count: policyViolations.length,
+      samples_validated: validationResults.length,
+      samples_failed: sampleFailures.length,
+      proposal_status: publishProposal ? "proposed" : "withheld",
+    },
+    policy,
+    source: {
+      current_schema_sha256: `sha256:${sha256(canonical(current))}`,
+      proposed_schema_sha256: proposedDigest,
+    },
+    validation: {
+      grounded_in_schemas: true,
+      proposal_iff_compatible: (publishProposal != null) === compatible,
+      breaking_changes_have_field_paths: breaking.every((b) => typeof b.field_path === "string" && b.field_path.length > 0),
+      required_fields_enforced: policyViolations.length === 0 || !compatible,
+      no_live_schema_write: true,
+      finding_rule:
+        "A breaking change is reported only when the proposed schema removes, narrows, or newly requires a field relative to the current schema; a pinned required_fields entry that is removed or demoted always blocks; a publish_schema_proposal is emitted only when the change is compatible under the policy; the skill never writes a live schema.",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// artifacts
+// ---------------------------------------------------------------------------
+
+function writeArtifacts(outputDir, packet, root) {
+  if (!outputDir) return;
+  const resolved = path.resolve(root, outputDir);
+  ensureInside(root, resolved, "output_dir");
+  fs.mkdirSync(resolved, { recursive: true });
+  fs.writeFileSync(path.join(resolved, "evidence.json"), `${JSON.stringify(packet, null, 2)}\n`);
+  fs.writeFileSync(path.join(resolved, "report.md"), renderReport(packet));
+}
+
+function renderReport(packet) {
+  const c = packet.compatibility;
+  const lines = [];
+  lines.push("# Schema Guard Report");
+  lines.push("");
+  lines.push(`- Scanner: ${packet.skill} v${packet.version}`);
+  lines.push(`- Compatible: ${c.compatible}`);
+  lines.push(`- Breaking changes: ${packet.summary.breaking_count}`);
+  lines.push(`- Policy violations: ${packet.summary.policy_violation_count}`);
+  lines.push(`- Additive changes: ${packet.summary.additive_count}`);
+  lines.push(`- Samples validated: ${packet.summary.samples_validated} (failed: ${packet.summary.samples_failed})`);
+  lines.push(`- Proposal: ${packet.summary.proposal_status}`);
+  lines.push(`- Versioning rule: ${c.versioning_rule} | breaking_allowed: ${c.breaking_allowed}`);
+  lines.push("");
+  lines.push("## Breaking changes");
+  lines.push("");
+  if (c.breaking_changes.length === 0) {
+    lines.push("None. The proposed schema does not remove, narrow, or newly require any field.");
+  } else {
+    lines.push("| Field | Kind | Old contract | New contract | Policy rule |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const b of c.breaking_changes) {
+      lines.push(`| ${b.field_path} | ${b.kind} | ${b.old_contract} | ${b.new_contract} | ${b.policy_rule} |`);
+    }
+  }
+  lines.push("");
+  lines.push("## Migration notes");
+  lines.push("");
+  if (packet.migration_notes.length === 0) lines.push("No migration action required.");
+  else for (const n of packet.migration_notes) lines.push(`- ${n}`);
+  lines.push("");
+  lines.push("## Guarantees");
+  lines.push("");
+  lines.push("- Breaking changes are grounded only in the current vs proposed schema diff.");
+  lines.push("- A pinned required_fields entry that is removed or demoted always blocks.");
+  lines.push("- A publish_schema_proposal is emitted only when the change is compatible under the policy.");
+  lines.push(`- The proposal is gated: performed_by=${PUBLISH_EXECUTOR}, requires_approval=true.`);
+  lines.push("- schema-guard writes no live schema; publishing is the gated executor's effect.");
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function ensureInside(root, resolved, label) {
+  const normalizedRoot = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  if (resolved !== root && !resolved.startsWith(normalizedRoot)) {
+    throw new Error(`${label} must stay inside the skill directory`);
+  }
+}
+
+// Deterministic key-sorted serialization so a schema digest is stable regardless
+// of key order. undefined is normalized to null to keep the string well-formed.
+function canonical(value) {
+  if (value === undefined || value === null) return "null";
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  const keys = Object.keys(value).filter((k) => value[k] !== undefined).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`).join(",")}}`;
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`schema-guard: ${err && err.message ? err.message : err}\n`);
+  process.exit(64);
+}


### PR DESCRIPTION
## What

Adds `schema-guard`, a runx skill that checks a proposed JSON Schema against the current one for **breaking changes**, validates sample payloads, and emits a **gated publish proposal only when the change is compatible** — without ever writing a live schema.

## Why

Schema Guard catches silent API and data-contract breakage before a migration lands. It reads `current_schema`, `proposed_schema`, `sample_payloads`, and a `compatibility_policy`, reports breaking changes, validates the samples, and emits a `publish_schema_proposal` only when the change is allowed.

## Design

- **Grounded in the diff.** Breaking changes (removed/narrowed/newly-required fields, removed enum values) are reported by field path with the old contract, new contract, and the policy rule they trip; nested objects are diffed with dotted paths.
- **Policy-aware.** A pinned `required_fields` entry that is removed or demoted from required to optional **always blocks**, independent of `breaking_allowed`.
- **Gated proposal.** `publish_schema_proposal.performed_by = schema-publisher`, `requires_approval = true`. This skill writes no live schema.
- **Offline & dependency-free.** No network, no installs, no code execution.

## Contract

- Typed inputs: `current_schema`, `proposed_schema`, `sample_payloads[]`, `compatibility_policy{breaking_allowed, required_fields, versioning_rule}`.
- Typed output: `compatibility`, `validation_results[]`, `migration_notes[]`, and `publish_schema_proposal` when compatible.

## Harness

Three cases in `X.yaml` (mirrored in `fixtures/`), asserting the gating contract on the packet:
- `additive-change-compatible-yields-proposal` — seals; `compatible: true`, proposal emitted.
- `breaking-change-withholds-proposal` — seals; `compatible: false`, `publish_schema_proposal: null`.
- `refuses-to-apply-schema` — `apply: true` is refused (the governed stop case).

Local `runx harness ./skills/schema-guard` passes 3/3.

Source / provenance: https://github.com/epistemedeus/schema-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)