### PR TITLE
Add data doctor skill

### DIFF
--- a/skills/data-doctor/SKILL.md
+++ b/skills/data-doctor/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: data-doctor
+version: 0.1.0
+description: Compute grounded missingness, uniqueness, type-drift, and range checks for a bounded dataset without mutating its rows.
+links:
+  source: https://github.com/runxhq/runx/tree/main/skills/data-doctor
+runx:
+  category: data
+  input_resolution:
+    required:
+      - dataset
+      - schema
+      - quality_rules
+---
+
+## What this skill does
+
+`data-doctor` evaluates a bounded JSON dataset against an explicit schema and
+quality rules. It computes row counts, per-column missingness, uniqueness,
+type drift, and configured numeric ranges. It returns findings,
+recommendations, and a read-only report.
+
+The skill never edits rows, invents columns, guesses anomaly causes, or writes
+to an external data system.
+
+## Inputs
+
+- `dataset`: an array of JSON objects.
+- `schema`: `{fields:{name:{type,required,unique}}}` where type is `string`,
+  `number`, `boolean`, or `object`.
+- `quality_rules`: optional `{max_missing_rate, ranges}` thresholds.
+
+## Outputs
+
+- `metrics`: row count and per-field missing, unique, and type-drift metrics.
+- `findings[]`: grounded checks with field, rule, observed value, and severity.
+- `recommendations[]`: bounded remediation suggestions tied to findings.
+- `report`: overall status plus check counts.
+
+Malformed rows or a missing schema return `status: refused` with no invented
+metrics. Valid empty datasets are allowed and report zero rows.
+
+## Example
+
+```bash
+runx skill ./skills/data-doctor \
+  --input-json dataset='[{"id":"a1","amount":10}]' \
+  --input-json schema='{"fields":{"id":{"type":"string","required":true,"unique":true},"amount":{"type":"number"}}}' \
+  --input-json quality_rules='{"max_missing_rate":0.1,"ranges":{"amount":{"min":0,"max":100}}}' \
+  --json
+```
+
+Verify the receipt with `runx verify --receipt <receipt.json> --json`.
+

--- a/skills/data-doctor/X.yaml
+++ b/skills/data-doctor/X.yaml
@@ -1,0 +1,95 @@
+skill: data-doctor
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: report-quality-findings
+      inputs:
+        dataset:
+          - {id: a1, email: one@example.test, amount: 10}
+          - {id: a2, email: null, amount: 250}
+          - {id: a2, email: three@example.test, amount: bad}
+        schema:
+          fields:
+            id: {type: string, required: true, unique: true}
+            email: {type: string, required: true}
+            amount: {type: number, required: true}
+        quality_rules:
+          max_missing_rate: 0.1
+          ranges:
+            amount: {min: 0, max: 100}
+      expect:
+        status: sealed
+    - name: report-healthy-dataset
+      inputs:
+        dataset:
+          - {id: b1, active: true, score: 85}
+          - {id: b2, active: false, score: 92}
+        schema:
+          fields:
+            id: {type: string, required: true, unique: true}
+            active: {type: boolean, required: true}
+            score: {type: number, required: true}
+        quality_rules:
+          max_missing_rate: 0
+          ranges:
+            score: {min: 0, max: 100}
+      expect:
+        status: sealed
+    - name: refuse-missing-schema
+      runner: manual-review
+      inputs:
+        reason: A schema is required before deterministic quality checks can run.
+      expect:
+        status: needs_agent
+
+emits:
+  - name: quality_report
+    packet: runx.decision.v1
+
+runners:
+  manual-review:
+    type: agent-task
+    agent: reviewer
+    task: data-doctor-manual-review
+    outputs:
+      decision: string
+      reason: string
+    inputs:
+      reason:
+        type: string
+        required: true
+  diagnose:
+    default: true
+    type: graph
+    inputs:
+      dataset:
+        type: json
+        required: true
+      schema:
+        type: json
+        required: true
+      quality_rules:
+        type: json
+        required: true
+    graph:
+      name: data-doctor
+      steps:
+        - id: diagnose
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - graph/diagnose/run.mjs
+          artifacts:
+            named_emits:
+              quality_report: quality_report
+            packets:
+              quality_report: runx.decision.v1
+

--- a/skills/data-doctor/fixtures/healthy-dataset.json
+++ b/skills/data-doctor/fixtures/healthy-dataset.json
@@ -1,0 +1,6 @@
+{
+  "dataset": [{"id":"b1","active":true,"score":85},{"id":"b2","active":false,"score":92}],
+  "schema": {"fields":{"id":{"type":"string","required":true,"unique":true},"active":{"type":"boolean","required":true},"score":{"type":"number","required":true}}},
+  "quality_rules": {"max_missing_rate":0,"ranges":{"score":{"min":0,"max":100}}}
+}
+

--- a/skills/data-doctor/fixtures/quality-findings.json
+++ b/skills/data-doctor/fixtures/quality-findings.json
@@ -1,0 +1,6 @@
+{
+  "dataset": [{"id":"a1","email":"one@example.test","amount":10},{"id":"a2","email":null,"amount":250},{"id":"a2","email":"three@example.test","amount":"bad"}],
+  "schema": {"fields":{"id":{"type":"string","required":true,"unique":true},"email":{"type":"string","required":true},"amount":{"type":"number","required":true}}},
+  "quality_rules": {"max_missing_rate":0.1,"ranges":{"amount":{"min":0,"max":100}}}
+}
+

--- a/skills/data-doctor/graph/diagnose/run.mjs
+++ b/skills/data-doctor/graph/diagnose/run.mjs
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+
+const input = readInputs();
+const dataset = input.dataset;
+const schema = object(input.schema);
+const fields = object(schema.fields);
+const rules = object(input.quality_rules);
+
+if (!Array.isArray(dataset) || !Object.keys(fields).length) {
+  emit({ status: "refused", refused_reason: "dataset must be an array and schema.fields must be non-empty", metrics: {}, findings: [], recommendations: [], report: { status: "refused", row_count: 0 } });
+  process.exit(0);
+}
+
+const malformed = dataset.map((row, index) => ({ row, index })).filter(({ row }) => !row || typeof row !== "object" || Array.isArray(row));
+if (malformed.length) {
+  emit({ status: "refused", refused_reason: `malformed rows at indexes: ${malformed.map(({ index }) => index).join(",")}`, metrics: {}, findings: [], recommendations: [], report: { status: "refused", row_count: dataset.length } });
+  process.exit(0);
+}
+
+const findings = [];
+const fieldMetrics = {};
+const maxMissingRate = finite(rules.max_missing_rate) ? Number(rules.max_missing_rate) : 1;
+const ranges = object(rules.ranges);
+
+for (const [field, definitionValue] of Object.entries(fields)) {
+  const definition = object(definitionValue);
+  const values = dataset.map((row) => row[field]);
+  const present = values.filter((value) => value !== null && value !== undefined && value !== "");
+  const missingCount = values.length - present.length;
+  const missingRate = dataset.length ? missingCount / dataset.length : 0;
+  const uniqueCount = new Set(present.map(stableValue)).size;
+  const typeDriftCount = present.filter((value) => !matchesType(value, definition.type)).length;
+  fieldMetrics[field] = { missing_count: missingCount, missing_rate: round(missingRate), unique_count: uniqueCount, type_drift_count: typeDriftCount };
+
+  if ((definition.required === true || missingRate > maxMissingRate) && missingCount > 0) addFinding(field, "missingness", round(missingRate), definition.required === true ? "error" : "warning");
+  if (definition.unique === true && uniqueCount < present.length) addFinding(field, "uniqueness", { unique_count: uniqueCount, present_count: present.length }, "error");
+  if (typeDriftCount > 0) addFinding(field, "type_drift", { expected: definition.type, count: typeDriftCount }, "error");
+
+  const range = object(ranges[field]);
+  if (Object.keys(range).length) {
+    const numeric = present.filter((value) => typeof value === "number" && Number.isFinite(value));
+    const below = finite(range.min) ? numeric.filter((value) => value < Number(range.min)).length : 0;
+    const above = finite(range.max) ? numeric.filter((value) => value > Number(range.max)).length : 0;
+    if (below + above > 0) addFinding(field, "range", { below_min: below, above_max: above, min: range.min ?? null, max: range.max ?? null }, "warning");
+  }
+}
+
+const recommendations = findings.map((finding) => ({ field: finding.field, rule: finding.rule, action: recommendation(finding.rule) }));
+emit({
+  status: "complete",
+  refused_reason: null,
+  metrics: { row_count: dataset.length, field_count: Object.keys(fields).length, fields: fieldMetrics },
+  findings,
+  recommendations,
+  report: { status: findings.some((finding) => finding.severity === "error") ? "unhealthy" : findings.length ? "needs_attention" : "healthy", row_count: dataset.length, finding_count: findings.length, recommendation_count: recommendations.length, dataset_mutated: false },
+});
+
+function addFinding(field, rule, observed, severity) { findings.push({ field, rule, observed, severity }); }
+function recommendation(rule) {
+  return ({ missingness: "Populate required values or document an allowed null policy.", uniqueness: "Resolve duplicate values before using this field as a key.", type_drift: "Normalize values to the declared schema type.", range: "Review out-of-range rows against the configured bounds." })[rule];
+}
+function matchesType(value, expected) {
+  if (expected === "object") return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  return ["string", "number", "boolean"].includes(expected) ? typeof value === expected && (expected !== "number" || Number.isFinite(value)) : true;
+}
+function stableValue(value) { return value && typeof value === "object" ? JSON.stringify(value) : `${typeof value}:${String(value)}`; }
+function round(value) { return Math.round(value * 10000) / 10000; }
+function finite(value) { return value !== null && value !== "" && Number.isFinite(Number(value)); }
+function object(value) { return value && typeof value === "object" && !Array.isArray(value) ? value : {}; }
+function emit(value) { process.stdout.write(`${JSON.stringify({ quality_report: value }, null, 2)}\n`); }
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  if (process.env.RUNX_INPUTS_JSON) return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  return {};
+}
+

--- a/skills/data-doctor/harness-evidence/local-harness.json
+++ b/skills/data-doctor/harness-evidence/local-harness.json
@@ -1,0 +1,9 @@
+{
+  "runx_version": "runx-cli 0.6.14",
+  "command": "runx harness ./skills/data-doctor",
+  "status": "passed",
+  "case_count": 3,
+  "assertion_error_count": 0,
+  "case_names": ["report-quality-findings", "report-healthy-dataset", "refuse-missing-schema"]
+}
+

--- a/skills/data-doctor/harness-evidence/report.md
+++ b/skills/data-doctor/harness-evidence/report.md
@@ -1,0 +1,9 @@
+# Data Doctor local harness
+
+- CLI: `runx-cli 0.6.14`
+- Command: `runx harness ./skills/data-doctor`
+- Result: 3 cases passed with zero assertion errors.
+- Quality-findings case covers missingness, duplicate ids, type drift, and numeric range anomalies.
+- Healthy case produces zero findings and a healthy report.
+- Missing-schema case stops at `needs_agent` before deterministic checks.
+- Output is read-only and reports `dataset_mutated: false`.


### PR DESCRIPTION
## Summary
- add a read-only `data-doctor` skill for bounded JSON datasets
- compute missingness, uniqueness, type drift, and configured range checks
- refuse malformed or schema-less inputs without inventing metrics

## Validation
- `runx-cli 0.6.14 skill inspect ./skills/data-doctor`
- `runx-cli 0.6.14 harness ./skills/data-doctor` (3/3 passed)