### PR TITLE
Add schema-guard skill: gated schema-compatibility checker

### DIFF
--- a/skills/schema-guard/SKILL.md
+++ b/skills/schema-guard/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: schema-guard
+description: Catch silent API and data contract breakage before a migration lands by diffing two JSON schemas, validating real sample payloads against both, and emitting a gated publish proposal only when the change passes the caller's compatibility policy.
+runx:
+  category: ops
+---
+
+# Schema Guard
+
+Schema Guard reads a current schema, a proposed schema, real sample payloads,
+and a compatibility policy. It reports every breaking change by field path,
+validates each sample against both schemas, writes migration notes, and emits a
+`publish_schema_proposal` only when the change is allowed. It never changes a
+live schema.
+
+The failure it prevents is the quiet one: a field removed, a type narrowed, an
+optional made required, and the first sign is a consumer erroring in
+production. Schema Guard turns that into a refusal at review time, with the
+exact field path and both contracts in hand.
+
+## What This Skill Does
+
+1. **Validate inputs.** Refuse when either schema, the sample array, or the
+   policy is missing or malformed. `breaking_allowed` must be an explicit
+   boolean; the skill does not guess intent.
+2. **Diff the schemas by field path.** Removed fields, changed types, narrowed
+   enums, optional-to-required flips, new required fields, and closing
+   `additionalProperties` are breaking. Added optional fields are additive.
+   Every breaking change carries `field_path`, `old_contract`, `new_contract`,
+   and the `policy_rule` that flagged it.
+3. **Enforce policy-protected fields.** Fields listed in
+   `compatibility_policy.required_fields` are breaking to remove or relax,
+   even where the general rules would only note it.
+4. **Validate real samples.** Each payload in `sample_payloads` is checked
+   against both schemas. A sample that passes the current schema and fails the
+   proposed one is direct evidence of breakage.
+5. **Report coverage honestly.** Proposed-schema fields no sample exercises
+   are named in `migration_notes`. An empty sample array is reported as empty
+   coverage, never treated as passing coverage.
+6. **Gate the proposal.** When the change is compatible (or breaking changes
+   exist but `breaking_allowed` is true), the output includes a
+   `publish_schema_proposal` with a version bump derived from
+   `versioning_rule`. The proposal is consumed by a schema-publisher executor
+   or a human approver; this skill performs no live schema write.
+
+## Refusals And Stops
+
+- Malformed or missing inputs exit with a usage refusal and no analysis.
+- Breaking changes (or samples broken by the proposal) with
+  `breaking_allowed: false` exit with a refusal: the full analysis is printed,
+  no `publish_schema_proposal` is emitted, and the receipt records a failed
+  run.
+- Sample coverage is never invented. Gaps are named; absent samples are
+  reported as absent.
+
+## Inputs
+
+- `current_schema` (required): the live contract as a JSON Schema object.
+  Supported subset: `type`, `properties`, `required`, `items`, `enum`,
+  `format`, `additionalProperties`.
+- `proposed_schema` (required): the proposed replacement, same subset.
+- `sample_payloads` (required): array of real payloads. Pass `[]` to state
+  that no samples exist.
+- `compatibility_policy` (required): `breaking_allowed` (boolean, required),
+  `required_fields` (array of policy-protected field paths),
+  `versioning_rule` (`semver`, `major-on-breaking`, or `minor-on-additive`).
+
+## Output Schema
+
+```yaml
+compatibility:
+  compatible: boolean            # no breaking changes and no samples broken
+  allowed_under_policy: boolean  # compatible, or breaking_allowed is true
+  breaking_changes:
+    - field_path: string
+      old_contract: string
+      new_contract: string
+      policy_rule: string
+  additive_changes:
+    - field_path: string
+      new_contract: string
+  samples_broken_by_proposal: [number]
+  policy:
+    breaking_allowed: boolean
+    required_fields: [string]
+    versioning_rule: string
+validation_results:
+  - payload_index: number
+    valid_against_current: boolean
+    valid_against_proposed: boolean
+    current_errors: [string]
+    proposed_errors: [string]
+migration_notes: [string]
+publish_schema_proposal:         # present only when allowed_under_policy
+  kind: schema_publish_proposal
+  gated: true
+  proposed_schema: object
+  version_bump: major | minor | patch
+  breaking_changes: []
+  migration_notes: [string]
+```
+
+## Quality Profile
+
+- Purpose: stop silent contract breakage before a schema migration lands.
+- Audience: API owners, data platform teams, and reviewers of schema PRs.
+- Artifact contract: compatibility verdict, per-field breaking changes,
+  per-sample validation results, migration notes, and a gated proposal.
+- Evidence bar: every breaking change cites a field path and both contracts;
+  every validation result cites the sample that produced it.
+- Safety bar: read-only, deterministic, no network calls, no live schema
+  writes; the proposal is a gated artifact for a downstream approver.
+- Stop conditions: malformed input, breaking changes under a strict policy,
+  or samples the proposal would break.

--- a/skills/schema-guard/X.yaml
+++ b/skills/schema-guard/X.yaml
@@ -1,0 +1,141 @@
+skill: schema-guard
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed-additive-change-emits-proposal
+      inputs:
+        current_schema:
+          type: object
+          required:
+            - id
+            - email
+          properties:
+            id:
+              type: string
+            email:
+              type: string
+              format: email
+            plan:
+              type: string
+              enum:
+                - free
+                - pro
+        proposed_schema:
+          type: object
+          required:
+            - id
+            - email
+          properties:
+            id:
+              type: string
+            email:
+              type: string
+              format: email
+            plan:
+              type: string
+              enum:
+                - free
+                - pro
+                - enterprise
+            display_name:
+              type: string
+        sample_payloads:
+          - id: usr_1
+            email: a@example.com
+            plan: free
+          - id: usr_2
+            email: b@example.com
+            plan: pro
+            display_name: Bee
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields:
+            - id
+            - email
+          versioning_rule: semver
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: refuses-breaking-change-no-proposal
+      inputs:
+        current_schema:
+          type: object
+          required:
+            - id
+            - email
+          properties:
+            id:
+              type: string
+            email:
+              type: string
+            legacy_code:
+              type: string
+            amount:
+              type: number
+        proposed_schema:
+          type: object
+          required:
+            - id
+            - email
+            - region
+          properties:
+            id:
+              type: string
+            email:
+              type: string
+            amount:
+              type: string
+            region:
+              type: string
+        sample_payloads:
+          - id: usr_1
+            email: a@example.com
+            legacy_code: LC-9
+            amount: 12.5
+        compatibility_policy:
+          breaking_allowed: false
+          required_fields:
+            - id
+            - email
+          versioning_rule: semver
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: failed
+
+runners:
+  guard:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      current_schema:
+        type: json
+        required: true
+        description: "The live contract as a JSON Schema object (type, properties, required, items, enum, format, additionalProperties)."
+      proposed_schema:
+        type: json
+        required: true
+        description: "The proposed replacement schema, same JSON Schema subset as current_schema."
+      sample_payloads:
+        type: json
+        required: true
+        description: "Array of real payloads to validate against both schemas. Pass [] to state that no samples exist; coverage is reported, never invented."
+      compatibility_policy:
+        type: json
+        required: true
+        description: "Policy object: breaking_allowed (boolean, required), required_fields (array of policy-protected field paths), versioning_rule (semver | major-on-breaking | minor-on-additive)."

--- a/skills/schema-guard/fixtures/additive-change.json
+++ b/skills/schema-guard/fixtures/additive-change.json
@@ -1,0 +1,30 @@
+{
+  "current_schema": {
+    "type": "object",
+    "required": ["id", "email"],
+    "properties": {
+      "id": { "type": "string" },
+      "email": { "type": "string", "format": "email" },
+      "plan": { "type": "string", "enum": ["free", "pro"] }
+    }
+  },
+  "proposed_schema": {
+    "type": "object",
+    "required": ["id", "email"],
+    "properties": {
+      "id": { "type": "string" },
+      "email": { "type": "string", "format": "email" },
+      "plan": { "type": "string", "enum": ["free", "pro", "enterprise"] },
+      "display_name": { "type": "string" }
+    }
+  },
+  "sample_payloads": [
+    { "id": "usr_1", "email": "a@example.com", "plan": "free" },
+    { "id": "usr_2", "email": "b@example.com", "plan": "pro", "display_name": "Bee" }
+  ],
+  "compatibility_policy": {
+    "breaking_allowed": false,
+    "required_fields": ["id", "email"],
+    "versioning_rule": "semver"
+  }
+}

--- a/skills/schema-guard/fixtures/breaking-change.json
+++ b/skills/schema-guard/fixtures/breaking-change.json
@@ -1,0 +1,30 @@
+{
+  "current_schema": {
+    "type": "object",
+    "required": ["id", "email"],
+    "properties": {
+      "id": { "type": "string" },
+      "email": { "type": "string" },
+      "legacy_code": { "type": "string" },
+      "amount": { "type": "number" }
+    }
+  },
+  "proposed_schema": {
+    "type": "object",
+    "required": ["id", "email", "region"],
+    "properties": {
+      "id": { "type": "string" },
+      "email": { "type": "string" },
+      "amount": { "type": "string" },
+      "region": { "type": "string" }
+    }
+  },
+  "sample_payloads": [
+    { "id": "usr_1", "email": "a@example.com", "legacy_code": "LC-9", "amount": 12.5 }
+  ],
+  "compatibility_policy": {
+    "breaking_allowed": false,
+    "required_fields": ["id", "email"],
+    "versioning_rule": "semver"
+  }
+}

--- a/skills/schema-guard/harness-evidence/local-harness.json
+++ b/skills/schema-guard/harness-evidence/local-harness.json
@@ -1,0 +1,15 @@
+{
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "assertion_errors": [],
+  "case_names": [
+    "sealed-additive-change-emits-proposal",
+    "refuses-breaking-change-no-proposal"
+  ],
+  "receipt_ids": [
+    "sha256:c6a3ce5183ad30d4ebee4673f3d988f228fbc5610326f2ca224df63de68b6f16",
+    "sha256:64a3b026eb18ca7d45b3a49019d3f0ce9df1b4ddbecfcb5eefb0c31a67ec5e43"
+  ],
+  "graph_case_count": 0
+}

--- a/skills/schema-guard/run.mjs
+++ b/skills/schema-guard/run.mjs
@@ -1,0 +1,368 @@
+// schema-guard: report breaking changes between two JSON schemas, validate
+// sample payloads against both, and emit a gated publish proposal only when
+// the change is compatible under the caller's policy. Read-only: no network,
+// no live schema writes. Exit 0 seals a compatible run; exit 65 refuses a
+// breaking or blocked change; exit 64 refuses malformed input.
+
+const EXIT_USAGE = 64;
+const EXIT_REFUSED = 65;
+
+function fail(code, message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function readJsonInput(name, { required = true } = {}) {
+  const raw = process.env[`RUNX_INPUT_${name.toUpperCase()}`];
+  if (raw === undefined || raw.trim() === "") {
+    if (required) fail(EXIT_USAGE, `${name} is required`);
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    fail(EXIT_USAGE, `${name} is not valid JSON`);
+  }
+}
+
+function isObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+// --- Schema walking -------------------------------------------------------
+// Supports the deterministic core of JSON Schema: type, properties, required,
+// items, enum, format, additionalProperties. Anything else is carried through
+// untouched and compared structurally.
+
+function schemaAt(schema, segment) {
+  if (!isObject(schema)) return undefined;
+  if (isObject(schema.properties) && segment in schema.properties) {
+    return schema.properties[segment];
+  }
+  return undefined;
+}
+
+function contractOf(schema) {
+  if (!isObject(schema)) return String(schema);
+  const parts = [];
+  if (schema.type) parts.push(`type=${JSON.stringify(schema.type)}`);
+  if (schema.enum) parts.push(`enum=${JSON.stringify(schema.enum)}`);
+  if (schema.format) parts.push(`format=${schema.format}`);
+  if (schema.additionalProperties === false) parts.push("additionalProperties=false");
+  return parts.length ? parts.join(" ") : "unconstrained";
+}
+
+function requiredSet(schema) {
+  return new Set(Array.isArray(schema?.required) ? schema.required : []);
+}
+
+function diffSchemas(current, proposed, policy) {
+  const breaking = [];
+  const additive = [];
+  const notes = [];
+  const policyRequired = new Set(
+    Array.isArray(policy.required_fields) ? policy.required_fields : []
+  );
+
+  function walk(cur, prop, path) {
+    const curProps = isObject(cur?.properties) ? cur.properties : {};
+    const propProps = isObject(prop?.properties) ? prop.properties : {};
+    const curReq = requiredSet(cur);
+    const propReq = requiredSet(prop);
+
+    for (const key of Object.keys(curProps)) {
+      const fieldPath = path ? `${path}.${key}` : key;
+      const c = curProps[key];
+      const p = propProps[key];
+
+      if (p === undefined) {
+        breaking.push({
+          field_path: fieldPath,
+          old_contract: contractOf(c),
+          new_contract: "absent",
+          policy_rule: policyRequired.has(fieldPath)
+            ? "required_fields: field is policy-protected and was removed"
+            : "field removed from schema",
+        });
+        continue;
+      }
+
+      const cType = JSON.stringify(c?.type ?? null);
+      const pType = JSON.stringify(p?.type ?? null);
+      if (cType !== pType) {
+        breaking.push({
+          field_path: fieldPath,
+          old_contract: contractOf(c),
+          new_contract: contractOf(p),
+          policy_rule: "field type changed",
+        });
+      }
+
+      if (Array.isArray(c?.enum) && Array.isArray(p?.enum)) {
+        const removedValues = c.enum.filter((v) => !p.enum.includes(v));
+        if (removedValues.length > 0) {
+          breaking.push({
+            field_path: fieldPath,
+            old_contract: contractOf(c),
+            new_contract: contractOf(p),
+            policy_rule: `enum narrowed: removed ${JSON.stringify(removedValues)}`,
+          });
+        } else if (p.enum.length > c.enum.length) {
+          notes.push(`${fieldPath}: enum widened (non-breaking for readers, check writers)`);
+        }
+      }
+
+      if (!curReq.has(key) && propReq.has(key)) {
+        breaking.push({
+          field_path: fieldPath,
+          old_contract: "optional",
+          new_contract: "required",
+          policy_rule: "optional field became required",
+        });
+      }
+      if (curReq.has(key) && !propReq.has(key)) {
+        if (policyRequired.has(fieldPath)) {
+          breaking.push({
+            field_path: fieldPath,
+            old_contract: "required",
+            new_contract: "optional",
+            policy_rule: "required_fields: policy-protected field was relaxed to optional",
+          });
+        } else {
+          notes.push(`${fieldPath}: required relaxed to optional (non-breaking for writers, check readers)`);
+        }
+      }
+
+      if (isObject(c) && isObject(p)) {
+        if (isObject(c.properties) || isObject(p.properties)) {
+          walk(c, p, fieldPath);
+        }
+        if (isObject(c.items) || isObject(p.items)) {
+          walk(
+            { properties: { "[]": c.items ?? {} } },
+            { properties: { "[]": p.items ?? {} } },
+            fieldPath
+          );
+        }
+      }
+    }
+
+    for (const key of Object.keys(propProps)) {
+      if (key in curProps) continue;
+      const fieldPath = path ? `${path}.${key}` : key;
+      if (propReq.has(key)) {
+        breaking.push({
+          field_path: fieldPath,
+          old_contract: "absent",
+          new_contract: `required ${contractOf(propProps[key])}`,
+          policy_rule: "new field added as required: existing writers will fail validation",
+        });
+      } else {
+        additive.push({ field_path: fieldPath, new_contract: contractOf(propProps[key]) });
+      }
+    }
+
+    if (cur?.additionalProperties !== false && prop?.additionalProperties === false) {
+      breaking.push({
+        field_path: path || "(root)",
+        old_contract: "additionalProperties allowed",
+        new_contract: "additionalProperties=false",
+        policy_rule: "schema closed to additional properties: existing extended payloads will fail",
+      });
+    }
+
+    for (const fieldPath of policyRequired) {
+      if (path === "" && !fieldPath.includes(".")) {
+        if (!(fieldPath in propProps) && fieldPath in curProps) continue; // already reported as removed
+        if (!(fieldPath in propProps) && !(fieldPath in curProps)) {
+          notes.push(`policy required_fields lists "${fieldPath}" but neither schema defines it`);
+        }
+      }
+    }
+  }
+
+  walk(current, proposed, "");
+  return { breaking, additive, notes };
+}
+
+// --- Sample validation ----------------------------------------------------
+
+function validateAgainst(schema, value, path, errors) {
+  if (!isObject(schema)) return;
+  const t = schema.type;
+  const typeOk = (want, v) => {
+    switch (want) {
+      case "object": return isObject(v);
+      case "array": return Array.isArray(v);
+      case "string": return typeof v === "string";
+      case "number": return typeof v === "number";
+      case "integer": return Number.isInteger(v);
+      case "boolean": return typeof v === "boolean";
+      case "null": return v === null;
+      default: return true;
+    }
+  };
+  if (t !== undefined) {
+    const wants = Array.isArray(t) ? t : [t];
+    if (!wants.some((w) => typeOk(w, value))) {
+      errors.push(`${path || "(root)"}: expected type ${JSON.stringify(t)}`);
+      return;
+    }
+  }
+  if (Array.isArray(schema.enum) && !schema.enum.some((v) => JSON.stringify(v) === JSON.stringify(value))) {
+    errors.push(`${path || "(root)"}: value not in enum ${JSON.stringify(schema.enum)}`);
+  }
+  if (isObject(value)) {
+    for (const req of requiredSet(schema)) {
+      if (!(req in value)) errors.push(`${path || "(root)"}: missing required field "${req}"`);
+    }
+    if (isObject(schema.properties)) {
+      for (const [k, v] of Object.entries(value)) {
+        if (k in schema.properties) {
+          validateAgainst(schema.properties[k], v, path ? `${path}.${k}` : k, errors);
+        } else if (schema.additionalProperties === false) {
+          errors.push(`${path || "(root)"}: unexpected field "${k}" (additionalProperties=false)`);
+        }
+      }
+    }
+  }
+  if (Array.isArray(value) && isObject(schema.items)) {
+    value.forEach((item, i) => validateAgainst(schema.items, item, `${path}[${i}]`, errors));
+  }
+}
+
+function coveredPaths(schema, value, out, path) {
+  if (!isObject(schema) || !isObject(schema.properties) || !isObject(value)) return;
+  for (const [k, sub] of Object.entries(schema.properties)) {
+    const fieldPath = path ? `${path}.${k}` : k;
+    if (k in value) {
+      out.add(fieldPath);
+      coveredPaths(sub, value[k], out, fieldPath);
+    }
+  }
+}
+
+function allPaths(schema, out, path) {
+  if (!isObject(schema) || !isObject(schema.properties)) return;
+  for (const [k, sub] of Object.entries(schema.properties)) {
+    const fieldPath = path ? `${path}.${k}` : k;
+    out.add(fieldPath);
+    allPaths(sub, out, fieldPath);
+  }
+}
+
+// --- Versioning -----------------------------------------------------------
+
+function proposeVersionBump(rule, hasBreaking, hasAdditive) {
+  switch (rule) {
+    case "semver":
+    case "major-on-breaking":
+      if (hasBreaking) return "major";
+      return hasAdditive ? "minor" : "patch";
+    case "minor-on-additive":
+      return hasAdditive || hasBreaking ? "minor" : "patch";
+    default:
+      return hasBreaking ? "major" : hasAdditive ? "minor" : "patch";
+  }
+}
+
+// --- Main -----------------------------------------------------------------
+
+const currentSchema = readJsonInput("current_schema");
+const proposedSchema = readJsonInput("proposed_schema");
+const samplePayloads = readJsonInput("sample_payloads");
+const policy = readJsonInput("compatibility_policy");
+
+if (!isObject(currentSchema)) fail(EXIT_USAGE, "current_schema must be a JSON object");
+if (!isObject(proposedSchema)) fail(EXIT_USAGE, "proposed_schema must be a JSON object");
+if (!Array.isArray(samplePayloads)) fail(EXIT_USAGE, "sample_payloads must be a JSON array");
+if (!isObject(policy)) fail(EXIT_USAGE, "compatibility_policy must be a JSON object");
+if (typeof policy.breaking_allowed !== "boolean") {
+  fail(EXIT_USAGE, "compatibility_policy.breaking_allowed must be a boolean");
+}
+
+const { breaking, additive, notes } = diffSchemas(currentSchema, proposedSchema, policy);
+
+const validationResults = samplePayloads.map((payload, index) => {
+  const currentErrors = [];
+  const proposedErrors = [];
+  validateAgainst(currentSchema, payload, "", currentErrors);
+  validateAgainst(proposedSchema, payload, "", proposedErrors);
+  return {
+    payload_index: index,
+    valid_against_current: currentErrors.length === 0,
+    valid_against_proposed: proposedErrors.length === 0,
+    current_errors: currentErrors,
+    proposed_errors: proposedErrors,
+  };
+});
+
+// Coverage is reported, never invented: fields no sample exercises are named.
+const proposedFieldPaths = new Set();
+allPaths(proposedSchema, proposedFieldPaths, "");
+const exercised = new Set();
+for (const payload of samplePayloads) coveredPaths(proposedSchema, payload, exercised, "");
+const uncovered = [...proposedFieldPaths].filter((p) => !exercised.has(p)).sort();
+
+const migrationNotes = [...notes];
+for (const b of breaking) {
+  migrationNotes.push(
+    `BREAKING ${b.field_path}: ${b.old_contract} -> ${b.new_contract} (${b.policy_rule})`
+  );
+}
+for (const a of additive) {
+  migrationNotes.push(`additive ${a.field_path}: ${a.new_contract}`);
+}
+if (samplePayloads.length === 0) {
+  migrationNotes.push("no sample payloads supplied: validation coverage is empty, not assumed");
+} else if (uncovered.length > 0) {
+  migrationNotes.push(`sample coverage gap: no sample exercises ${uncovered.join(", ")}`);
+}
+
+const samplesBrokenByProposal = validationResults.filter(
+  (r) => r.valid_against_current && !r.valid_against_proposed
+);
+
+const blockedByPolicy = breaking.length > 0 && policy.breaking_allowed !== true;
+const blockedBySamples = samplesBrokenByProposal.length > 0 && policy.breaking_allowed !== true;
+const compatible = breaking.length === 0 && samplesBrokenByProposal.length === 0;
+const allowed = compatible || policy.breaking_allowed === true;
+
+const compatibility = {
+  compatible,
+  allowed_under_policy: allowed,
+  breaking_changes: breaking,
+  additive_changes: additive,
+  samples_broken_by_proposal: samplesBrokenByProposal.map((r) => r.payload_index),
+  policy: {
+    breaking_allowed: policy.breaking_allowed === true,
+    required_fields: Array.isArray(policy.required_fields) ? policy.required_fields : [],
+    versioning_rule: typeof policy.versioning_rule === "string" ? policy.versioning_rule : "semver",
+  },
+};
+
+const output = {
+  compatibility,
+  validation_results: validationResults,
+  migration_notes: migrationNotes,
+};
+
+if (allowed) {
+  output.publish_schema_proposal = {
+    kind: "schema_publish_proposal",
+    gated: true,
+    note: "Proposal only. Consumed by a schema-publisher executor or a human approver; this skill performs no live schema write.",
+    proposed_schema: proposedSchema,
+    version_bump: proposeVersionBump(compatibility.policy.versioning_rule, breaking.length > 0, additive.length > 0),
+    breaking_changes: breaking,
+    migration_notes: migrationNotes,
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  process.exit(0);
+}
+
+process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+process.stderr.write(
+  `refused: ${breaking.length} breaking change(s), ${samplesBrokenByProposal.length} sample(s) broken, and compatibility_policy.breaking_allowed is false; no publish_schema_proposal emitted\n`
+);
+process.exit(EXIT_REFUSED);


### PR DESCRIPTION
Adds `skills/schema-guard`: a skill that diffs a current and proposed JSON schema by field path, validates real sample payloads against both, enforces a caller-supplied compatibility policy, and emits a gated `publish_schema_proposal` only when the change is allowed. It performs no live schema writes.

Package contents: `X.yaml`, `SKILL.md`, `run.mjs`, two fixtures (additive and breaking change), and local harness evidence.

Local harness passes both cases on runx-cli 0.6.16: `sealed-additive-change-emits-proposal` (sealed) and `refuses-breaking-change-no-proposal` (refused). Published to the registry as `cleo-poole/schema-guard@sha-aa5e9a8c8b4a` (digest `1181a7d9...`) from this revision.