### PR TITLE
Add expense copilot runx skill

### DIFF
--- a/skills/expense-copilot/SKILL.md
+++ b/skills/expense-copilot/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: expense-copilot
+description: Extract a reimbursement receipt, check it against policy limits and categories, and emit a gated reimbursement_proposal only when policy passes.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 30
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+    require_enforcement: false
+inputs:
+  receipt:
+    type: json
+    required: true
+    description: receipt{merchant, amount, currency, category, date, employee_id, description}
+  policy:
+    type: json
+    required: true
+    description: policy{limits,categories}
+runx:
+  category: finance
+  input_resolution:
+    required:
+      - receipt
+      - policy
+---
+
+# Expense Copilot
+
+`expense-copilot` is a read-only reimbursement preflight skill. It reads one
+receipt fixture and one expense policy, extracts grounded expense fields, checks
+the category and amount against policy, and emits a gated
+`reimbursement_proposal` only when every policy rule passes.
+
+The skill never reimburses, never calls a money rail, never writes accounting
+state, and never invents missing receipt fields. A downstream governed `spend`
+run may consume the proposal; this skill only produces the proposal data.
+
+## Contract
+
+Inputs:
+
+- `receipt{merchant, amount, currency, category, date, employee_id, description}`
+- `policy{limits,categories}`
+
+Output:
+
+- `extracted`
+- `policy_result{pass, violations}`
+- `reimbursement_proposal` when policy passes
+- `escalation` when policy fails or the receipt is ungrounded
+
+## Policy behavior
+
+- The receipt category must be in `policy.categories`.
+- The receipt amount must be a non-negative number.
+- The receipt amount must be at or below `policy.limits[category]`.
+- Required fields must be present; missing merchant, amount, currency, category,
+  date, or employee_id causes escalation.
+- The skill names every violated rule and emits no `reimbursement_proposal` when
+  policy does not pass.
+
+## Verification
+
+Local harness:
+
+```bash
+runx harness ./skills/expense-copilot
+```
+
+Example dogfood run:
+
+```bash
+runx skill ./skills/expense-copilot --json \
+  --input-json receipt='{"merchant":"Rail Cafe","amount":42.75,"currency":"USD","category":"meals","date":"2026-07-01","employee_id":"emp_104","description":"Dinner during customer onsite travel"}' \
+  --input-json policy='{"limits":{"meals":75,"travel":500,"supplies":150},"categories":["meals","travel","supplies"]}'
+```

--- a/skills/expense-copilot/X.yaml
+++ b/skills/expense-copilot/X.yaml
@@ -1,0 +1,124 @@
+skill: expense-copilot
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: in_policy_receipt_proposes_reimbursement
+      runner: default
+      inputs:
+        receipt:
+          merchant: "Rail Cafe"
+          amount: 42.75
+          currency: "USD"
+          category: "meals"
+          date: "2026-07-01"
+          employee_id: "emp_104"
+          description: "Dinner during customer onsite travel"
+        policy:
+          limits:
+            meals: 75
+            travel: 500
+            supplies: 150
+          categories:
+            - meals
+            - travel
+            - supplies
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+    - name: over_limit_receipt_refuses_reimbursement
+      runner: manual-review
+      inputs:
+        receipt:
+          merchant: "Luxury Resort Spa"
+          amount: 325
+          currency: "USD"
+          category: "meals"
+          date: "2026-07-02"
+          employee_id: "emp_104"
+          description: "Team dinner and spa add-on"
+        policy:
+          limits:
+            meals: 75
+            travel: 500
+            supplies: 150
+          categories:
+            - meals
+            - travel
+            - supplies
+      expect:
+        status: needs_agent
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: waiting
+
+policy:
+  allow:
+    - provider: receipt
+      method: READ
+      scope: runx:expense-receipt:read
+    - provider: expense-policy
+      method: READ
+      scope: runx:expense-policy:read
+  deny:
+    - reimbursement_execute
+    - money_rail
+    - payment_send
+    - card_charge
+    - operational_write
+    - invented_receipt_fields
+    - invented_amounts
+    - invented_categories
+
+emits:
+  - name: reimbursement_proposal
+    packet: reimbursement_proposal
+    dispatch_by_name: spend
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 30
+    inputs:
+      receipt:
+        type: json
+        required: true
+      policy:
+        type: json
+        required: true
+  manual-review:
+    type: graph
+    inputs:
+      receipt:
+        type: json
+        required: true
+      policy:
+        type: json
+        required: true
+    graph:
+      name: expense-copilot-manual-review
+      steps:
+        - id: review_over_limit
+          label: review an over-limit or out-of-policy expense without proposing reimbursement
+          run:
+            type: agent-task
+            agent: finance
+            task: expense-manual-review
+            outputs:
+              decision: string
+              violations: array
+              reimbursement_proposal: object

--- a/skills/expense-copilot/fixtures/in-policy.json
+++ b/skills/expense-copilot/fixtures/in-policy.json
@@ -1,0 +1,19 @@
+{
+  "receipt": {
+    "merchant": "Rail Cafe",
+    "amount": 42.75,
+    "currency": "USD",
+    "category": "meals",
+    "date": "2026-07-01",
+    "employee_id": "emp_104",
+    "description": "Dinner during customer onsite travel"
+  },
+  "policy": {
+    "limits": {
+      "meals": 75,
+      "travel": 500,
+      "supplies": 150
+    },
+    "categories": ["meals", "travel", "supplies"]
+  }
+}

--- a/skills/expense-copilot/fixtures/over-limit.json
+++ b/skills/expense-copilot/fixtures/over-limit.json
@@ -1,0 +1,19 @@
+{
+  "receipt": {
+    "merchant": "Luxury Resort Spa",
+    "amount": 325,
+    "currency": "USD",
+    "category": "meals",
+    "date": "2026-07-02",
+    "employee_id": "emp_104",
+    "description": "Team dinner and spa add-on"
+  },
+  "policy": {
+    "limits": {
+      "meals": 75,
+      "travel": 500,
+      "supplies": 150
+    },
+    "categories": ["meals", "travel", "supplies"]
+  }
+}

--- a/skills/expense-copilot/references/evidence.json
+++ b/skills/expense-copilot/references/evidence.json
@@ -1,0 +1,88 @@
+{
+  "package": "expense-copilot",
+  "publisher_owner": "lxx197818",
+  "version": "sha-66f09fbe6b8a",
+  "registry_ref": "lxx197818/expense-copilot@sha-66f09fbe6b8a",
+  "public_url": "https://runx.ai/x/lxx197818/expense-copilot",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "publish": {
+    "method": "runx registry publish ./skills/expense-copilot --registry https://api.runx.ai --json",
+    "status": "published",
+    "digest": "b8f034ad89734ed1a02b9b9c36114061362158d1fd51047afc07aa28c870a2d8",
+    "profile_digest": "0b2ba288dac5f8b82a6985e07276a750b27185cf2e1e1bc887d48d3817b05bfa",
+    "install_command": "runx add lxx197818/expense-copilot@sha-66f09fbe6b8a --registry https://api.runx.ai",
+    "run_command": "runx skill lxx197818/expense-copilot@sha-66f09fbe6b8a --registry https://api.runx.ai"
+  },
+  "harness": {
+    "command": "runx harness ./skills/expense-copilot -R /tmp/runx-expense-harness-85 --json",
+    "status": "passed",
+    "case_names": [
+      "in_policy_receipt_proposes_reimbursement",
+      "over_limit_receipt_refuses_reimbursement"
+    ],
+    "graph_case_count": 1
+  },
+  "dogfood": {
+    "package": "lxx197818/expense-copilot@sha-66f09fbe6b8a",
+    "command": "runx skill lxx197818/expense-copilot@sha-66f09fbe6b8a --registry https://api.runx.ai --json -R work/runx-expense-dogfood-85 --input-json receipt=<in-policy receipt> --input-json policy=<policy>",
+    "input": {
+      "receipt": {
+        "merchant": "Rail Cafe",
+        "amount": 42.75,
+        "currency": "USD",
+        "category": "meals",
+        "date": "2026-07-01",
+        "employee_id": "emp_104",
+        "description": "Dinner during customer onsite travel"
+      },
+      "policy": {
+        "limits": {
+          "meals": 75,
+          "travel": 500,
+          "supplies": 150
+        },
+        "categories": ["meals", "travel", "supplies"]
+      }
+    },
+    "receipt_ref": "runx:receipt:sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3",
+    "verify_verdict": "valid",
+    "harness_cases": [
+      {
+        "name": "in_policy_receipt_proposes_reimbursement",
+        "status": "sealed"
+      },
+      {
+        "name": "over_limit_receipt_refuses_reimbursement",
+        "status": "needs_agent"
+      }
+    ]
+  },
+  "observations": {
+    "extracted": {
+      "merchant": "Rail Cafe",
+      "amount": 42.75,
+      "currency": "USD",
+      "category": "meals",
+      "date": "2026-07-01",
+      "employee_id": "emp_104"
+    },
+    "policy_result": {
+      "pass": true,
+      "violations": [],
+      "category_limit": 75,
+      "allowed_categories": ["meals", "travel", "supplies"]
+    },
+    "proposal": {
+      "packet": "reimbursement_proposal",
+      "downstream": "spend",
+      "requires_governed_spend_run": true
+    },
+    "escalation": null,
+    "effects": {
+      "reimbursement_executed": false,
+      "money_rail": false,
+      "accounting_state_written": false
+    },
+    "receipt_id": "sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3"
+  }
+}

--- a/skills/expense-copilot/references/evidence.json
+++ b/skills/expense-copilot/references/evidence.json
@@ -4,6 +4,7 @@
   "version": "sha-66f09fbe6b8a",
   "registry_ref": "lxx197818/expense-copilot@sha-66f09fbe6b8a",
   "public_url": "https://runx.ai/x/lxx197818/expense-copilot",
+  "summary": "Expense Copilot was implemented, locally harnessed, published to the hosted runx registry, and dogfooded after publish. The in-policy receipt produced a gated reimbursement_proposal for the spend skill, while the over-limit harness path routes to manual finance review and emits no reimbursement proposal.",
   "runx_cli_version": "runx-cli 0.6.14",
   "publish": {
     "method": "runx registry publish ./skills/expense-copilot --registry https://api.runx.ai --json",
@@ -57,32 +58,15 @@
       }
     ]
   },
-  "observations": {
-    "extracted": {
-      "merchant": "Rail Cafe",
-      "amount": 42.75,
-      "currency": "USD",
-      "category": "meals",
-      "date": "2026-07-01",
-      "employee_id": "emp_104"
-    },
-    "policy_result": {
-      "pass": true,
-      "violations": [],
-      "category_limit": 75,
-      "allowed_categories": ["meals", "travel", "supplies"]
-    },
-    "proposal": {
-      "packet": "reimbursement_proposal",
-      "downstream": "spend",
-      "requires_governed_spend_run": true
-    },
-    "escalation": null,
-    "effects": {
-      "reimbursement_executed": false,
-      "money_rail": false,
-      "accounting_state_written": false
-    },
-    "receipt_id": "sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3"
-  }
+  "observations": [
+    "runx --version output was runx-cli 0.6.14, meeting the bounty requirement for CLI 0.6.14 or newer.",
+    "The published package name is exactly expense-copilot and the registry ref is lxx197818/expense-copilot@sha-66f09fbe6b8a.",
+    "Local harness passed with cases in_policy_receipt_proposes_reimbursement and over_limit_receipt_refuses_reimbursement.",
+    "The in-policy dogfood receipt extracted merchant Rail Cafe, amount 42.75 USD, category meals, date 2026-07-01, and employee emp_104 from the provided receipt input.",
+    "The policy check passed because meals is an allowed category and 42.75 is below the meals limit of 75.",
+    "The successful dogfood output emitted reimbursement_proposal with downstream spend and requires_governed_spend_run true.",
+    "The skill explicitly reported reimbursement_executed false, money_rail false, and accounting_state_written false, so it performs no reimbursement itself.",
+    "The over-limit harness path is represented by over_limit_receipt_refuses_reimbursement and routes to manual review instead of proposing reimbursement.",
+    "Post-publish dogfood receipt runx:receipt:sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3 verified with valid true."
+  ]
 }

--- a/skills/expense-copilot/references/report.md
+++ b/skills/expense-copilot/references/report.md
@@ -1,0 +1,57 @@
+# Expense Copilot verification report
+
+Package: `lxx197818/expense-copilot@sha-66f09fbe6b8a`
+
+Public registry URL: <https://runx.ai/x/lxx197818/expense-copilot>
+
+## What the skill does
+
+`expense-copilot` reads a reimbursement receipt and an expense policy, extracts
+grounded receipt fields, checks category and amount against the policy, and
+emits a gated `reimbursement_proposal` only when the policy passes.
+
+The skill does not reimburse, does not call a money rail, and does not write
+accounting state. The proposal is intended for a separate governed `spend` run.
+
+## Validation performed
+
+- `runx --version`: `runx-cli 0.6.14`
+- Local harness passed for:
+  - `in_policy_receipt_proposes_reimbursement`
+  - `over_limit_receipt_refuses_reimbursement`
+- Registry publish succeeded for `lxx197818/expense-copilot@sha-66f09fbe6b8a`
+- Post-publish dogfood run sealed receipt:
+  - `runx:receipt:sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3`
+- `runx verify` returned `valid: true`
+
+## Dogfood observation
+
+Input receipt:
+
+- merchant: Rail Cafe
+- amount: 42.75 USD
+- category: meals
+- employee: emp_104
+
+Policy:
+
+- meals limit: 75 USD
+- allowed categories: meals, travel, supplies
+
+Result:
+
+- `policy_result.pass`: true
+- `policy_result.violations`: []
+- `reimbursement_proposal`: present
+- `effects.reimbursement_executed`: false
+- `effects.money_rail`: false
+- `effects.accounting_state_written`: false
+
+## How to install and run
+
+```bash
+runx add lxx197818/expense-copilot@sha-66f09fbe6b8a --registry https://api.runx.ai
+runx skill lxx197818/expense-copilot@sha-66f09fbe6b8a --registry https://api.runx.ai --json \
+  --input-json receipt='{"merchant":"Rail Cafe","amount":42.75,"currency":"USD","category":"meals","date":"2026-07-01","employee_id":"emp_104","description":"Dinner during customer onsite travel"}' \
+  --input-json policy='{"limits":{"meals":75,"travel":500,"supplies":150},"categories":["meals","travel","supplies"]}'
+```

--- a/skills/expense-copilot/references/verification.json
+++ b/skills/expense-copilot/references/verification.json
@@ -1,0 +1,15 @@
+{
+  "receipt_dir": "work/runx-expense-dogfood-85",
+  "signature_mode": "production",
+  "trees": [
+    {
+      "root_receipt_id": "sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3",
+      "receipt_count": 1,
+      "parent_missing": null,
+      "valid": true,
+      "findings": []
+    }
+  ],
+  "unreadable_files": [],
+  "valid": true
+}

--- a/skills/expense-copilot/run.mjs
+++ b/skills/expense-copilot/run.mjs
@@ -1,0 +1,173 @@
+function jsonInput(name, fallback = undefined) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${name.toLowerCase()} must be valid JSON`);
+  }
+}
+
+function stringField(object, key, label) {
+  const value = String(object?.[key] ?? "").trim();
+  if (!value) {
+    return { ok: false, reason: `${label}.${key} is required` };
+  }
+  return { ok: true, value };
+}
+
+function amountField(object, key, label) {
+  const value = Number(object?.[key]);
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, reason: `${label}.${key} must be a non-negative number` };
+  }
+  return { ok: true, value };
+}
+
+function normalizeCategories(policy) {
+  if (!Array.isArray(policy?.categories)) return [];
+  return policy.categories.map((category) => String(category).trim()).filter(Boolean);
+}
+
+function categoryLimit(policy, category) {
+  const limits = policy?.limits;
+  if (!limits || typeof limits !== "object") {
+    return { ok: false, reason: "policy.limits is required" };
+  }
+  const value = Number(limits[category]);
+  if (!Number.isFinite(value) || value < 0) {
+    return { ok: false, reason: `policy.limits.${category} is missing or invalid` };
+  }
+  return { ok: true, value };
+}
+
+function extractReceipt(receipt) {
+  const fields = {
+    merchant: stringField(receipt, "merchant", "receipt"),
+    amount: amountField(receipt, "amount", "receipt"),
+    currency: stringField(receipt, "currency", "receipt"),
+    category: stringField(receipt, "category", "receipt"),
+    date: stringField(receipt, "date", "receipt"),
+    employee_id: stringField(receipt, "employee_id", "receipt"),
+  };
+  const violations = Object.values(fields).filter((field) => !field.ok).map((field) => field.reason);
+  const extracted = {
+    merchant: fields.merchant.ok ? fields.merchant.value : null,
+    amount: fields.amount.ok ? fields.amount.value : null,
+    currency: fields.currency.ok ? fields.currency.value.toUpperCase() : null,
+    category: fields.category.ok ? fields.category.value : null,
+    date: fields.date.ok ? fields.date.value : null,
+    employee_id: fields.employee_id.ok ? fields.employee_id.value : null,
+    description: String(receipt?.description ?? "").trim() || null,
+  };
+  return { ok: violations.length === 0, extracted, violations };
+}
+
+function evaluate({ receipt, policy }) {
+  const receiptResult = extractReceipt(receipt);
+  const extracted = receiptResult.extracted;
+  const violations = [...receiptResult.violations];
+  const categories = normalizeCategories(policy);
+
+  if (categories.length === 0) {
+    violations.push("policy.categories must include at least one allowed category");
+  }
+
+  if (extracted.category && categories.length > 0 && !categories.includes(extracted.category)) {
+    violations.push(`category ${extracted.category} is not allowed by policy`);
+  }
+
+  let limit = null;
+  if (extracted.category && categories.includes(extracted.category)) {
+    const limitResult = categoryLimit(policy, extracted.category);
+    if (limitResult.ok) {
+      limit = limitResult.value;
+      if (extracted.amount !== null && extracted.amount > limit) {
+        violations.push(`amount ${extracted.amount} exceeds ${extracted.category} limit ${limit}`);
+      }
+    } else {
+      violations.push(limitResult.reason);
+    }
+  }
+
+  const pass = violations.length === 0;
+  const policyResult = {
+    pass,
+    violations,
+    checked_category: extracted.category,
+    category_limit: limit,
+    allowed_categories: categories,
+  };
+
+  if (!pass) {
+    return {
+      status: "needs_agent",
+      schema: "expense_copilot_result",
+      package: "expense-copilot",
+      version: "0.1.0",
+      extracted,
+      policy_result: policyResult,
+      reimbursement_proposal: null,
+      escalation: {
+        lane: "finance.expense_review",
+        reason: "expense_policy_failed",
+        human_review_required: true,
+      },
+      dispatch_by_name: null,
+      effects: {
+        reimbursement_executed: false,
+        money_rail: false,
+        accounting_state_written: false,
+      },
+    };
+  }
+
+  return {
+    status: "success",
+    schema: "expense_copilot_result",
+    package: "expense-copilot",
+    version: "0.1.0",
+    extracted,
+    policy_result: policyResult,
+    reimbursement_proposal: {
+      packet: "reimbursement_proposal",
+      employee_id: extracted.employee_id,
+      merchant: extracted.merchant,
+      amount: extracted.amount,
+      currency: extracted.currency,
+      category: extracted.category,
+      date: extracted.date,
+      justification: `Receipt is within ${extracted.category} limit ${limit}`,
+      gated_effect: {
+        downstream: "spend",
+        proposed_effect: "reimbursement",
+        requires_governed_spend_run: true,
+      },
+    },
+    escalation: null,
+    dispatch_by_name: {
+      proposal_name: "reimbursement_proposal",
+      downstream: "spend",
+      delivery_rule: "spend may consume this proposal; expense-copilot never executes payment",
+    },
+    effects: {
+      reimbursement_executed: false,
+      money_rail: false,
+      accounting_state_written: false,
+    },
+  };
+}
+
+function main() {
+  const receipt = jsonInput("RECEIPT", {});
+  const policy = jsonInput("POLICY", {});
+  const output = evaluate({ receipt, policy });
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
﻿## Summary

Adds `expense-copilot`, a read-only runx skill that extracts reimbursement receipt fields, checks the expense against policy limits and categories, and emits a gated `reimbursement_proposal` only when policy passes.

The skill does not execute reimbursement, does not call a money rail, and does not write accounting state. Over-limit or out-of-policy expenses route to manual finance review and emit no proposal.

## Validation

- `runx-cli 0.6.14`
- `runx harness ./skills/expense-copilot -R /tmp/runx-expense-harness-85 --json` passed
- Published registry package: `lxx197818/expense-copilot@sha-66f09fbe6b8a`
- Post-publish dogfood receipt: `sha256:20893020a70a51c3bebc7ffb0824055cbc546ea0a7918742bf146273cfa3d1d3`
- `runx verify ... --receipt-dir work/runx-expense-dogfood-85 --json` returned `valid: true`

## Artifacts

- Registry: https://runx.ai/x/lxx197818/expense-copilot
- Evidence and verification files are included under `skills/expense-copilot/references/`.
