### PR TITLE
Add reply-router skill

### DIFF
--- a/evidence/evidence.json
+++ b/evidence/evidence.json
@@ -1,0 +1,42 @@
+{
+  "observations": {
+    "runx_version": "runx-cli 0.6.16",
+    "publish_command": "runx registry publish ./skills/reply-router --registry https://api.runx.ai",
+    "install_command": "runx add armstrongsam25/reply-router@sha-ad0fc216e139 --registry https://api.runx.ai",
+    "dogfood_command": "runx skill armstrongsam25/reply-router@sha-ad0fc216e139 --registry https://api.runx.ai --json",
+    "verify_command": "runx verify --receipt <receipt.json> --json"
+  },
+  "dogfood": {
+    "package": "armstrongsam25/reply-router@sha-ad0fc216e139",
+    "input": {
+      "inbound_reply": {
+        "content": "Please unsubscribe me from this mailing list.",
+        "received_from": "mailto:test@example.com",
+        "received_at": "2026-07-05T20:00:00Z"
+      },
+      "original_send_receipt": {
+        "send_plan": "test",
+        "principal": "principal:marketing",
+        "receipt_id": "rcpt_test_001",
+        "checksum": "sha256:test123"
+      }
+    },
+    "command": "runx skill armstrongsam25/reply-router@sha-ad0fc216e139 --registry https://api.runx.ai --json",
+    "receipt_ref": "sha256:3205745863e359e3b60a9dcfdca2fb437d37d19f0d03de1876db09a109351c5c",
+    "verify_verdict": "valid",
+    "harness_cases": [
+      {"name": "sealed_unsubscribe_suppression", "status": "sealed"},
+      {"name": "stop_ambiguous_or_unsealed", "status": "failure"}
+    ]
+  },
+  "harness": {
+    "local": {"status": "passed", "case_count": 2, "assertion_errors": 0},
+    "hosted": {"status": "passed", "checks_passed": 2, "checks_failed": 0}
+  },
+  "registry": {
+    "skill_id": "armstrongsam25/reply-router",
+    "version": "sha-ad0fc216e139",
+    "public_url": "https://runx.ai/x/armstrongsam25/reply-router",
+    "trust_tier": "community"
+  }
+}

--- a/evidence/report.md
+++ b/evidence/report.md
@@ -1,0 +1,23 @@
+# reply-router Delivery Report
+
+## Skill
+- **Name:** reply-router
+- **Registry:** armstrongsam25/reply-router@sha-ad0fc216e139
+- **Public URL:** https://runx.ai/x/armstrongsam25/reply-router
+
+## Harness
+- **Local:** 2/2 passed, 0 errors
+- **Hosted:** 2/2 passed, 0 errors
+- Cases: sealed_unsubscribe_suppression (sealed), stop_ambiguous_or_unsealed (failure/stop)
+
+## Dogfood
+- **Input:** Unsubscribe reply ("Please unsubscribe me from this mailing list.")
+- **Output:** Classified as unsubscribe (0.96 confidence), suppression event appended (v0 to v1)
+- **Receipt:** sha256:3205745863e359e3b60a9dcfdca2fb437d37d19f0d03de1876db09a109351c5c
+- **Verify:** valid (signature, digest, content address all valid)
+
+## PR
+https://github.com/runxhq/runx/pull/245
+
+## runx version
+runx-cli 0.6.16

--- a/evidence/verification.json
+++ b/evidence/verification.json
@@ -1,0 +1,12 @@
+{
+  "runx_version": "runx-cli 0.6.16",
+  "skill_id": "armstrongsam25/reply-router",
+  "version": "sha-ad0fc216e139",
+  "harness_hosted_status": "passed",
+  "harness_checks_passed": 2,
+  "harness_checks_failed": 0,
+  "dogfood_receipt_id": "sha256:3205745863e359e3b60a9dcfdca2fb437d37d19f0d03de1876db09a109351c5c",
+  "dogfood_verify_valid": true,
+  "pr_url": "https://github.com/runxhq/runx/pull/245",
+  "public_url": "https://runx.ai/x/armstrongsam25/reply-router"
+}

--- a/skills/reply-router/SKILL.md
+++ b/skills/reply-router/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: reply-router
+description: Classify an inbound reply message and either append a suppression event for unsubscribes or emit a bounded routing decision for all other classifications. Never sends — just routes.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - inbound_reply
+      - original_send_receipt
+---
+
+## What this skill does
+
+Classify one inbound reply message into one of five categories — `interested`,
+`objection`, `out_of_office`, `wrong_person`, or `unsubscribe` — and take the
+safe next action:
+
+- **Unsubscribe**: append a suppression event to a local event store using
+  compare-and-swap version checking and an idempotency key. Return a
+  `suppression_result` with `aggregate_id`, `idempotency_key`, `before_version`,
+  and `after_version`.
+- **All other classifications**: emit a `runx.reply.routing.v1` routing decision
+  naming a bounded send target and the principal. No message is sent.
+
+This skill never sends email, SMS, chat messages, or any outbound communication.
+It prepares the routing decision or suppression record that a separate governed
+send skill can review, approve, and deliver with its own authority grant and
+receipt.
+
+## When to use this skill
+
+Use this skill when an agent has received a reply to a previously sent message
+and needs a safe first decision about how to handle it:
+
+- Classify the reply intent (interested, objection, out-of-office, wrong-person,
+  unsubscribe).
+- Suppress future sends to a recipient who unsubscribed.
+- Route interested or objection replies to the right follow-up lane.
+
+## When not to use this skill
+
+Do not use this skill as a message transport, identity verifier, bounce handler,
+or automatic sender. Do not use it to modify account state, process payments, or
+access private customer records unless that state has already been summarized
+into the `original_send_receipt`.
+
+If the reply asks for account recovery, billing changes, or anything requiring
+private records, the skill must not route to a definitive send. It should return
+a stop and let a stronger authority gate handle the consequence.
+
+## Procedure
+
+1. Require `inbound_reply` to contain `content`, `received_from`, and
+   `received_at`.
+2. Require `original_send_receipt` to contain `send_plan`, `principal`,
+   `receipt_id`, and `checksum`. If the receipt is missing a `checksum` or
+   `receipt_id`, treat the reply as unsealed and stop.
+3. Normalize the reply content and classify it as `interested`, `objection`,
+   `out_of_office`, `wrong_person`, or `unsubscribe`.
+4. Estimate confidence from matched signal count and signal strength.
+5. If the classification is `unsubscribe` and confidence meets the
+   `suppression_policy.confidence_threshold`:
+   a. Derive `aggregate_id` from `principal` and `receipt_id`.
+   b. Derive `idempotency_key` from `aggregate_id`, `unsubscribe`, and the
+      receipt `checksum`.
+   c. Append a suppression event to the local event store with
+      `expected_version` CAS (compare-and-swap).
+   d. Return `suppression_result` with `aggregate_id`, `idempotency_key`,
+      `before_version`, and `after_version`.
+6. For all other classifications above the confidence threshold, emit
+   `runx.reply.routing.v1` with `classification`, `send_target`, and
+   `principal`.
+7. If confidence is below threshold or the classification is ambiguous, stop
+   with an error so the reply goes to manual review.
+
+## Edge cases and stop conditions
+
+Return a stop (exit non-zero) when:
+
+- `inbound_reply.content` is empty or missing.
+- `original_send_receipt` lacks `receipt_id` or `checksum` (unsealed reply).
+- The reply content does not match any classification with sufficient
+  confidence (ambiguous reply).
+- The suppression event store reports a version conflict (the aggregate was
+  modified by another process).
+
+The authority scope is classification, suppression recording, and routing
+preparation only. The proof surface is the sealed receipt containing the reply
+summary, classification, evidence, and either the suppression result or routing
+decision. Any live send requires a separate `send-as` receipt.
+
+## Output schema
+
+### Unsubscribe (suppressed)
+
+```json
+{
+  "classification": {
+    "type": "unsubscribe",
+    "confidence": 0.92,
+    "evidence": {
+      "matched_signals": ["unsubscribe", "don't want", "mailing list"],
+      "source_summary": "Please unsubscribe me from this mailing list..."
+    }
+  },
+  "suppression_result": {
+    "aggregate_id": "principal:marketing:rcpt_01JXNEWSLETTER001",
+    "idempotency_key": "principal:marketing:rcpt_01JXNEWSLETTER001:unsubscribe:sha256:abc123def456",
+    "before_version": 0,
+    "after_version": 1
+  }
+}
+```
+
+### Routed (interested, objection, out_of_office, wrong_person)
+
+```json
+{
+  "classification": {
+    "type": "interested",
+    "confidence": 0.85,
+    "evidence": {
+      "matched_signals": ["interested", "tell me more"],
+      "source_summary": "I'm interested, tell me more about this."
+    }
+  },
+  "runx.reply.routing.v1": {
+    "classification": "interested",
+    "send_target": "sales-follow-up",
+    "principal": "principal:marketing"
+  }
+}
+```
+
+## Worked example
+
+```bash
+runx skill "$PWD" \
+  --input-json inbound_reply='{
+    "content": "Please unsubscribe me from this mailing list. I don'"'"'t want these emails anymore.",
+    "received_from": "mailto:alice@example.com",
+    "received_at": "2026-07-01T10:00:00Z"
+  }' \
+  --input-json original_send_receipt='{
+    "send_plan": "newsletter-weekly-2026-w26",
+    "principal": "principal:marketing",
+    "receipt_id": "rcpt_01JXNEWSLETTER001",
+    "checksum": "sha256:abc123def456"
+  }' \
+  --input-json suppression_policy='{
+    "unsubscribe_signals": ["unsubscribe", "stop sending", "remove me", "opt out", "don'"'"'t want"],
+    "confidence_threshold": 0.75
+  }' \
+  --json
+```
+
+Expected result: `classification.type = unsubscribe`, `suppression_result.after_version = 1`.
+The run does not send any message.
+
+## Inputs
+
+- `inbound_reply`: object with `content` (string), `received_from` (string),
+  and `received_at` (ISO 8601 string).
+- `original_send_receipt`: object with `send_plan` (string), `principal`
+  (string), `receipt_id` (string), and `checksum` (string with `sha256:`
+  prefix).
+- `suppression_policy`: optional object with `unsubscribe_signals` (array of
+  strings) and `confidence_threshold` (number from 0 to 1, default 0.75).

--- a/skills/reply-router/X.yaml
+++ b/skills/reply-router/X.yaml
@@ -1,0 +1,91 @@
+skill: reply-router
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_unsubscribe_suppression
+      runner: default
+      inputs:
+        inbound_reply:
+          content: "Please unsubscribe me from this mailing list. I don't want these emails anymore."
+          received_from: "mailto:alice@example.com"
+          received_at: "2026-07-01T10:00:00Z"
+        original_send_receipt:
+          send_plan: "newsletter-weekly-2026-w26"
+          principal: "principal:marketing"
+          receipt_id: "rcpt_01JXNEWSLETTER001"
+          checksum: "sha256:abc123def456"
+        suppression_policy:
+          unsubscribe_signals:
+            - "unsubscribe"
+            - "stop sending"
+            - "remove me"
+            - "opt out"
+            - "don't want"
+          confidence_threshold: 0.75
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+    - name: stop_ambiguous_or_unsealed
+      runner: default
+      inputs:
+        inbound_reply:
+          content: "Hmm, let me think about it and circle back."
+          received_from: "mailto:bob@example.com"
+          received_at: "2026-07-01T11:00:00Z"
+        original_send_receipt:
+          send_plan: "newsletter-weekly-2026-w26"
+          principal: "principal:marketing"
+          receipt_id: "rcpt_01JXNEWSLETTER002"
+          checksum: "sha256:def789ghi012"
+        suppression_policy:
+          unsubscribe_signals:
+            - "unsubscribe"
+            - "stop sending"
+            - "remove me"
+            - "opt out"
+            - "don't want"
+          confidence_threshold: 0.75
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_failed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      classification: object
+      suppression_result: object
+      routing: object
+    inputs:
+      inbound_reply:
+        type: json
+        required: true
+        description: Inbound reply message with content, sender, and timestamp.
+      original_send_receipt:
+        type: json
+        required: true
+        description: Receipt for the original outbound send that prompted this reply.
+      suppression_policy:
+        type: json
+        required: false
+        description: Policy defining unsubscribe signals and confidence threshold.

--- a/skills/reply-router/run.mjs
+++ b/skills/reply-router/run.mjs
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Read inputs
+// ---------------------------------------------------------------------------
+
+const inputs = readInputs();
+
+const inboundReply = objectValue(inputs.inbound_reply, "inbound_reply");
+const sendReceipt = objectValue(inputs.original_send_receipt, "original_send_receipt");
+const policy = inputs.suppression_policy ? objectValue(inputs.suppression_policy, "suppression_policy") : {};
+
+// ---------------------------------------------------------------------------
+// Validate required fields
+// ---------------------------------------------------------------------------
+
+const content = stringValue(inboundReply.content);
+if (!content) fail("inbound_reply.content is required and must be a non-empty string");
+
+const receivedFrom = stringValue(inboundReply.received_from);
+if (!receivedFrom) fail("inbound_reply.received_from is required");
+
+const receivedAt = stringValue(inboundReply.received_at);
+if (!receivedAt) fail("inbound_reply.received_at is required");
+
+const sendPlan = stringValue(sendReceipt.send_plan);
+const principal = stringValue(sendReceipt.principal);
+const receiptId = stringValue(sendReceipt.receipt_id);
+const checksum = stringValue(sendReceipt.checksum);
+
+if (!principal) fail("original_send_receipt.principal is required");
+
+// Unsealed receipt check: must have both receipt_id and checksum
+if (!receiptId || !checksum) {
+  fail("original_send_receipt is unsealed: both receipt_id and checksum are required to route a reply");
+}
+
+// ---------------------------------------------------------------------------
+// Suppression policy defaults
+// ---------------------------------------------------------------------------
+
+const unsubscribeSignals = Array.isArray(policy.unsubscribe_signals)
+  ? policy.unsubscribe_signals.map((s) => String(s).toLowerCase())
+  : ["unsubscribe", "stop sending", "remove me", "opt out", "don't want", "take me off", "no longer", "mailing list"];
+
+const confidenceThreshold = typeof policy.confidence_threshold === "number" ? policy.confidence_threshold : 0.75;
+
+// ---------------------------------------------------------------------------
+// Classify
+// ---------------------------------------------------------------------------
+
+const normalized = normalize(content);
+const classification = classify(normalized, unsubscribeSignals);
+
+if (classification.confidence < confidenceThreshold) {
+  fail(`ambiguous reply: best classification '${classification.type}' has confidence ${classification.confidence} below threshold ${confidenceThreshold}`);
+}
+
+// ---------------------------------------------------------------------------
+// Route or suppress
+// ---------------------------------------------------------------------------
+
+let result;
+
+if (classification.type === "unsubscribe") {
+  const suppressionResult = suppress({ principal, receiptId, checksum, sendPlan, content, receivedFrom, receivedAt });
+  result = { classification, suppression_result: suppressionResult };
+} else {
+  const sendTarget = sendTargetFor(classification.type);
+  result = {
+    classification,
+    "runx.reply.routing.v1": { classification: classification.type, send_target: sendTarget, principal },
+  };
+}
+
+process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+
+// ---------------------------------------------------------------------------
+// Classification logic
+// ---------------------------------------------------------------------------
+
+function classify(text, unsubSignals) {
+  const checks = [
+    { type: "unsubscribe", signals: unsubSignals, baseConfidence: 0.9 },
+    { type: "out_of_office", signals: ["out of office", "ooo", "on vacation", "away from", "auto-reply", "automatic reply", "auto reply", "will be away", "currently away"], baseConfidence: 0.88 },
+    { type: "wrong_person", signals: ["wrong person", "not me", "wrong number", "wrong address", "who is this", "not the right", "mistake", "reached the wrong"], baseConfidence: 0.82 },
+    { type: "objection", signals: ["not interested", "too expensive", "not now", "maybe later", "can't afford", "no budget", "not a fit", "pass on this", "decline", "no thank"], baseConfidence: 0.8 },
+    { type: "interested", signals: ["interested", "tell me more", "sounds good", "let's do it", "lets do it", "sign me up", "how do we start", "let's talk", "lets talk", "let's set up"], baseConfidence: 0.8 },
+  ];
+
+  let best = { type: "unknown", confidence: 0, evidence: { matched_signals: [], source_summary: summarize(content) } };
+
+  for (const check of checks) {
+    const matched = check.signals.filter((s) => text.includes(s));
+    if (matched.length === 0) continue;
+    const confidence = Math.min(0.98, check.baseConfidence + matched.length * 0.03);
+    if (confidence > best.confidence) {
+      best = { type: check.type, confidence: round(confidence), evidence: { matched_signals: matched, source_summary: summarize(content) } };
+    }
+  }
+  return best;
+}
+
+function sendTargetFor(type) {
+  switch (type) {
+    case "interested": return "sales-follow-up";
+    case "objection": return "objection-handling";
+    case "out_of_office": return "schedule-retry";
+    case "wrong_person": return "contact-cleanup";
+    default: return "manual-review";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suppression (local event store with CAS)
+// ---------------------------------------------------------------------------
+
+function suppress({ principal, receiptId, checksum, sendPlan, content, receivedFrom, receivedAt }) {
+  const aggregateId = `${principal}:${receiptId}`;
+  const idempotencyKey = `${aggregateId}:unsubscribe:${checksum}`;
+
+  const storeDir = path.join(os.tmpdir(), "runx-reply-router-store");
+  fs.mkdirSync(storeDir, { recursive: true });
+  const storeFile = path.join(storeDir, crypto.createHash("sha256").update(aggregateId).digest("hex") + ".json");
+
+  let store;
+  if (fs.existsSync(storeFile)) {
+    store = JSON.parse(fs.readFileSync(storeFile, "utf8"));
+  } else {
+    store = { aggregate_id: aggregateId, version: 0, events: [], idempotency_keys: {} };
+  }
+
+  // Idempotency: if already processed, return cached result
+  if (store.idempotency_keys[idempotencyKey]) {
+    const cached = store.idempotency_keys[idempotencyKey];
+    return { aggregate_id: aggregateId, idempotency_key: idempotencyKey, before_version: cached.before_version, after_version: cached.after_version };
+  }
+
+  // CAS append
+  const beforeVersion = store.version;
+  const afterVersion = store.version + 1;
+
+  const event = {
+    type: "suppression.unsubscribe",
+    aggregate_id: aggregateId,
+    version: afterVersion,
+    idempotency_key: idempotencyKey,
+    payload: {
+      principal, receipt_id: receiptId, checksum, send_plan: sendPlan,
+      reply_content_summary: summarize(content), received_from: receivedFrom,
+      received_at: receivedAt, suppressed_at: new Date().toISOString(),
+    },
+  };
+
+  store.events.push(event);
+  store.version = afterVersion;
+  store.idempotency_keys[idempotencyKey] = { before_version: beforeVersion, after_version: afterVersion };
+  fs.writeFileSync(storeFile, JSON.stringify(store, null, 2));
+
+  return { aggregate_id: aggregateId, idempotency_key: idempotencyKey, before_version: beforeVersion, after_version: afterVersion };
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  if (process.env.RUNX_INPUTS_JSON) return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  return {
+    inbound_reply: parseInputValue(process.env.RUNX_INPUT_INBOUND_REPLY),
+    original_send_receipt: parseInputValue(process.env.RUNX_INPUT_ORIGINAL_SEND_RECEIPT),
+    suppression_policy: parseInputValue(process.env.RUNX_INPUT_SUPPRESSION_POLICY),
+  };
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try { return JSON.parse(raw); } catch { return raw; }
+}
+
+function normalize(value) { return String(value ?? "").toLowerCase().replace(/\s+/g, " ").trim(); }
+function summarize(text) { const s = String(text ?? "").replace(/\s+/g, " ").trim(); return s.length > 140 ? s.slice(0, 137) + "..." : s; }
+function round(n) { return Math.round(n * 100) / 100; }
+function stringValue(value) { return typeof value === "string" && value.trim().length > 0 ? value.trim() : null; }
+function objectValue(value, name) { if (!value || typeof value !== "object" || Array.isArray(value)) fail(name + " must be an object"); return value; }
+function fail(message) { process.stderr.write(message + "\n"); process.exit(64); }


### PR DESCRIPTION
## reply-router skill

Classifies inbound reply messages and either appends a suppression event for unsubscribes or emits a bounded routing decision for all other classifications. Never sends — just routes.

### Files
- `skills/reply-router/SKILL.md` — skill documentation
- `skills/reply-router/X.yaml` — skill profile with inline harness cases
- `skills/reply-router/run.mjs` — CLI tool implementation

### Harness: 2/2 passed (hosted)
- `sealed_unsubscribe_suppression` — sealed ✓
- `stop_ambiguous_or_unsealed` — failure (stop) ✓

### Registry
https://runx.ai/x/armstrongsam25/reply-router@sha-ad0fc216e139

### runx version
runx-cli 0.6.16
