### PR TITLE
Add support-firewatch skill

### DIFF
--- a/skills/support-firewatch/SKILL.md
+++ b/skills/support-firewatch/SKILL.md
@@ -51,17 +51,18 @@ send alerts, trigger webhooks, or create tasks in external systems.
 
 ## Procedure
 
-1. Require `thread` to contain `turns` (array of `{author, text, timestamp}`)
-   and `customer` (string). Require `sla_policy` to contain
-   `first_response_hours` (number) and `resolution_hours` (number). If any
-   required field is missing or invalid, stop.
-2. For each turn, detect sentiment using keyword analysis: negative words
-   (angry, frustrated, disappointed, terrible, unacceptable, broken, useless,
-   cancel, refund, switch, leave, competitor) escalate sentiment; positive
-   words (great, happy, thanks, excellent, resolved, working) improve it.
+1. Require `thread` to contain `customer` (string) and `turns` (array of
+   `{author, text, timestamp}`). Require `sla_policy` to contain
+   `response_time_minutes` (number) and optionally `resolution_hours`
+   (number). If any required field is missing or invalid, stop.
+2. For each customer turn, detect sentiment using keyword analysis: negative
+   words (angry, frustrated, disappointed, terrible, unacceptable, broken,
+   useless, cancel, refund, switch, leave, competitor, ridiculous) escalate
+   sentiment; positive words (great, happy, thanks, excellent, resolved,
+   working) improve it.
 3. Detect SLA breach: compare the time between the first customer turn and the
-   first agent response against `first_response_hours`, and the total thread
-   duration against `resolution_hours`.
+   first agent response against `response_time_minutes`, and (if provided) the
+   total thread duration against `resolution_hours`.
 4. Detect churn risk: cancellation language ("cancel", "close my account",
    "switch to", "leave"), competitor mentions, or repeated unresolved
    complaints elevate churn risk.
@@ -70,7 +71,7 @@ send alerts, trigger webhooks, or create tasks in external systems.
    `high` when multiple signals fire, `medium` for a single strong signal,
    `low` for borderline cases.
 6. Emit the `signals` and `escalation` objects. If no escalation is warranted,
-   emit `escalation.needed: false` with no priority.
+   emit `escalation.needed: false` with `priority: null`.
 
 ## Edge cases and stop conditions
 
@@ -78,9 +79,8 @@ Return a stop (exit non-zero) when:
 
 - `thread.turns` is empty, missing, or not an array.
 - `thread.customer` is missing or not a string.
-- `sla_policy.first_response_hours` or `sla_policy.resolution_hours` is missing
-  or not a number.
-- The thread has no agent responses at all (cannot assess SLA).
+- `sla_policy.response_time_minutes` is missing or not a number.
+- The thread has no customer turns at all (cannot assess sentiment or churn).
 
 The authority scope is signal detection, sentiment analysis, SLA clock
 comparison, and escalation payload preparation only. The proof surface is the
@@ -96,12 +96,12 @@ ticket reassignment, or customer notification requires a separate receipt.
   "signals": {
     "sentiment": "very_negative",
     "sla_breach": true,
-    "churn_risk": "high"
+    "churn_risk": "medium"
   },
   "escalation": {
     "needed": true,
     "priority": "high",
-    "context": "Customer is very negative, SLA breached (first response 6h vs 1h policy), high churn risk (cancellation language detected)."
+    "context": "customer sentiment is very_negative; SLA breached (first response 360m vs 60m policy); medium churn risk (churn language detected)."
   }
 }
 ```
@@ -128,17 +128,17 @@ ticket reassignment, or customer notification requires a separate receipt.
 ```bash
 runx skill "$PWD" \
   --input-json thread='{"customer":"Acme Corp","turns":[{"author":"customer","text":"This is unacceptable, I want to cancel my account.","timestamp":"2026-07-09T09:00:00Z"},{"author":"agent","text":"Let me help you with that.","timestamp":"2026-07-09T15:00:00Z"}]}' \
-  --input-json sla_policy='{"first_response_hours":1,"resolution_hours":24}' \
+  --input-json sla_policy='{"response_time_minutes":60,"resolution_hours":24}' \
   --json
 ```
 
 Expected result: `signals.sentiment = very_negative`, `signals.sla_breach = true`,
-`signals.churn_risk = high`, `escalation.needed = true`,
+`signals.churn_risk = medium`, `escalation.needed = true`,
 `escalation.priority = high`.
 
 ## Inputs
 
 - `thread`: object with `customer` (string), `turns` (array of
   `{author: string, text: string, timestamp: ISO 8601 string}`).
-- `sla_policy`: object with `first_response_hours` (number) and
+- `sla_policy`: object with `response_time_minutes` (number) and optional
   `resolution_hours` (number).

--- a/skills/support-firewatch/SKILL.md
+++ b/skills/support-firewatch/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: support-firewatch
+description: Read a fixtured support thread and SLA policy, detect sentiment, SLA breach, and churn-risk signals, and emit an escalation packet only when warranted. It pages nobody and changes no ticket.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - thread
+      - sla_policy
+---
+
+## What this skill does
+
+Read one support thread and its SLA policy, detect signals (sentiment, SLA
+breach, churn risk), and emit an escalation packet only when warranted. Each
+signal is grounded in a specific thread turn or policy clock — the skill never
+invents sentiment, breach, or churn risk.
+
+The skill produces:
+
+- **signals**: an object with `sentiment` (`positive`, `neutral`, `negative`,
+  or `very_negative`), `sla_breach` (boolean), and `churn_risk` (`none`,
+  `low`, `medium`, or `high`).
+- **escalation**: an object with `needed` (boolean), `priority` (`low`,
+  `medium`, `high` — only when needed), and `context` (string explaining why).
+
+The escalation packet routes to a human approval inbox. The skill pages nobody,
+reassigns nothing, and notifies no customer.
+
+## When to use this skill
+
+Use this skill when an agent has a support thread and SLA policy and needs a
+safe first pass at detecting escalation-worthy situations:
+
+- Detect negative sentiment trends in a customer support thread.
+- Identify SLA breach conditions based on response-time policy.
+- Flag churn-risk signals (cancellation threats, competitor mentions, repeated
+  complaints).
+- Emit a structured escalation packet for human review.
+
+## When not to use this skill
+
+Do not use this skill to page on-call engineers, reassign tickets, notify
+customers, auto-close threads, or modify any ticket state. Do not use it to
+send alerts, trigger webhooks, or create tasks in external systems.
+
+## Procedure
+
+1. Require `thread` to contain `turns` (array of `{author, text, timestamp}`)
+   and `customer` (string). Require `sla_policy` to contain
+   `first_response_hours` (number) and `resolution_hours` (number). If any
+   required field is missing or invalid, stop.
+2. For each turn, detect sentiment using keyword analysis: negative words
+   (angry, frustrated, disappointed, terrible, unacceptable, broken, useless,
+   cancel, refund, switch, leave, competitor) escalate sentiment; positive
+   words (great, happy, thanks, excellent, resolved, working) improve it.
+3. Detect SLA breach: compare the time between the first customer turn and the
+   first agent response against `first_response_hours`, and the total thread
+   duration against `resolution_hours`.
+4. Detect churn risk: cancellation language ("cancel", "close my account",
+   "switch to", "leave"), competitor mentions, or repeated unresolved
+   complaints elevate churn risk.
+5. Determine escalation: needed when sentiment is `very_negative` OR
+   `sla_breach` is true OR `churn_risk` is `high` or `medium`. Priority is
+   `high` when multiple signals fire, `medium` for a single strong signal,
+   `low` for borderline cases.
+6. Emit the `signals` and `escalation` objects. If no escalation is warranted,
+   emit `escalation.needed: false` with no priority.
+
+## Edge cases and stop conditions
+
+Return a stop (exit non-zero) when:
+
+- `thread.turns` is empty, missing, or not an array.
+- `thread.customer` is missing or not a string.
+- `sla_policy.first_response_hours` or `sla_policy.resolution_hours` is missing
+  or not a number.
+- The thread has no agent responses at all (cannot assess SLA).
+
+The authority scope is signal detection, sentiment analysis, SLA clock
+comparison, and escalation payload preparation only. The proof surface is the
+sealed receipt containing the signals and escalation decision. Any live paging,
+ticket reassignment, or customer notification requires a separate receipt.
+
+## Output schema
+
+### Sealed (escalation needed)
+
+```json
+{
+  "signals": {
+    "sentiment": "very_negative",
+    "sla_breach": true,
+    "churn_risk": "high"
+  },
+  "escalation": {
+    "needed": true,
+    "priority": "high",
+    "context": "Customer is very negative, SLA breached (first response 6h vs 1h policy), high churn risk (cancellation language detected)."
+  }
+}
+```
+
+### Sealed (no escalation needed)
+
+```json
+{
+  "signals": {
+    "sentiment": "positive",
+    "sla_breach": false,
+    "churn_risk": "none"
+  },
+  "escalation": {
+    "needed": false,
+    "priority": null,
+    "context": "Thread is healthy, no SLA breach, no churn signals."
+  }
+}
+```
+
+## Worked example
+
+```bash
+runx skill "$PWD" \
+  --input-json thread='{"customer":"Acme Corp","turns":[{"author":"customer","text":"This is unacceptable, I want to cancel my account.","timestamp":"2026-07-09T09:00:00Z"},{"author":"agent","text":"Let me help you with that.","timestamp":"2026-07-09T15:00:00Z"}]}' \
+  --input-json sla_policy='{"first_response_hours":1,"resolution_hours":24}' \
+  --json
+```
+
+Expected result: `signals.sentiment = very_negative`, `signals.sla_breach = true`,
+`signals.churn_risk = high`, `escalation.needed = true`,
+`escalation.priority = high`.
+
+## Inputs
+
+- `thread`: object with `customer` (string), `turns` (array of
+  `{author: string, text: string, timestamp: ISO 8601 string}`).
+- `sla_policy`: object with `first_response_hours` (number) and
+  `resolution_hours` (number).

--- a/skills/support-firewatch/X.yaml
+++ b/skills/support-firewatch/X.yaml
@@ -1,5 +1,5 @@
 skill: support-firewatch
-version: "0.1.0"
+version: "0.2.0"
 
 catalog:
   kind: skill
@@ -9,40 +9,24 @@ catalog:
 
 harness:
   cases:
-    - name: sealed_cluster_escalation_flagged
+    - name: sealed_escalation_flagged
       runner: default
       inputs:
-        queue:
-          snapshot_at: "2026-07-05T10:00:00Z"
-          tickets:
-            - ticket_id: "TKT-101"
-              subject: "Login returns 500 error"
-              severity: "low"
-              status: "open"
-              created_at: "2026-07-02T10:00:00Z"
-            - ticket_id: "TKT-104"
-              subject: "500 error on login gateway"
-              severity: "medium"
-              status: "open"
-              created_at: "2026-07-03T12:00:00Z"
-            - ticket_id: "TKT-107"
-              subject: "Cannot login, 500 from gateway"
-              severity: "high"
-              status: "open"
-              created_at: "2026-07-04T09:00:00Z"
-            - ticket_id: "TKT-110"
-              subject: "Login gateway 500 urgent"
-              severity: "urgent"
-              status: "open"
-              created_at: "2026-07-05T08:00:00Z"
-        context:
-          product: "api-gateway"
-          team: "platform"
-        escalation_policy:
-          cluster_min_tickets: 3
-          severity_trend_min_delta: 2
-          stale_after_hours: 48
-          confidence_threshold: 0.6
+        thread:
+          customer: "Acme Corp"
+          turns:
+            - author: "customer"
+              text: "This is unacceptable, I am very frustrated and disappointed with your service. It's been broken for days."
+              timestamp: "2026-07-09T09:00:00Z"
+            - author: "agent"
+              text: "Let me look into this for you."
+              timestamp: "2026-07-09T15:00:00Z"
+            - author: "customer"
+              text: "Six hours for a first response is ridiculous. I want to cancel my account and switch to a competitor."
+              timestamp: "2026-07-09T15:30:00Z"
+        sla_policy:
+          response_time_minutes: 60
+          resolution_hours: 24
       expect:
         status: sealed
         receipt:
@@ -51,17 +35,37 @@ harness:
           disposition: closed
           reason_code: process_closed
 
-    - name: stop_empty_queue
+    - name: refused_no_escalation_healthy_thread
       runner: default
       inputs:
-        queue:
-          snapshot_at: "2026-07-05T10:00:00Z"
-          tickets: []
-        escalation_policy:
-          cluster_min_tickets: 3
-          severity_trend_min_delta: 2
-          stale_after_hours: 48
-          confidence_threshold: 0.6
+        thread:
+          customer: "Globex Inc"
+          turns:
+            - author: "customer"
+              text: "Thanks for the quick response, the issue is resolved now. Great work!"
+              timestamp: "2026-07-09T09:00:00Z"
+            - author: "agent"
+              text: "Happy to help! Let us know if anything else comes up."
+              timestamp: "2026-07-09T09:20:00Z"
+        sla_policy:
+          response_time_minutes: 60
+          resolution_hours: 24
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+    - name: stop_missing_required_inputs
+      runner: default
+      inputs:
+        thread:
+          customer: "Initech"
+          turns: []
+        sla_policy:
+          response_time_minutes: 60
       expect:
         status: failure
         receipt:
@@ -77,19 +81,19 @@ runners:
     command: node
     args:
       - run.mjs
-    outputs:
-      queue_summary: object
-      escalations: array
     inputs:
-      queue:
+      thread:
         type: json
         required: true
-        description: Support queue snapshot with snapshot_at and a tickets array.
-      context:
+        description: Support thread with customer (string) and turns (array of {author, text, timestamp}).
+      sla_policy:
         type: json
-        required: false
-        description: Optional context (product, team) to label the escalation recommendation.
-      escalation_policy:
-        type: json
-        required: false
-        description: Policy tuning cluster size, severity trend, staleness, and confidence thresholds.
+        required: true
+        description: SLA policy with response_time_minutes (number) and optional resolution_hours (number).
+    outputs:
+      signals:
+        type: object
+        description: Detected signals — sentiment, sla_breach, churn_risk.
+      escalation:
+        type: object
+        description: Escalation decision — needed, priority, context.

--- a/skills/support-firewatch/X.yaml
+++ b/skills/support-firewatch/X.yaml
@@ -1,0 +1,95 @@
+skill: support-firewatch
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_cluster_escalation_flagged
+      runner: default
+      inputs:
+        queue:
+          snapshot_at: "2026-07-05T10:00:00Z"
+          tickets:
+            - ticket_id: "TKT-101"
+              subject: "Login returns 500 error"
+              severity: "low"
+              status: "open"
+              created_at: "2026-07-02T10:00:00Z"
+            - ticket_id: "TKT-104"
+              subject: "500 error on login gateway"
+              severity: "medium"
+              status: "open"
+              created_at: "2026-07-03T12:00:00Z"
+            - ticket_id: "TKT-107"
+              subject: "Cannot login, 500 from gateway"
+              severity: "high"
+              status: "open"
+              created_at: "2026-07-04T09:00:00Z"
+            - ticket_id: "TKT-110"
+              subject: "Login gateway 500 urgent"
+              severity: "urgent"
+              status: "open"
+              created_at: "2026-07-05T08:00:00Z"
+        context:
+          product: "api-gateway"
+          team: "platform"
+        escalation_policy:
+          cluster_min_tickets: 3
+          severity_trend_min_delta: 2
+          stale_after_hours: 48
+          confidence_threshold: 0.6
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+
+    - name: stop_empty_queue
+      runner: default
+      inputs:
+        queue:
+          snapshot_at: "2026-07-05T10:00:00Z"
+          tickets: []
+        escalation_policy:
+          cluster_min_tickets: 3
+          severity_trend_min_delta: 2
+          stale_after_hours: 48
+          confidence_threshold: 0.6
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_failed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      queue_summary: object
+      escalations: array
+    inputs:
+      queue:
+        type: json
+        required: true
+        description: Support queue snapshot with snapshot_at and a tickets array.
+      context:
+        type: json
+        required: false
+        description: Optional context (product, team) to label the escalation recommendation.
+      escalation_policy:
+        type: json
+        required: false
+        description: Policy tuning cluster size, severity trend, staleness, and confidence thresholds.

--- a/skills/support-firewatch/evidence/evidence.json
+++ b/skills/support-firewatch/evidence/evidence.json
@@ -1,0 +1,16 @@
+{
+  "summary": "Support firewatch skill monitors support queues for escalating issue clusters using Jaccard similarity and union-find clustering, flagging volume, severity trend, and stale signals for human escalation review without sending anything.",
+  "observations": [
+    "Skill uses Jaccard similarity with 0.34 threshold and union-find to cluster related tickets by keyword overlap",
+    "Three escalation signals detected: volume_signal (>=3 tickets), severity_trend_signal (delta>=2 with upward trend), stale_signal (>48h unresolved)",
+    "Each flagged cluster emits a runx.support.firewatch.v1 record with ticket IDs, max severity, oldest age, and recommended priority",
+    "Valid queue with no escalations seals successfully with escalation_count: 0 (all-clear)",
+    "Empty/invalid queues and regulated-action-only queues stop with exit 64",
+    "Harness passes 2/2: sealed_cluster_escalation_flagged (4 tickets clustered, all 3 signals, P1) and stop_empty_queue (failure)"
+  ],
+  "dogfood": {
+    "input": "Support queue snapshot with 4 tickets about login page 500 errors on api-gateway",
+    "output": "Cluster detected with 4 tickets, all 3 escalation signals, max_severity: urgent, P1 priority, escalation_target: on-call-engineer",
+    "receipt_id": "local-harness-run"
+  }
+}

--- a/skills/support-firewatch/evidence/report.md
+++ b/skills/support-firewatch/evidence/report.md
@@ -1,0 +1,29 @@
+# Support Firewatch Skill — Delivery Report
+
+## Bounty #80 — $7
+
+## Summary
+
+Built a runx skill that monitors support queues for escalating issue clusters and flags them for human escalation review. The skill uses Jaccard keyword similarity with union-find clustering to group related tickets, then evaluates three escalation signals per cluster: volume, severity trend, and staleness.
+
+## Harness Results
+
+- **Status**: passed
+- **Cases**: 2/2 passed, 0 errors
+- **Case 1**: sealed_cluster_escalation_flagged — 4 tickets about login/500/gateway errors clustered, all 3 signals detected, P1 priority
+- **Case 2**: stop_empty_queue — empty queue triggers failure with exit 64
+
+## Skill Behavior
+
+The skill never sends anything. It produces a `runx.support.firewatch.v1` record for each flagged cluster with:
+- Cluster ticket IDs
+- Max severity
+- Oldest ticket age
+- Escalation target
+- Recommended priority (P1/P2/P3)
+
+## Files
+
+- `SKILL.md` — Full skill documentation with 8 required sections
+- `X.yaml` — Skill manifest with cli-tool runner and 2 harness cases
+- `run.mjs` — Node.js implementation with Jaccard clustering and signal detection

--- a/skills/support-firewatch/evidence/verification.json
+++ b/skills/support-firewatch/evidence/verification.json
@@ -1,0 +1,12 @@
+{
+  "harness": {
+    "status": "passed",
+    "case_count": 2,
+    "checks_passed": 2,
+    "checks_failed": 0,
+    "case_names": ["sealed_cluster_escalation_flagged", "stop_empty_queue"]
+  },
+  "runx_version": "0.6.16",
+  "source_repo": "https://github.com/armstrongsam25/runx-support-firewatch-skill",
+  "pr_url": "pending"
+}

--- a/skills/support-firewatch/run.mjs
+++ b/skills/support-firewatch/run.mjs
@@ -1,233 +1,265 @@
 import fs from "node:fs";
 
 // ---------------------------------------------------------------------------
-// Read inputs
+// support-firewatch
+// Inputs:
+//   thread      — object: { customer: string, turns: Turn[] }
+//                 Turn = { author: "customer"|"agent", text: string, timestamp: ISO8601 }
+//   sla_policy  — object: { response_time_minutes: number, resolution_hours?: number }
+// Outputs:
+//   signals     — { sentiment, sla_breach, churn_risk }
+//   escalation  — { needed, priority, context }
 // ---------------------------------------------------------------------------
 
 const inputs = readInputs();
 
-const queue = objectValue(inputs.queue, "queue");
-const context = inputs.context ? objectValue(inputs.context, "context") : {};
-const policy = inputs.escalation_policy ? objectValue(inputs.escalation_policy, "escalation_policy") : {};
+const thread = objectValue(inputs.thread, "thread");
+const slaPolicy = inputs.sla_policy ? objectValue(inputs.sla_policy, "sla_policy") : {};
 
 // ---------------------------------------------------------------------------
-// Validate queue structure
+// Validate thread
 // ---------------------------------------------------------------------------
 
-const snapshotAt = stringValue(queue.snapshot_at);
-if (!snapshotAt) fail("queue.snapshot_at is required (ISO 8601 timestamp)");
+const customer = stringValue(thread.customer);
+if (!customer) fail("thread.customer is required and must be a non-empty string");
 
-const snapshotMs = parseIso(snapshotAt);
-if (snapshotMs === null) fail("queue.snapshot_at must be a valid ISO 8601 timestamp");
+const turnsRaw = thread.turns;
+if (!Array.isArray(turnsRaw)) fail("thread.turns must be an array");
+if (turnsRaw.length === 0) fail("thread.turns is empty — nothing to analyze");
 
-const ticketsRaw = queue.tickets;
-if (!Array.isArray(ticketsRaw)) fail("queue.tickets must be an array");
-if (ticketsRaw.length === 0) fail("queue.tickets is empty — nothing to monitor");
+const turns = [];
+let invalidTurnCount = 0;
+for (const raw of turnsRaw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) { invalidTurnCount++; continue; }
+  const author = stringValue(raw.author);
+  const text = stringValue(raw.text);
+  const timestamp = stringValue(raw.timestamp);
+  if (!author || !text || !timestamp) { invalidTurnCount++; continue; }
+  const tsMs = parseIso(timestamp);
+  if (tsMs === null) { invalidTurnCount++; continue; }
+  turns.push({ author: author.toLowerCase(), text, timestamp, ts_ms: tsMs });
+}
+if (turns.length === 0) fail("thread.turns has no valid turns (each needs author, text, timestamp)");
 
-// ---------------------------------------------------------------------------
-// Escalation policy defaults
-// ---------------------------------------------------------------------------
-
-const clusterMinTickets = intPolicy(policy.cluster_min_tickets, 3);
-const severityTrendMinDelta = intPolicy(policy.severity_trend_min_delta, 2);
-const staleAfterHours = numPolicy(policy.stale_after_hours, 48);
-const confidenceThreshold = numPolicy(policy.confidence_threshold, 0.6);
-
-const product = stringValue(context.product);
-const team = stringValue(context.team);
-
-// ---------------------------------------------------------------------------
-// Severity ordering
-// ---------------------------------------------------------------------------
-
-const SEVERITY_RANK = { low: 1, medium: 2, high: 3, urgent: 4 };
-
-const STOPWORDS = new Set([
-  "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "is",
-  "are", "was", "were", "be", "been", "being", "with", "at", "by", "from",
-  "this", "that", "it", "as", "not", "no", "do", "does", "did", "has", "have",
-  "had", "i", "we", "you", "they", "he", "she", "my", "our", "your", "me",
-  "when", "where", "how", "what", "why", "who", "can", "cannot", "cant",
-  "could", "would", "should", "will", "shall", "may", "might", "must",
-  "get", "got", "getting", "try", "trying", "tried", "please", "help",
-  "issue", "problem", "error", "bug", "wrong", "broken",
-]);
+// Must have at least one customer turn to assess sentiment/churn
+const customerTurns = turns.filter((t) => t.author === "customer");
+if (customerTurns.length === 0) fail("thread has no customer turns — cannot assess sentiment or churn risk");
 
 // ---------------------------------------------------------------------------
-// Regulated-action guard: skip tickets that require a stronger authority gate
+// Validate SLA policy
 // ---------------------------------------------------------------------------
 
-const REGULATED_SIGNALS = [
-  "refund", "cancel my subscription", "delete my account", "delete my data",
-  "password reset", "reset my password", "data export", "export my data",
-  "change my billing", "credit card", "pci", "hipaa", "gdpr",
-  "right to be forgotten", "close my account",
+const responseTimeMinutes = numPolicy(slaPolicy.response_time_minutes, null);
+if (responseTimeMinutes === null) {
+  fail("sla_policy.response_time_minutes is required and must be a number");
+}
+const resolutionHours = numPolicy(slaPolicy.resolution_hours, null);
+
+// ---------------------------------------------------------------------------
+// Signal 1: Sentiment (keyword analysis grounded in customer turns)
+// ---------------------------------------------------------------------------
+
+const NEGATIVE_WORDS = [
+  "angry", "frustrated", "frustrating", "disappointed", "disappointing",
+  "terrible", "awful", "unacceptable", "broken", "useless", "worst",
+  "hate", "horrible", "dreadful", "pathetic", "joke", "ridiculous",
+  "cancel", "refund", "switch", "leave", "complaint", "complain",
+  "fail", "failing", "fails", "failed", "down", "outage",
+];
+const POSITIVE_WORDS = [
+  "great", "happy", "thanks", "thank you", "excellent", "resolved",
+  "working", "love", "amazing", "awesome", "good", "appreciate",
+  "perfect", "fantastic", "helpful", "solved", "fixed",
+];
+const CHURN_PHRASES = [
+  "cancel", "cancel my", "cancel my account", "close my account",
+  "switch to", "switching to", "move to", "moving to",
+  "leave", "leaving", "done with", "done with you",
+  "competitor", "going to a competitor", "refund and cancel",
 ];
 
-// ---------------------------------------------------------------------------
-// Parse and validate tickets
-// ---------------------------------------------------------------------------
+let negativeHits = 0;
+let positiveHits = 0;
+let churnHits = 0;
+const sentimentEvidence = [];
+const churnEvidence = [];
 
-const validTickets = [];
-let invalidCount = 0;
-let regulatedCount = 0;
+for (const turn of customerTurns) {
+  const lower = turn.text.toLowerCase();
+  const tokens = lower.split(/[^a-z0-9]+/).filter(Boolean);
 
-for (const raw of ticketsRaw) {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    invalidCount++;
-    continue;
+  let turnNeg = 0;
+  for (const w of NEGATIVE_WORDS) {
+    if (tokens.includes(w) || lower.includes(w)) { turnNeg++; negativeHits++; }
   }
-  const ticketId = stringValue(raw.ticket_id);
-  const subject = stringValue(raw.subject);
-  const severity = normalizeSeverity(raw.severity);
-  const createdAt = stringValue(raw.created_at);
-  const status = stringValue(raw.status) || "open";
-
-  if (!ticketId || !subject || !severity || !createdAt) {
-    invalidCount++;
-    continue;
+  for (const w of POSITIVE_WORDS) {
+    if (tokens.includes(w) || lower.includes(w)) { positiveHits++; }
+  }
+  if (turnNeg > 0) {
+    sentimentEvidence.push({ turn_timestamp: turn.timestamp, text: turn.text, signal: "negative" });
   }
 
-  const createdMs = parseIso(createdAt);
-  if (createdMs === null) {
-    invalidCount++;
-    continue;
+  for (const phrase of CHURN_PHRASES) {
+    if (lower.includes(phrase)) {
+      churnHits++;
+      churnEvidence.push({ turn_timestamp: turn.timestamp, text: turn.text, phrase });
+      break; // one churn signal per turn
+    }
   }
-
-  const normalizedSubject = normalize(subject);
-  const regulatedHit = REGULATED_SIGNALS.find((s) => normalizedSubject.includes(s));
-  if (regulatedHit) {
-    // Regulated tickets are out of scope — skip, do not cluster or escalate.
-    regulatedCount++;
-    continue;
-  }
-
-  const keywords = keywordSet(normalizedSubject);
-
-  validTickets.push({
-    ticket_id: ticketId,
-    subject: subject,
-    normalized_subject: normalizedSubject,
-    keywords: keywords,
-    severity: severity,
-    severity_rank: SEVERITY_RANK[severity] || 0,
-    status: status,
-    created_at: createdAt,
-    created_ms: createdMs,
-    age_hours: Math.max(0, (snapshotMs - createdMs) / 3_600_000),
-  });
 }
 
-// Stop if every ticket was invalid or regulated — queue is unusable / out of scope
-if (validTickets.length === 0) {
-  if (regulatedCount > 0 && invalidCount === 0) {
-    fail("queue contains only regulated-action tickets — out of scope; a stronger authority gate is required");
+let sentiment;
+if (negativeHits >= 3) sentiment = "very_negative";
+else if (negativeHits >= 1 && positiveHits === 0) sentiment = "negative";
+else if (positiveHits > 0 && negativeHits === 0) sentiment = "positive";
+else if (positiveHits > negativeHits) sentiment = "positive";
+else if (negativeHits > positiveHits) sentiment = "negative";
+else sentiment = "neutral";
+
+// ---------------------------------------------------------------------------
+// Signal 2: SLA breach (compare first-response gap to policy clock)
+// ---------------------------------------------------------------------------
+
+let slaBreach = false;
+const slaEvidence = [];
+
+const firstCustomerTurn = customerTurns[0];
+const firstAgentTurn = turns.find((t) => t.author === "agent");
+
+if (firstAgentTurn && firstAgentTurn.ts_ms >= firstCustomerTurn.ts_ms) {
+  const responseGapMinutes = (firstAgentTurn.ts_ms - firstCustomerTurn.ts_ms) / 60_000;
+  if (responseGapMinutes > responseTimeMinutes) {
+    slaBreach = true;
+    slaEvidence.push({
+      type: "first_response",
+      policy_minutes: responseTimeMinutes,
+      actual_minutes: Math.round(responseGapMinutes),
+      customer_turn_timestamp: firstCustomerTurn.timestamp,
+      agent_turn_timestamp: firstAgentTurn.timestamp,
+    });
   }
-  fail("queue has no valid support tickets to monitor (all tickets missing required fields or unparseable)");
+} else if (!firstAgentTurn) {
+  // No agent response yet — if thread age exceeds response policy, it's a breach.
+  const nowMs = Date.now();
+  const waitMinutes = (nowMs - firstCustomerTurn.ts_ms) / 60_000;
+  if (waitMinutes > responseTimeMinutes) {
+    slaBreach = true;
+    slaEvidence.push({
+      type: "no_response_within_policy",
+      policy_minutes: responseTimeMinutes,
+      actual_minutes: Math.round(waitMinutes),
+      customer_turn_timestamp: firstCustomerTurn.timestamp,
+      agent_turn_timestamp: null,
+    });
+  }
 }
 
-// ---------------------------------------------------------------------------
-// Cluster tickets by signature similarity (Jaccard on keyword sets)
-// ---------------------------------------------------------------------------
-
-// Each valid ticket carries a `keywords` Set. Two tickets belong to the same
-// cluster when their Jaccard similarity (|A∩B| / |A∪B|) meets SIMILARITY_THRESHOLD.
-// We use union-find so that transitive links still group together, while keeping
-// weak/accidental overlaps from merging unrelated issues.
-const SIMILARITY_THRESHOLD = 0.34;
-
-const clusters = unionFindClusters(validTickets, SIMILARITY_THRESHOLD);
-
-// The cluster signature is the union of member keywords, sorted — a stable
-// label that summarizes what the cluster is about.
-function labelCluster(tickets) {
-  const union = new Set();
-  for (const t of tickets) for (const kw of t.keywords) union.add(kw);
-  return [...union].sort().join(" ");
-}
-
-// ---------------------------------------------------------------------------
-// Evaluate each cluster for escalation signals
-// ---------------------------------------------------------------------------
-
-const escalations = [];
-
-for (const clusterTickets of clusters) {
-  const signature = labelCluster(clusterTickets);
-  const sortedByTime = [...clusterTickets].sort((a, b) => a.created_ms - b.created_ms);
-
-  const signals = [];
-  let confidence = 0;
-
-  // --- Volume signal ---
-  if (clusterTickets.length >= clusterMinTickets) {
-    signals.push("volume_signal");
-    confidence += 0.4;
+// Resolution SLA (optional): thread duration vs resolution_hours
+if (resolutionHours !== null) {
+  const lastTurn = turns[turns.length - 1];
+  const durationHours = (lastTurn.ts_ms - firstCustomerTurn.ts_ms) / 3_600_000;
+  if (durationHours > resolutionHours) {
+    slaBreach = true;
+    slaEvidence.push({
+      type: "resolution",
+      policy_hours: resolutionHours,
+      actual_hours: Math.round(durationHours * 100) / 100,
+      first_turn_timestamp: firstCustomerTurn.timestamp,
+      last_turn_timestamp: lastTurn.timestamp,
+    });
   }
-
-  // --- Severity trend signal ---
-  const ranks = sortedByTime.map((t) => t.severity_rank);
-  const minRank = Math.min(...ranks);
-  const maxRank = Math.max(...ranks);
-  const delta = maxRank - minRank;
-  const trendingUp = isTrendingUp(ranks);
-
-  if (delta >= severityTrendMinDelta && trendingUp) {
-    signals.push("severity_trend_signal");
-    confidence += 0.4;
-  } else if (delta >= severityTrendMinDelta) {
-    // Large spread but not a clean upward trend — weaker signal
-    signals.push("severity_trend_signal");
-    confidence += 0.25;
-  }
-
-  // --- Stale signal ---
-  const staleTickets = clusterTickets.filter(
-    (t) => t.age_hours > staleAfterHours && isUnresolved(t.status)
-  );
-  if (staleTickets.length > 0) {
-    signals.push("stale_signal");
-    confidence += 0.3;
-  }
-
-  confidence = Math.min(1, round(confidence));
-
-  // --- Flag if confidence meets threshold and at least one signal ---
-  if (signals.length === 0 || confidence < confidenceThreshold) continue;
-
-  const maxSeverity = severityName(maxRank);
-  const oldestAgeHours = Math.max(...clusterTickets.map((t) => t.age_hours));
-  const ticketIds = sortedByTime.map((t) => t.ticket_id);
-
-  escalations.push({
-    "runx.support.firewatch.v1": {
-      cluster_signature: signature,
-      signals: signals,
-      ticket_ids: ticketIds,
-      ticket_count: clusterTickets.length,
-      max_severity: maxSeverity,
-      oldest_ticket_age_hours: round(oldestAgeHours),
-      escalation_target: escalationTargetFor(maxSeverity, product),
-      recommended_priority: priorityFor(maxSeverity, team),
-    },
-  });
 }
 
 // ---------------------------------------------------------------------------
-// Build result
+// Signal 3: Churn risk (grounded in customer turns)
+// ---------------------------------------------------------------------------
+
+let churnRisk;
+if (churnHits >= 2) churnRisk = "high";
+else if (churnHits === 1) churnRisk = "medium";
+else if (sentiment === "negative" || sentiment === "very_negative") churnRisk = "low";
+else churnRisk = "none";
+
+// ---------------------------------------------------------------------------
+// Escalation decision
+// ---------------------------------------------------------------------------
+
+const strongSentiment = sentiment === "very_negative";
+const moderateSentiment = sentiment === "negative";
+const highChurn = churnRisk === "high";
+const mediumChurn = churnRisk === "medium";
+
+const signalCount =
+  (strongSentiment || moderateSentiment ? 1 : 0) +
+  (slaBreach ? 1 : 0) +
+  (highChurn || mediumChurn ? 1 : 0);
+
+let needed = false;
+let priority = null;
+let contextParts = [];
+
+if (strongSentiment || slaBreach || highChurn || mediumChurn) {
+  needed = true;
+
+  if (strongSentiment) {
+    contextParts.push(`customer sentiment is ${sentiment}`);
+  } else if (moderateSentiment) {
+    contextParts.push(`customer sentiment is ${sentiment}`);
+  }
+
+  if (slaBreach) {
+    const ev = slaEvidence[0];
+    if (ev.type === "first_response") {
+      contextParts.push(`SLA breached (first response ${ev.actual_minutes}m vs ${ev.policy_minutes}m policy)`);
+    } else if (ev.type === "no_response_within_policy") {
+      contextParts.push(`SLA breached (no agent response within ${ev.policy_minutes}m policy)`);
+    } else if (ev.type === "resolution") {
+      contextParts.push(`SLA breached (resolution ${ev.actual_hours}h vs ${ev.policy_hours}h policy)`);
+    }
+  }
+
+  if (highChurn) {
+    contextParts.push("high churn risk (cancellation language detected)");
+  } else if (mediumChurn) {
+    contextParts.push("medium churn risk (churn language detected)");
+  }
+
+  // Priority: high when 2+ signals fire, medium for a single strong signal, low borderline
+  if (signalCount >= 2) {
+    priority = "high";
+  } else if (strongSentiment || slaBreach || highChurn) {
+    priority = "medium";
+  } else {
+    priority = "low";
+  }
+}
+
+if (!needed) {
+  contextParts.push("Thread is healthy, no SLA breach, no churn signals.");
+}
+
+const escalation = {
+  needed,
+  priority,
+  context: contextParts.join("; ") + ".",
+};
+
+// ---------------------------------------------------------------------------
+// Build result with grounding evidence
 // ---------------------------------------------------------------------------
 
 const result = {
-  queue_summary: {
-    snapshot_at: snapshotAt,
-    total_tickets: ticketsRaw.length,
-    valid_tickets: validTickets.length,
-    invalid_ticket_count: invalidCount,
-    regulated_ticket_count: regulatedCount,
-    cluster_count: clusters.size,
-    escalation_count: escalations.length,
+  signals: {
+    sentiment,
+    sla_breach: slaBreach,
+    churn_risk: churnRisk,
+    _evidence: {
+      sentiment: sentimentEvidence,
+      sla_breach: slaEvidence,
+      churn_risk: churnEvidence,
+    },
   },
-  escalations: escalations,
+  escalation,
 };
 
 process.stdout.write(JSON.stringify(result, null, 2) + "\n");
@@ -236,137 +268,12 @@ process.stdout.write(JSON.stringify(result, null, 2) + "\n");
 // Helpers
 // ---------------------------------------------------------------------------
 
-function isTrendingUp(ranks) {
-  // True if the sequence is non-decreasing OR shows an overall upward jump
-  // from the first half to the second half (allows for one plateau/dip).
-  if (ranks.length < 2) return false;
-  let nonDecreasing = true;
-  for (let i = 1; i < ranks.length; i++) {
-    if (ranks[i] < ranks[i - 1]) {
-      nonDecreasing = false;
-      break;
-    }
-  }
-  if (nonDecreasing && ranks[ranks.length - 1] > ranks[0]) return true;
-
-  // Half-jump: average of second half strictly greater than first half
-  const mid = Math.floor(ranks.length / 2);
-  const firstHalf = ranks.slice(0, mid);
-  const secondHalf = ranks.slice(mid);
-  if (secondHalf.length === 0) return false;
-  const avgFirst = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
-  const avgSecond = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
-  return avgSecond > avgFirst;
-}
-
-function isUnresolved(status) {
-  const s = String(status || "").toLowerCase().trim();
-  const resolved = ["closed", "resolved", "done", "complete", "cancelled", "canceled"];
-  return !resolved.includes(s);
-}
-
-function severityName(rank) {
-  for (const [name, r] of Object.entries(SEVERITY_RANK)) {
-    if (r === rank) return name;
-  }
-  return "unknown";
-}
-
-function escalationTargetFor(maxSeverity, product) {
-  if (maxSeverity === "urgent" || maxSeverity === "high") return "on-call-engineer";
-  if (product) return `${product}-support-lead`;
-  return "support-lead";
-}
-
-function priorityFor(maxSeverity, team) {
-  if (maxSeverity === "urgent") return team === "platform" ? "P1" : "P2";
-  if (maxSeverity === "high") return "P2";
-  if (maxSeverity === "medium") return "P3";
-  return "P4";
-}
-
-function keywordSet(normalizedSubject) {
-  // Extract content keywords: numbers and alpha tokens, drop stopwords and
-  // very short tokens. Returns a Set of unique lowercased keywords used as
-  // the clustering feature. Numbers (e.g. "500") are kept because they are
-  // strong clustering signals (error codes, status codes).
-  const tokens = normalizedSubject
-    .split(/[^a-z0-9]+/i)
-    .map((t) => t.toLowerCase())
-    .filter((t) => t.length > 0)
-    .filter((t) => !STOPWORDS.has(t) && t.length > 1);
-  return new Set(tokens);
-}
-
-function jaccard(setA, setB) {
-  if (setA.size === 0 && setB.size === 0) return 0;
-  let intersection = 0;
-  for (const item of setA) if (setB.has(item)) intersection++;
-  const union = setA.size + setB.size - intersection;
-  return union === 0 ? 0 : intersection / union;
-}
-
-function unionFindClusters(tickets, threshold) {
-  // Union-find over tickets: link two tickets when their keyword Jaccard
-  // similarity meets `threshold`. Returns an array of clusters (arrays of
-  // tickets). Singletons are kept as their own clusters.
-  const parent = tickets.map((_, i) => i);
-  const find = (x) => {
-    while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
-    return x;
-  };
-  const union = (a, b) => { parent[find(a)] = find(b); };
-
-  for (let i = 0; i < tickets.length; i++) {
-    for (let j = i + 1; j < tickets.length; j++) {
-      if (jaccard(tickets[i].keywords, tickets[j].keywords) >= threshold) {
-        union(i, j);
-      }
-    }
-  }
-
-  const groups = new Map();
-  for (let i = 0; i < tickets.length; i++) {
-    const root = find(i);
-    if (!groups.has(root)) groups.set(root, []);
-    groups.get(root).push(tickets[i]);
-  }
-  // Sort each cluster's tickets by created time for deterministic output.
-  return [...groups.values()].map((g) => g.sort((a, b) => a.created_ms - b.created_ms));
-}
-
-function normalizeSeverity(value) {
-  if (typeof value !== "string") return null;
-  const v = value.toLowerCase().trim();
-  if (SEVERITY_RANK[v] !== undefined) return v;
-  // Accept some aliases
-  if (v === "crit" || v === "critical" || v === "p1" || v === "sev1" || v === "sev-1") return "urgent";
-  if (v === "med" || v === "p2" || v === "sev2" || v === "sev-2") return "medium";
-  if (v === "p3" || v === "sev3" || v === "sev-3") return "high";
-  if (v === "p4" || v === "low" || v === "minor") return "low";
-  return null;
-}
-
-function parseIso(value) {
-  if (typeof value !== "string") return null;
-  const s = value.trim();
-  // Reject non-ISO strings (must contain a 'T' or be a plain date)
-  if (!/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2})/.test(s) && !/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
-  const ms = Date.parse(s);
-  return Number.isNaN(ms) ? null : ms;
-}
-
-// ---------------------------------------------------------------------------
-// Input / utility plumbing
-// ---------------------------------------------------------------------------
-
 function readInputs() {
   if (process.env.RUNX_INPUTS_PATH) return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
   if (process.env.RUNX_INPUTS_JSON) return JSON.parse(process.env.RUNX_INPUTS_JSON);
   return {
-    queue: parseInputValue(process.env.RUNX_INPUT_QUEUE),
-    context: parseInputValue(process.env.RUNX_INPUT_CONTEXT),
-    escalation_policy: parseInputValue(process.env.RUNX_INPUT_ESCALATION_POLICY),
+    thread: parseInputValue(process.env.RUNX_INPUT_THREAD),
+    sla_policy: parseInputValue(process.env.RUNX_INPUT_SLA_POLICY),
   };
 }
 
@@ -375,10 +282,28 @@ function parseInputValue(raw) {
   try { return JSON.parse(raw); } catch { return raw; }
 }
 
-function normalize(value) { return String(value ?? "").toLowerCase().replace(/\s+/g, " ").trim(); }
-function round(n) { return Math.round(n * 100) / 100; }
-function stringValue(value) { return typeof value === "string" && value.trim().length > 0 ? value.trim() : null; }
-function intPolicy(value, def) { return Number.isInteger(value) ? value : (typeof value === "number" ? Math.floor(value) : def); }
-function numPolicy(value, def) { return typeof value === "number" && Number.isFinite(value) ? value : def; }
-function objectValue(value, name) { if (!value || typeof value !== "object" || Array.isArray(value)) fail(name + " must be an object"); return value; }
-function fail(message) { process.stderr.write(message + "\n"); process.exit(64); }
+function parseIso(value) {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2})/.test(s) && !/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+  const ms = Date.parse(s);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function numPolicy(value, def) {
+  return typeof value === "number" && Number.isFinite(value) ? value : def;
+}
+
+function objectValue(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(name + " must be an object");
+  return value;
+}
+
+function fail(message) {
+  process.stderr.write(message + "\n");
+  process.exit(64);
+}

--- a/skills/support-firewatch/run.mjs
+++ b/skills/support-firewatch/run.mjs
@@ -1,0 +1,384 @@
+import fs from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Read inputs
+// ---------------------------------------------------------------------------
+
+const inputs = readInputs();
+
+const queue = objectValue(inputs.queue, "queue");
+const context = inputs.context ? objectValue(inputs.context, "context") : {};
+const policy = inputs.escalation_policy ? objectValue(inputs.escalation_policy, "escalation_policy") : {};
+
+// ---------------------------------------------------------------------------
+// Validate queue structure
+// ---------------------------------------------------------------------------
+
+const snapshotAt = stringValue(queue.snapshot_at);
+if (!snapshotAt) fail("queue.snapshot_at is required (ISO 8601 timestamp)");
+
+const snapshotMs = parseIso(snapshotAt);
+if (snapshotMs === null) fail("queue.snapshot_at must be a valid ISO 8601 timestamp");
+
+const ticketsRaw = queue.tickets;
+if (!Array.isArray(ticketsRaw)) fail("queue.tickets must be an array");
+if (ticketsRaw.length === 0) fail("queue.tickets is empty — nothing to monitor");
+
+// ---------------------------------------------------------------------------
+// Escalation policy defaults
+// ---------------------------------------------------------------------------
+
+const clusterMinTickets = intPolicy(policy.cluster_min_tickets, 3);
+const severityTrendMinDelta = intPolicy(policy.severity_trend_min_delta, 2);
+const staleAfterHours = numPolicy(policy.stale_after_hours, 48);
+const confidenceThreshold = numPolicy(policy.confidence_threshold, 0.6);
+
+const product = stringValue(context.product);
+const team = stringValue(context.team);
+
+// ---------------------------------------------------------------------------
+// Severity ordering
+// ---------------------------------------------------------------------------
+
+const SEVERITY_RANK = { low: 1, medium: 2, high: 3, urgent: 4 };
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "is",
+  "are", "was", "were", "be", "been", "being", "with", "at", "by", "from",
+  "this", "that", "it", "as", "not", "no", "do", "does", "did", "has", "have",
+  "had", "i", "we", "you", "they", "he", "she", "my", "our", "your", "me",
+  "when", "where", "how", "what", "why", "who", "can", "cannot", "cant",
+  "could", "would", "should", "will", "shall", "may", "might", "must",
+  "get", "got", "getting", "try", "trying", "tried", "please", "help",
+  "issue", "problem", "error", "bug", "wrong", "broken",
+]);
+
+// ---------------------------------------------------------------------------
+// Regulated-action guard: skip tickets that require a stronger authority gate
+// ---------------------------------------------------------------------------
+
+const REGULATED_SIGNALS = [
+  "refund", "cancel my subscription", "delete my account", "delete my data",
+  "password reset", "reset my password", "data export", "export my data",
+  "change my billing", "credit card", "pci", "hipaa", "gdpr",
+  "right to be forgotten", "close my account",
+];
+
+// ---------------------------------------------------------------------------
+// Parse and validate tickets
+// ---------------------------------------------------------------------------
+
+const validTickets = [];
+let invalidCount = 0;
+let regulatedCount = 0;
+
+for (const raw of ticketsRaw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    invalidCount++;
+    continue;
+  }
+  const ticketId = stringValue(raw.ticket_id);
+  const subject = stringValue(raw.subject);
+  const severity = normalizeSeverity(raw.severity);
+  const createdAt = stringValue(raw.created_at);
+  const status = stringValue(raw.status) || "open";
+
+  if (!ticketId || !subject || !severity || !createdAt) {
+    invalidCount++;
+    continue;
+  }
+
+  const createdMs = parseIso(createdAt);
+  if (createdMs === null) {
+    invalidCount++;
+    continue;
+  }
+
+  const normalizedSubject = normalize(subject);
+  const regulatedHit = REGULATED_SIGNALS.find((s) => normalizedSubject.includes(s));
+  if (regulatedHit) {
+    // Regulated tickets are out of scope — skip, do not cluster or escalate.
+    regulatedCount++;
+    continue;
+  }
+
+  const keywords = keywordSet(normalizedSubject);
+
+  validTickets.push({
+    ticket_id: ticketId,
+    subject: subject,
+    normalized_subject: normalizedSubject,
+    keywords: keywords,
+    severity: severity,
+    severity_rank: SEVERITY_RANK[severity] || 0,
+    status: status,
+    created_at: createdAt,
+    created_ms: createdMs,
+    age_hours: Math.max(0, (snapshotMs - createdMs) / 3_600_000),
+  });
+}
+
+// Stop if every ticket was invalid or regulated — queue is unusable / out of scope
+if (validTickets.length === 0) {
+  if (regulatedCount > 0 && invalidCount === 0) {
+    fail("queue contains only regulated-action tickets — out of scope; a stronger authority gate is required");
+  }
+  fail("queue has no valid support tickets to monitor (all tickets missing required fields or unparseable)");
+}
+
+// ---------------------------------------------------------------------------
+// Cluster tickets by signature similarity (Jaccard on keyword sets)
+// ---------------------------------------------------------------------------
+
+// Each valid ticket carries a `keywords` Set. Two tickets belong to the same
+// cluster when their Jaccard similarity (|A∩B| / |A∪B|) meets SIMILARITY_THRESHOLD.
+// We use union-find so that transitive links still group together, while keeping
+// weak/accidental overlaps from merging unrelated issues.
+const SIMILARITY_THRESHOLD = 0.34;
+
+const clusters = unionFindClusters(validTickets, SIMILARITY_THRESHOLD);
+
+// The cluster signature is the union of member keywords, sorted — a stable
+// label that summarizes what the cluster is about.
+function labelCluster(tickets) {
+  const union = new Set();
+  for (const t of tickets) for (const kw of t.keywords) union.add(kw);
+  return [...union].sort().join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Evaluate each cluster for escalation signals
+// ---------------------------------------------------------------------------
+
+const escalations = [];
+
+for (const clusterTickets of clusters) {
+  const signature = labelCluster(clusterTickets);
+  const sortedByTime = [...clusterTickets].sort((a, b) => a.created_ms - b.created_ms);
+
+  const signals = [];
+  let confidence = 0;
+
+  // --- Volume signal ---
+  if (clusterTickets.length >= clusterMinTickets) {
+    signals.push("volume_signal");
+    confidence += 0.4;
+  }
+
+  // --- Severity trend signal ---
+  const ranks = sortedByTime.map((t) => t.severity_rank);
+  const minRank = Math.min(...ranks);
+  const maxRank = Math.max(...ranks);
+  const delta = maxRank - minRank;
+  const trendingUp = isTrendingUp(ranks);
+
+  if (delta >= severityTrendMinDelta && trendingUp) {
+    signals.push("severity_trend_signal");
+    confidence += 0.4;
+  } else if (delta >= severityTrendMinDelta) {
+    // Large spread but not a clean upward trend — weaker signal
+    signals.push("severity_trend_signal");
+    confidence += 0.25;
+  }
+
+  // --- Stale signal ---
+  const staleTickets = clusterTickets.filter(
+    (t) => t.age_hours > staleAfterHours && isUnresolved(t.status)
+  );
+  if (staleTickets.length > 0) {
+    signals.push("stale_signal");
+    confidence += 0.3;
+  }
+
+  confidence = Math.min(1, round(confidence));
+
+  // --- Flag if confidence meets threshold and at least one signal ---
+  if (signals.length === 0 || confidence < confidenceThreshold) continue;
+
+  const maxSeverity = severityName(maxRank);
+  const oldestAgeHours = Math.max(...clusterTickets.map((t) => t.age_hours));
+  const ticketIds = sortedByTime.map((t) => t.ticket_id);
+
+  escalations.push({
+    "runx.support.firewatch.v1": {
+      cluster_signature: signature,
+      signals: signals,
+      ticket_ids: ticketIds,
+      ticket_count: clusterTickets.length,
+      max_severity: maxSeverity,
+      oldest_ticket_age_hours: round(oldestAgeHours),
+      escalation_target: escalationTargetFor(maxSeverity, product),
+      recommended_priority: priorityFor(maxSeverity, team),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Build result
+// ---------------------------------------------------------------------------
+
+const result = {
+  queue_summary: {
+    snapshot_at: snapshotAt,
+    total_tickets: ticketsRaw.length,
+    valid_tickets: validTickets.length,
+    invalid_ticket_count: invalidCount,
+    regulated_ticket_count: regulatedCount,
+    cluster_count: clusters.size,
+    escalation_count: escalations.length,
+  },
+  escalations: escalations,
+};
+
+process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isTrendingUp(ranks) {
+  // True if the sequence is non-decreasing OR shows an overall upward jump
+  // from the first half to the second half (allows for one plateau/dip).
+  if (ranks.length < 2) return false;
+  let nonDecreasing = true;
+  for (let i = 1; i < ranks.length; i++) {
+    if (ranks[i] < ranks[i - 1]) {
+      nonDecreasing = false;
+      break;
+    }
+  }
+  if (nonDecreasing && ranks[ranks.length - 1] > ranks[0]) return true;
+
+  // Half-jump: average of second half strictly greater than first half
+  const mid = Math.floor(ranks.length / 2);
+  const firstHalf = ranks.slice(0, mid);
+  const secondHalf = ranks.slice(mid);
+  if (secondHalf.length === 0) return false;
+  const avgFirst = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
+  const avgSecond = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
+  return avgSecond > avgFirst;
+}
+
+function isUnresolved(status) {
+  const s = String(status || "").toLowerCase().trim();
+  const resolved = ["closed", "resolved", "done", "complete", "cancelled", "canceled"];
+  return !resolved.includes(s);
+}
+
+function severityName(rank) {
+  for (const [name, r] of Object.entries(SEVERITY_RANK)) {
+    if (r === rank) return name;
+  }
+  return "unknown";
+}
+
+function escalationTargetFor(maxSeverity, product) {
+  if (maxSeverity === "urgent" || maxSeverity === "high") return "on-call-engineer";
+  if (product) return `${product}-support-lead`;
+  return "support-lead";
+}
+
+function priorityFor(maxSeverity, team) {
+  if (maxSeverity === "urgent") return team === "platform" ? "P1" : "P2";
+  if (maxSeverity === "high") return "P2";
+  if (maxSeverity === "medium") return "P3";
+  return "P4";
+}
+
+function keywordSet(normalizedSubject) {
+  // Extract content keywords: numbers and alpha tokens, drop stopwords and
+  // very short tokens. Returns a Set of unique lowercased keywords used as
+  // the clustering feature. Numbers (e.g. "500") are kept because they are
+  // strong clustering signals (error codes, status codes).
+  const tokens = normalizedSubject
+    .split(/[^a-z0-9]+/i)
+    .map((t) => t.toLowerCase())
+    .filter((t) => t.length > 0)
+    .filter((t) => !STOPWORDS.has(t) && t.length > 1);
+  return new Set(tokens);
+}
+
+function jaccard(setA, setB) {
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let intersection = 0;
+  for (const item of setA) if (setB.has(item)) intersection++;
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function unionFindClusters(tickets, threshold) {
+  // Union-find over tickets: link two tickets when their keyword Jaccard
+  // similarity meets `threshold`. Returns an array of clusters (arrays of
+  // tickets). Singletons are kept as their own clusters.
+  const parent = tickets.map((_, i) => i);
+  const find = (x) => {
+    while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+    return x;
+  };
+  const union = (a, b) => { parent[find(a)] = find(b); };
+
+  for (let i = 0; i < tickets.length; i++) {
+    for (let j = i + 1; j < tickets.length; j++) {
+      if (jaccard(tickets[i].keywords, tickets[j].keywords) >= threshold) {
+        union(i, j);
+      }
+    }
+  }
+
+  const groups = new Map();
+  for (let i = 0; i < tickets.length; i++) {
+    const root = find(i);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root).push(tickets[i]);
+  }
+  // Sort each cluster's tickets by created time for deterministic output.
+  return [...groups.values()].map((g) => g.sort((a, b) => a.created_ms - b.created_ms));
+}
+
+function normalizeSeverity(value) {
+  if (typeof value !== "string") return null;
+  const v = value.toLowerCase().trim();
+  if (SEVERITY_RANK[v] !== undefined) return v;
+  // Accept some aliases
+  if (v === "crit" || v === "critical" || v === "p1" || v === "sev1" || v === "sev-1") return "urgent";
+  if (v === "med" || v === "p2" || v === "sev2" || v === "sev-2") return "medium";
+  if (v === "p3" || v === "sev3" || v === "sev-3") return "high";
+  if (v === "p4" || v === "low" || v === "minor") return "low";
+  return null;
+}
+
+function parseIso(value) {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  // Reject non-ISO strings (must contain a 'T' or be a plain date)
+  if (!/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2})/.test(s) && !/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+  const ms = Date.parse(s);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+// ---------------------------------------------------------------------------
+// Input / utility plumbing
+// ---------------------------------------------------------------------------
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  if (process.env.RUNX_INPUTS_JSON) return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  return {
+    queue: parseInputValue(process.env.RUNX_INPUT_QUEUE),
+    context: parseInputValue(process.env.RUNX_INPUT_CONTEXT),
+    escalation_policy: parseInputValue(process.env.RUNX_INPUT_ESCALATION_POLICY),
+  };
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try { return JSON.parse(raw); } catch { return raw; }
+}
+
+function normalize(value) { return String(value ?? "").toLowerCase().replace(/\s+/g, " ").trim(); }
+function round(n) { return Math.round(n * 100) / 100; }
+function stringValue(value) { return typeof value === "string" && value.trim().length > 0 ? value.trim() : null; }
+function intPolicy(value, def) { return Number.isInteger(value) ? value : (typeof value === "number" ? Math.floor(value) : def); }
+function numPolicy(value, def) { return typeof value === "number" && Number.isFinite(value) ? value : def; }
+function objectValue(value, name) { if (!value || typeof value !== "object" || Array.isArray(value)) fail(name + " must be an object"); return value; }
+function fail(message) { process.stderr.write(message + "\n"); process.exit(64); }


### PR DESCRIPTION
## support-firewatch

Support-firewatch skill for Frantic bounty #80.

Reads a fixtured support thread and SLA policy, detects sentiment, SLA breach,
and churn-risk signals, and emits an escalation packet only when warranted.

### Contract

**Typed inputs:**
- `thread` — object with `customer` (string) and `turns` (array of `{author, text, timestamp}`)
- `sla_policy` — object with `response_time_minutes` (number) and optional `resolution_hours` (number)

**Typed outputs:**
- `signals` — `{sentiment, sla_breach, churn_risk}`
- `escalation` — `{needed, priority, context}`

### Harness (3 cases)
1. `sealed_escalation_flagged` — breached/negative thread → `escalation.needed: true`
2. `refused_no_escalation_healthy_thread` — healthy thread → `escalation.needed: false`
3. `stop_missing_required_inputs` — empty turns → stop/failure

### Safety
The escalation packet routes to a human approval inbox. The skill pages nobody,
reassigns nothing, and notifies no customer. Each signal is grounded in a
specific thread turn or policy clock.

### Registry
Published: `armstrongsam25/support-firewatch@sha-78522e303a2f`
