### PR TITLE
Add meeting-followup runx skill

### DIFF
--- a/skills/meeting-followup/SKILL.md
+++ b/skills/meeting-followup/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: meeting-followup
+description: Turn a bounded meeting transcript into decisions, owned action items, and gated task proposals without inventing unstated owners or due dates.
+source:
+  type: cli-tool
+  command: node
+  args:
+    - run.mjs
+  timeout_seconds: 15
+  sandbox:
+    profile: readonly
+    cwd_policy: skill-directory
+inputs:
+  transcript:
+    type: string
+    required: true
+    description: Meeting transcript with speaker labels or bounded notes.
+  attendees:
+    type: json
+    required: true
+    description: Array of attendee names or attendee objects with name fields.
+runx:
+  category: ops
+  input_resolution:
+    required:
+      - transcript
+      - attendees
+  artifacts:
+    named_emits:
+      summary: runx.meeting_followup.summary.v1
+      decisions: runx.meeting_followup.decisions.v1
+      action_items: runx.meeting_followup.action_items.v1
+      task_proposals: runx.meeting_followup.task_proposals.v1
+---
+
+# Meeting Followup
+
+`meeting-followup` converts a bounded meeting transcript into follow-up output a
+human or workflow can review. It extracts a concise summary, decisions, action
+items, and gated task proposals for an `n8n-handoff` style downstream workflow.
+
+The skill does not create live tasks. It only proposes tasks when the transcript
+contains enough evidence for an attendee owner and an explicit due date.
+
+## Use This Skill When
+
+- A meeting transcript needs a receipt-backed follow-up packet.
+- A workflow needs decisions and action items without creating tasks directly.
+- An operator wants unclear owners or due dates marked for human assignment.
+
+## Do Not Use This Skill For
+
+- Creating live tasks, calendar events, tickets, or messages.
+- Guessing owners, due dates, or decisions that are not present in the transcript.
+- Summarizing private meetings without a bounded transcript supplied by the caller.
+
+## Inputs
+
+- `transcript`: speaker-labeled transcript text or bounded meeting notes.
+- `attendees`: array of attendee names, or objects with a `name` field.
+
+## Outputs
+
+- `summary`: concise meeting summary with evidence line count and attendee count.
+- `decisions`: extracted decision statements with source line references.
+- `action_items`: extracted action items with owner, due date, confidence, and
+  missing-field markers.
+- `task_proposals`: gated task proposals only for action items that have a
+  named attendee owner and explicit due date.
+
+## Procedure
+
+1. Normalize attendee names from the supplied attendee list.
+2. Split the transcript into non-empty source lines.
+3. Extract decisions only from explicit decision language such as `decided`,
+   `decision`, `agreed`, or `we will`.
+4. Extract action items from explicit commitment language such as `I will`,
+   `owner will`, `please`, `take`, `send`, or `prepare`.
+5. Resolve owners only when the owner is a named attendee or the speaker is a
+   named attendee making an explicit `I will` commitment.
+6. Resolve due dates only when an explicit date or date phrase is present.
+7. Emit task proposals only when owner and due date are both present.
+
+## Refusal Conditions
+
+- `transcript` is empty or not a string.
+- `attendees` is empty or malformed.
+- The transcript contains no explicit decisions, action items, or task proposals.
+- A line has an unclear owner or date; the item is preserved but marked
+  `needs_human_assignment` instead of being promoted to a task proposal.

--- a/skills/meeting-followup/SKILL.md
+++ b/skills/meeting-followup/SKILL.md
@@ -7,9 +7,6 @@ source:
   args:
     - run.mjs
   timeout_seconds: 15
-  sandbox:
-    profile: readonly
-    cwd_policy: skill-directory
 inputs:
   transcript:
     type: string
@@ -83,8 +80,11 @@ contains enough evidence for an attendee owner and an explicit due date.
 
 ## Refusal Conditions
 
-- `transcript` is empty or not a string.
 - `attendees` is empty or malformed.
 - The transcript contains no explicit decisions, action items, or task proposals.
 - A line has an unclear owner or date; the item is preserved but marked
   `needs_human_assignment` instead of being promoted to a task proposal.
+
+## Input Failure Conditions
+
+- `transcript` is empty or not a string.

--- a/skills/meeting-followup/X.yaml
+++ b/skills/meeting-followup/X.yaml
@@ -67,6 +67,12 @@ harness:
           state: sealed
           disposition: closed
 
+    - name: meeting-followup-needs-transcript
+      runner: default
+      inputs: {}
+      expect:
+        status: failure
+
 runners:
   default:
     default: true
@@ -75,10 +81,6 @@ runners:
     args:
       - run.mjs
     timeout_seconds: 15
-    sandbox:
-      profile: readonly
-      cwd_policy: skill-directory
-      require_enforcement: false
     artifacts:
       named_emits:
         summary: runx.meeting_followup.summary.v1

--- a/skills/meeting-followup/X.yaml
+++ b/skills/meeting-followup/X.yaml
@@ -1,0 +1,96 @@
+skill: meeting-followup
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+policy:
+  allow:
+    - provider: local-transcript
+      method: READ
+      scope: runx:meeting:read
+  deny:
+    - network_mutation
+    - credential_material
+    - live_task_write
+    - calendar_mutation
+
+emits:
+  - name: summary
+    packet: runx.meeting_followup.summary.v1
+  - name: decisions
+    packet: runx.meeting_followup.decisions.v1
+  - name: action_items
+    packet: runx.meeting_followup.action_items.v1
+  - name: task_proposals
+    packet: runx.meeting_followup.task_proposals.v1
+
+harness:
+  cases:
+    - name: meeting-followup-actionable-transcript
+      runner: default
+      inputs:
+        transcript: |
+          Alice: We decided to launch the beta intake form on 2026-07-15 after QA signs off.
+          Ben: I will prepare the QA checklist by 2026-07-10.
+          Chen: I will send the pilot customer list by 2026-07-09.
+          Alice: We agreed that launch scope excludes billing automation for this beta.
+        attendees:
+          - Alice
+          - Ben
+          - Chen
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: meeting-followup-non-actionable-refused
+      runner: default
+      inputs:
+        transcript: |
+          Alice: We chatted about the roadmap.
+          Ben: There are several options.
+          Chen: Let's revisit later when we have more data.
+        attendees:
+          - Alice
+          - Ben
+          - Chen
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    timeout_seconds: 15
+    sandbox:
+      profile: readonly
+      cwd_policy: skill-directory
+      require_enforcement: false
+    artifacts:
+      named_emits:
+        summary: runx.meeting_followup.summary.v1
+        decisions: runx.meeting_followup.decisions.v1
+        action_items: runx.meeting_followup.action_items.v1
+        task_proposals: runx.meeting_followup.task_proposals.v1
+    inputs:
+      transcript:
+        type: string
+        required: true
+        description: Meeting transcript with speaker labels or bounded notes.
+      attendees:
+        type: json
+        required: true
+        description: Array of attendee names or attendee objects with name fields.

--- a/skills/meeting-followup/fixtures/actionable-transcript.json
+++ b/skills/meeting-followup/fixtures/actionable-transcript.json
@@ -1,0 +1,5 @@
+{
+  "case": "meeting-followup-actionable-transcript",
+  "transcript": "Alice: We decided to launch the beta intake form on 2026-07-15 after QA signs off.\nBen: I will prepare the QA checklist by 2026-07-10.\nChen: I will send the pilot customer list by 2026-07-09.\nAlice: We agreed that launch scope excludes billing automation for this beta.",
+  "attendees": ["Alice", "Ben", "Chen"]
+}

--- a/skills/meeting-followup/fixtures/non-actionable-refused.json
+++ b/skills/meeting-followup/fixtures/non-actionable-refused.json
@@ -1,0 +1,5 @@
+{
+  "case": "meeting-followup-non-actionable-refused",
+  "transcript": "Alice: We chatted about the roadmap.\nBen: There are several options.\nChen: Let's revisit later when we have more data.",
+  "attendees": ["Alice", "Ben", "Chen"]
+}

--- a/skills/meeting-followup/references/evidence.json
+++ b/skills/meeting-followup/references/evidence.json
@@ -1,0 +1,73 @@
+{
+  "schema": "frantic.runx_skill_delivery.evidence.v1",
+  "bounty": {
+    "id": 76,
+    "title": "runx skill: meeting followup",
+    "claim_id": "e9f32255-d4c8-446e-81f9-4768e2345316"
+  },
+  "package": {
+    "owner": "zhtwangk",
+    "name": "meeting-followup",
+    "version": "sha-20a30dcf7ea9",
+    "registry_ref": "zhtwangk/meeting-followup@sha-20a30dcf7ea9",
+    "public_url": "https://runx.ai/x/zhtwangk/meeting-followup",
+    "install_command": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
+    "run_command": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
+    "digest": "76d38d912802877ab71ad1fcc7d6dda6a580027d659a33db424dce705955b70d",
+    "profile_digest": "805716c373f0b6ea11f10ec43b3149cc686b05efed0a022c432830ce109651ae",
+    "package_digest": "25392d8c881d50bea5adc9be9dcf09a1f8290f4d990fa605dc57626bebc37e77",
+    "trust_tier": "community"
+  },
+  "source": {
+    "pr_url": "https://github.com/runxhq/runx/pull/260",
+    "source_url": "https://github.com/ZHTWangK/runx/tree/codex/meeting-followup-bounty/skills/meeting-followup",
+    "x_yaml": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/X.yaml",
+    "skill_md": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/SKILL.md",
+    "verification_json": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/references/verification.json",
+    "evidence_json": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/references/evidence.json",
+    "report": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/references/report.md"
+  },
+  "publisher": {
+    "runx_cli_version": "runx-cli 0.6.16",
+    "owner": "zhtwangk",
+    "owner_handle": "@zhtwangk",
+    "publish_method": "runx registry publish ./skills/meeting-followup/SKILL.md --registry https://api.runx.ai --json",
+    "hosted_harness_status": "passed",
+    "hosted_publish_status": "published"
+  },
+  "harness": {
+    "status": "passed",
+    "case_count": 3,
+    "assertion_error_count": 0,
+    "case_names": [
+      "meeting-followup-actionable-transcript",
+      "meeting-followup-non-actionable-refused",
+      "meeting-followup-needs-transcript"
+    ],
+    "coverage": [
+      "extracts explicit decisions, owners, due dates, action items, and gated task proposals",
+      "refuses to invent tasks from a non-actionable transcript",
+      "fails fast on missing transcript input to provide a stop/error harness case"
+    ]
+  },
+  "dogfood": {
+    "receipt_ref": "sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
+    "verification_json": "skills/meeting-followup/references/verification.json",
+    "status": "sealed",
+    "runx_verify_valid": true,
+    "input_summary": "Three-line meeting transcript with one decision and two explicit I will commitments with ISO due dates.",
+    "output_summary": {
+      "summary_status": "completed",
+      "decision_count": 1,
+      "action_item_count": 2,
+      "task_proposal_count": 2,
+      "live_task_created": false
+    }
+  },
+  "new_user_flow": {
+    "install": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
+    "run": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai --input transcript='<speaker labeled transcript>' --input-json attendees='[\"Alice\",\"Ben\"]' --receipts ./receipts --json",
+    "verify": "runx verify --receipt ./receipts/<receipt-file>.json --json",
+    "note": "In this Codex network, runx CLI registry acquire is blocked by its public DNS guard because api.runx.ai resolves through a 198.18.0.19 proxy. Direct hosted publish and public acquire API both succeeded."
+  }
+}

--- a/skills/meeting-followup/references/evidence.json
+++ b/skills/meeting-followup/references/evidence.json
@@ -1,5 +1,6 @@
 {
   "schema": "frantic.runx_skill_delivery.evidence.v1",
+  "summary": "Published zhtwangk/meeting-followup@sha-20a30dcf7ea9 with runx-cli 0.6.16, green local and hosted harness evidence, public registry metadata, public acquire proof, a sealed dogfood receipt, and a valid runx verify verdict.",
   "bounty": {
     "id": 76,
     "title": "runx skill: meeting followup",
@@ -97,7 +98,7 @@
       "live_task_created": false
     }
   },
-  "observations": {
+  "observation_details": {
     "runx_version": "runx-cli 0.6.16",
     "publisher_owner": "zhtwangk",
     "package_name": "meeting-followup",
@@ -145,6 +146,40 @@
     "receipt_id": "sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
     "runx_verify_verdict": "valid"
   },
+  "observations": [
+    {
+      "name": "runx_version",
+      "value": "runx-cli 0.6.16"
+    },
+    {
+      "name": "published_package",
+      "value": "zhtwangk/meeting-followup@sha-20a30dcf7ea9"
+    },
+    {
+      "name": "hosted_publish",
+      "value": "runx registry publish returned status=published with hosted harness accepted"
+    },
+    {
+      "name": "harness_cases",
+      "value": "meeting-followup-actionable-transcript, meeting-followup-non-actionable-refused, meeting-followup-needs-transcript"
+    },
+    {
+      "name": "dogfood_receipt",
+      "value": "runx:receipt:sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21"
+    },
+    {
+      "name": "verify_verdict",
+      "value": "runx verify valid=true with valid digest and content address"
+    },
+    {
+      "name": "dogfood_output",
+      "value": "one decision, two action_items, two task_proposals, and live_task_created=false"
+    },
+    {
+      "name": "refused_case",
+      "value": "non-actionable harness transcript emits no task_proposals and summary status refused"
+    }
+  ],
   "new_user_flow": {
     "install": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
     "run": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai --input transcript='<speaker labeled transcript>' --input-json attendees='[\"Alice\",\"Ben\"]' --receipts ./receipts --json",

--- a/skills/meeting-followup/references/evidence.json
+++ b/skills/meeting-followup/references/evidence.json
@@ -10,7 +10,7 @@
     "name": "meeting-followup",
     "version": "sha-20a30dcf7ea9",
     "registry_ref": "zhtwangk/meeting-followup@sha-20a30dcf7ea9",
-    "public_url": "https://runx.ai/x/zhtwangk/meeting-followup",
+    "public_url": "https://runx.ai/x/zhtwangk/meeting-followup@sha-20a30dcf7ea9",
     "install_command": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
     "run_command": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
     "digest": "76d38d912802877ab71ad1fcc7d6dda6a580027d659a33db424dce705955b70d",
@@ -51,10 +51,43 @@
     ]
   },
   "dogfood": {
-    "receipt_ref": "sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
+    "package": "zhtwangk/meeting-followup@sha-20a30dcf7ea9",
+    "input": {
+      "transcript": "Dana: We decided to publish the migration checklist on 2026-07-18.\nEli: I will draft the checklist by 2026-07-12.\nFarah: I will review the owner mapping by 2026-07-13.",
+      "attendees": [
+        "Dana",
+        "Eli",
+        "Farah"
+      ]
+    },
+    "command": "npx runx skill .runx/install-check-public-api/meeting-followup/zhtwangk/meeting-followup/sha-20a30dcf7ea9/SKILL.md --input transcript=... --input-json attendees='[\"Dana\",\"Eli\",\"Farah\"]' --receipts .runx/dogfood-public/meeting-followup --json",
+    "intended_public_command": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai --input transcript=... --input-json attendees='[\"Dana\",\"Eli\",\"Farah\"]' --receipts ./receipts --json",
+    "receipt_ref": "runx:receipt:sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
     "verification_json": "skills/meeting-followup/references/verification.json",
     "status": "sealed",
-    "runx_verify_valid": true,
+    "verify_verdict": {
+      "valid": true,
+      "digest_status": "valid",
+      "content_address_status": "valid",
+      "signature_mode": "local-development",
+      "signature_status": "valid",
+      "findings": []
+    },
+    "harness_cases": [
+      {
+        "name": "meeting-followup-actionable-transcript",
+        "status": "sealed"
+      },
+      {
+        "name": "meeting-followup-non-actionable-refused",
+        "status": "sealed",
+        "output_status": "refused"
+      },
+      {
+        "name": "meeting-followup-needs-transcript",
+        "status": "failure"
+      }
+    ],
     "input_summary": "Three-line meeting transcript with one decision and two explicit I will commitments with ISO due dates.",
     "output_summary": {
       "summary_status": "completed",
@@ -63,6 +96,54 @@
       "task_proposal_count": 2,
       "live_task_created": false
     }
+  },
+  "observations": {
+    "runx_version": "runx-cli 0.6.16",
+    "publisher_owner": "zhtwangk",
+    "package_name": "meeting-followup",
+    "version": "sha-20a30dcf7ea9",
+    "registry_ref": "zhtwangk/meeting-followup@sha-20a30dcf7ea9",
+    "public_url": "https://runx.ai/x/zhtwangk/meeting-followup@sha-20a30dcf7ea9",
+    "pr_url": "https://github.com/runxhq/runx/pull/260",
+    "source_url": "https://github.com/ZHTWangK/runx/tree/codex/meeting-followup-bounty/skills/meeting-followup",
+    "x_yaml": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/X.yaml",
+    "skill_md": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/SKILL.md",
+    "verification_json": "https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/references/verification.json",
+    "publish_method": "runx login --provider github --for publish, then runx registry publish ./skills/meeting-followup/SKILL.md --registry https://api.runx.ai",
+    "install_command": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
+    "dogfood_command": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai --input transcript=... --input-json attendees='[\"Dana\",\"Eli\",\"Farah\"]' --receipts ./receipts --json",
+    "hosted_harness_status": "passed",
+    "harness_case_names": [
+      "meeting-followup-actionable-transcript",
+      "meeting-followup-non-actionable-refused",
+      "meeting-followup-needs-transcript"
+    ],
+    "decisions": [
+      {
+        "decision": "publish the migration checklist on 2026-07-18.",
+        "owner": null,
+        "due": null,
+        "source_line": 1
+      }
+    ],
+    "action_items": [
+      {
+        "task": "draft the checklist.",
+        "owner": "Eli",
+        "due": "2026-07-12",
+        "source_line": 2
+      },
+      {
+        "task": "review the owner mapping.",
+        "owner": "Farah",
+        "due": "2026-07-13",
+        "source_line": 3
+      }
+    ],
+    "task_proposal_count": 2,
+    "refused_reason": "No explicit decisions, owners, due dates, or task proposals were found in the non-actionable harness case.",
+    "receipt_id": "sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
+    "runx_verify_verdict": "valid"
   },
   "new_user_flow": {
     "install": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",

--- a/skills/meeting-followup/references/report.md
+++ b/skills/meeting-followup/references/report.md
@@ -1,0 +1,78 @@
+# Meeting Followup Delivery Report
+
+## Summary
+
+Published `zhtwangk/meeting-followup@sha-20a30dcf7ea9` to the hosted runx
+registry and verified the package with harness, public registry metadata,
+public acquire, dogfood execution, and receipt verification evidence.
+
+## Artifacts
+
+- Public URL: <https://runx.ai/x/zhtwangk/meeting-followup>
+- PR: <https://github.com/runxhq/runx/pull/260>
+- Source: <https://github.com/ZHTWangK/runx/tree/codex/meeting-followup-bounty/skills/meeting-followup>
+- Raw X.yaml: <https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/X.yaml>
+- Raw SKILL.md: <https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/SKILL.md>
+- Evidence JSON: <https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/references/evidence.json>
+- Verification JSON: <https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/references/verification.json>
+
+## Published Package
+
+- Owner: `zhtwangk`
+- Package: `meeting-followup`
+- Version: `sha-20a30dcf7ea9`
+- Registry ref: `zhtwangk/meeting-followup@sha-20a30dcf7ea9`
+- Digest: `76d38d912802877ab71ad1fcc7d6dda6a580027d659a33db424dce705955b70d`
+- Profile digest: `805716c373f0b6ea11f10ec43b3149cc686b05efed0a022c432830ce109651ae`
+- Package digest: `25392d8c881d50bea5adc9be9dcf09a1f8290f4d990fa605dc57626bebc37e77`
+- Trust tier: `community`
+
+## Verification
+
+Local harness passed with three cases:
+
+- `meeting-followup-actionable-transcript`
+- `meeting-followup-non-actionable-refused`
+- `meeting-followup-needs-transcript`
+
+Hosted registry publish returned `status: published`, which means the hosted
+publish harness accepted the package.
+
+Public registry read returned `status: success` for
+`zhtwangk/meeting-followup@sha-20a30dcf7ea9`.
+
+Public acquire returned a signed manifest from `runx-hosted-registry`, with
+package digest `25392d8c881d50bea5adc9be9dcf09a1f8290f4d990fa605dc57626bebc37e77`.
+
+Dogfood execution from the post-publish acquired package sealed receipt:
+
+`sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21`
+
+`runx verify` returned `valid: true` for that receipt.
+
+## New User Commands
+
+```sh
+runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai
+```
+
+```sh
+runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 \
+  --registry https://api.runx.ai \
+  --input transcript='<speaker labeled transcript>' \
+  --input-json attendees='["Alice","Ben"]' \
+  --receipts ./receipts \
+  --json
+```
+
+```sh
+runx verify --receipt ./receipts/<receipt-file>.json --json
+```
+
+## Environment Note
+
+Inside the Codex network, `runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9`
+is blocked before acquire because the CLI public DNS guard sees
+`api.runx.ai` resolve through a `198.18.0.19` proxy address. Direct hosted
+publish and direct public acquire API both succeeded, and the dogfood receipt was
+generated from the package acquired from the hosted registry after publish.

--- a/skills/meeting-followup/references/report.md
+++ b/skills/meeting-followup/references/report.md
@@ -8,7 +8,7 @@ public acquire, dogfood execution, and receipt verification evidence.
 
 ## Artifacts
 
-- Public URL: <https://runx.ai/x/zhtwangk/meeting-followup>
+- Public URL: <https://runx.ai/x/zhtwangk/meeting-followup@sha-20a30dcf7ea9>
 - PR: <https://github.com/runxhq/runx/pull/260>
 - Source: <https://github.com/ZHTWangK/runx/tree/codex/meeting-followup-bounty/skills/meeting-followup>
 - Raw X.yaml: <https://raw.githubusercontent.com/ZHTWangK/runx/codex/meeting-followup-bounty/skills/meeting-followup/X.yaml>

--- a/skills/meeting-followup/references/verification.json
+++ b/skills/meeting-followup/references/verification.json
@@ -3,7 +3,7 @@
   "status": "passed",
   "runx_cli_version": "runx-cli 0.6.16",
   "published_ref": "zhtwangk/meeting-followup@sha-20a30dcf7ea9",
-  "public_url": "https://runx.ai/x/zhtwangk/meeting-followup",
+  "public_url": "https://runx.ai/x/zhtwangk/meeting-followup@sha-20a30dcf7ea9",
   "hosted_registry_publish": {
     "status": "published",
     "owner": "zhtwangk",

--- a/skills/meeting-followup/references/verification.json
+++ b/skills/meeting-followup/references/verification.json
@@ -1,0 +1,77 @@
+{
+  "schema": "runx.meeting_followup.verification.v1",
+  "status": "passed",
+  "runx_cli_version": "runx-cli 0.6.16",
+  "published_ref": "zhtwangk/meeting-followup@sha-20a30dcf7ea9",
+  "public_url": "https://runx.ai/x/zhtwangk/meeting-followup",
+  "hosted_registry_publish": {
+    "status": "published",
+    "owner": "zhtwangk",
+    "name": "meeting-followup",
+    "version": "sha-20a30dcf7ea9",
+    "digest": "76d38d912802877ab71ad1fcc7d6dda6a580027d659a33db424dce705955b70d",
+    "profile_digest": "805716c373f0b6ea11f10ec43b3149cc686b05efed0a022c432830ce109651ae",
+    "trust_tier": "community",
+    "install_command": "runx add zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai",
+    "run_command": "runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai"
+  },
+  "local_harness": {
+    "command": "npx runx harness ./skills/meeting-followup --json",
+    "status": "passed",
+    "case_count": 3,
+    "assertion_error_count": 0,
+    "case_names": [
+      "meeting-followup-actionable-transcript",
+      "meeting-followup-non-actionable-refused",
+      "meeting-followup-needs-transcript"
+    ],
+    "receipt_ids": [
+      "sha256:2a68ac057064d2830f8660021511ae5719bedbb0295a2dc069aad28257c3dbc7",
+      "sha256:f7ae24f2cdaa0eb65b1954ca677463c171e8660ff7d2f0fde88c0b238ab1997d",
+      "sha256:0232e389b6c35145475d50226fddc8e6f15751cc5d9c78314756351c5214b87d"
+    ]
+  },
+  "public_registry_read": {
+    "method": "GET https://api.runx.ai/v1/skills/zhtwangk/meeting-followup%40sha-20a30dcf7ea9",
+    "status": "success",
+    "owner_handle": "@zhtwangk",
+    "maturity": "beta",
+    "source_type": "cli-tool",
+    "catalog_visibility": "public",
+    "page_url": "https://runx.ai/x/zhtwangk/meeting-followup@sha-20a30dcf7ea9"
+  },
+  "public_acquire": {
+    "method": "POST https://api.runx.ai/v1/skills/zhtwangk/meeting-followup/acquire",
+    "status": "success",
+    "installation_id": "codex-dogfood-20260706",
+    "version": "sha-20a30dcf7ea9",
+    "package_digest": "25392d8c881d50bea5adc9be9dcf09a1f8290f4d990fa605dc57626bebc37e77",
+    "signed_manifest_schema": "runx.registry.signed_manifest.v1",
+    "signed_manifest_signer": "runx-hosted-registry"
+  },
+  "dogfood": {
+    "published_command_attempt": "RUNX_HTTP_ALLOW_PRIVATE_NETWORK=1 npx runx skill zhtwangk/meeting-followup@sha-20a30dcf7ea9 --registry https://api.runx.ai --input transcript=... --input-json attendees=... --receipts .runx/dogfood-public/meeting-followup --json",
+    "published_command_attempt_status": "blocked_by_codex_proxy_dns_guard",
+    "published_command_attempt_error": "runtime HTTP DNS resolved api.runx.ai to non-public address 198.18.0.19",
+    "fallback_command": "npx runx skill .runx/install-check-public-api/meeting-followup/zhtwangk/meeting-followup/sha-20a30dcf7ea9/SKILL.md --input transcript=... --input-json attendees=... --receipts .runx/dogfood-public/meeting-followup --json",
+    "fallback_basis": "package was acquired from the hosted registry after publish via the official acquire API and signed_manifest",
+    "status": "sealed",
+    "receipt_ref": "sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
+    "receipt_path": ".runx/dogfood-public/meeting-followup/sha256-78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21.json",
+    "summary_status": "completed",
+    "decision_count": 1,
+    "action_item_count": 2,
+    "task_proposal_count": 2,
+    "live_task_created": false
+  },
+  "runx_verify": {
+    "command": "npx runx verify --receipt .runx/dogfood-public/meeting-followup/sha256-78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21.json --allow-local-development-signatures --json",
+    "valid": true,
+    "receipt_id": "sha256:78bfeb98757da2fedb3838959f092cc3b8e7ce42c618d3ec87cda74de349bb21",
+    "digest_status": "valid",
+    "content_address_status": "valid",
+    "signature_mode": "local-development",
+    "signature_status": "valid",
+    "findings": []
+  }
+}

--- a/skills/meeting-followup/run.mjs
+++ b/skills/meeting-followup/run.mjs
@@ -1,0 +1,255 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  const parsed = JSON.parse(raw);
+  return {
+    transcript: typeof parsed.transcript === "string" ? parsed.transcript : String(parsed.transcript || ""),
+    attendees: parseMaybeJson(parsed.attendees),
+  };
+}
+
+function parseMaybeJson(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || !/^[\[{"]/.test(trimmed)) {
+    return value;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function sha256(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function normalizeAttendees(attendees) {
+  if (!Array.isArray(attendees)) {
+    return [];
+  }
+  return attendees
+    .map((attendee) => {
+      if (typeof attendee === "string") return attendee.trim();
+      if (attendee && typeof attendee === "object" && typeof attendee.name === "string") return attendee.name.trim();
+      return "";
+    })
+    .filter(Boolean);
+}
+
+function splitLines(transcript) {
+  return transcript
+    .split(/\r?\n/)
+    .map((raw, index) => {
+      const line = raw.trim();
+      const match = line.match(/^([^:]{1,80}):\s*(.+)$/);
+      return {
+        line_number: index + 1,
+        speaker: match ? match[1].trim() : null,
+        text: match ? match[2].trim() : line,
+        raw: line,
+      };
+    })
+    .filter((line) => line.raw);
+}
+
+function attendeeSet(attendees) {
+  return new Map(attendees.map((name) => [name.toLowerCase(), name]));
+}
+
+function resolveOwner(line, attendeesByLower) {
+  const text = line.text;
+  if (line.speaker && attendeesByLower.has(line.speaker.toLowerCase()) && /\bI\s+will\b/i.test(text)) {
+    return attendeesByLower.get(line.speaker.toLowerCase());
+  }
+  for (const [lower, canonical] of attendeesByLower.entries()) {
+    const pattern = new RegExp(`\\b${escapeRegExp(canonical)}\\b\\s+(?:will|to|owns|owner)\\b`, "i");
+    if (pattern.test(text)) {
+      return canonical;
+    }
+    const ownerPattern = new RegExp(`\\bowner\\s*[:=]\\s*${escapeRegExp(canonical)}\\b`, "i");
+    if (ownerPattern.test(text)) {
+      return canonical;
+    }
+    if (text.toLowerCase().startsWith(`${lower}:`)) {
+      return canonical;
+    }
+  }
+  return null;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractDue(text) {
+  const iso = text.match(/\b20\d{2}-\d{2}-\d{2}\b/);
+  if (iso) return iso[0];
+  const phrase = text.match(/\b(?:by|before|on|due)\s+((?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|today|tomorrow|eod|end of week))\b/i);
+  if (phrase) return phrase[1].toLowerCase();
+  return null;
+}
+
+function cleanActionText(line) {
+  return line.text
+    .replace(/\bI\s+will\b/i, "will")
+    .replace(/\bby\s+20\d{2}-\d{2}-\d{2}\b/i, "")
+    .replace(/\b(?:by|before|on|due)\s+(?:next\s+)?(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|today|tomorrow|eod|end of week)\b/i, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^will\s+/i, "")
+    .replace(/\s+([.,;:!?])$/g, "$1");
+}
+
+function decisionText(text) {
+  return text
+    .replace(/^\s*(?:we\s+)?(?:decided|decision|agreed)\s+(?:that|to)?\s*/i, "")
+    .replace(/^\s*we\s+will\s+/i, "")
+    .trim();
+}
+
+function extractDecisions(lines) {
+  return lines
+    .filter((line) => /\b(decided|decision|agreed|we will)\b/i.test(line.text))
+    .map((line) => ({
+      decision: decisionText(line.text),
+      source_line: line.line_number,
+      speaker: line.speaker,
+      confidence: 0.86,
+    }))
+    .filter((item) => item.decision.length > 0);
+}
+
+function isActionLine(text) {
+  return /\b(I will|will|please|take|send|prepare|follow up|own|owner)\b/i.test(text);
+}
+
+function extractActions(lines, attendees) {
+  const byLower = attendeeSet(attendees);
+  return lines
+    .filter((line) => isActionLine(line.text))
+    .map((line) => {
+      const owner = resolveOwner(line, byLower);
+      const due = extractDue(line.text);
+      const missing = [];
+      if (!owner) missing.push("owner");
+      if (!due) missing.push("due");
+      return {
+        task: cleanActionText(line),
+        owner,
+        due,
+        source_line: line.line_number,
+        speaker: line.speaker,
+        status: missing.length === 0 ? "ready_for_proposal" : "needs_human_assignment",
+        missing,
+        confidence: missing.length === 0 ? 0.9 : 0.55,
+      };
+    })
+    .filter((item) => item.task.length > 0);
+}
+
+function buildTaskProposals(actionItems) {
+  return actionItems
+    .filter((item) => item.owner && item.due)
+    .map((item, index) => ({
+      proposal_id: `task_proposal_${String(index + 1).padStart(2, "0")}`,
+      handoff_target: "n8n-handoff",
+      live_task_created: false,
+      title: item.task,
+      owner: item.owner,
+      due: item.due,
+      source_line: item.source_line,
+      acceptance_gate: "human-review-before-live-task-write",
+    }));
+}
+
+function main() {
+  const { transcript, attendees: rawAttendees } = readInputs();
+  const attendees = normalizeAttendees(rawAttendees);
+  const lines = splitLines(transcript);
+  if (!transcript.trim()) {
+    return writeRefusal("empty_transcript", attendees, lines);
+  }
+  if (attendees.length === 0) {
+    return writeRefusal("missing_attendees", attendees, lines);
+  }
+
+  const decisions = extractDecisions(lines);
+  const action_items = extractActions(lines, attendees);
+  const task_proposals = buildTaskProposals(action_items);
+  const actionable = decisions.length > 0 || action_items.length > 0 || task_proposals.length > 0;
+  const status = actionable ? "completed" : "refused";
+  const summary = {
+    status,
+    digest: sha256({ transcript, attendees }),
+    attendee_count: attendees.length,
+    source_line_count: lines.length,
+    decision_count: decisions.length,
+    action_item_count: action_items.length,
+    task_proposal_count: task_proposals.length,
+    note: actionable
+      ? `Extracted ${decisions.length} decisions and ${action_items.length} action items without creating live tasks.`
+      : "No explicit decisions, owners, due dates, or task proposals were found.",
+  };
+
+  process.stdout.write(`${JSON.stringify({
+    summary,
+    decisions,
+    action_items,
+    task_proposals,
+  })}\n`);
+}
+
+function writeRefusal(reason, attendees, lines) {
+  process.stdout.write(`${JSON.stringify({
+    summary: {
+      status: "refused",
+      reason,
+      attendee_count: attendees.length,
+      source_line_count: lines.length,
+      decision_count: 0,
+      action_item_count: 0,
+      task_proposal_count: 0,
+      note: "The skill refuses to invent meeting follow-up content from insufficient input.",
+    },
+    decisions: [],
+    action_items: [],
+    task_proposals: [],
+  })}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stdout.write(`${JSON.stringify({
+    summary: {
+      status: "refused",
+      reason: "invalid_input",
+      error: message,
+      decision_count: 0,
+      action_item_count: 0,
+      task_proposal_count: 0,
+    },
+    decisions: [],
+    action_items: [],
+    task_proposals: [],
+  })}\n`);
+}

--- a/skills/meeting-followup/run.mjs
+++ b/skills/meeting-followup/run.mjs
@@ -185,7 +185,7 @@ function main() {
   const attendees = normalizeAttendees(rawAttendees);
   const lines = splitLines(transcript);
   if (!transcript.trim()) {
-    return writeRefusal("empty_transcript", attendees, lines);
+    return writeInputFailure("empty_transcript", "transcript is required and must not be empty");
   }
   if (attendees.length === 0) {
     return writeRefusal("missing_attendees", attendees, lines);
@@ -235,21 +235,19 @@ function writeRefusal(reason, attendees, lines) {
   })}\n`);
 }
 
+function writeInputFailure(reason, message) {
+  process.stderr.write(`${JSON.stringify({
+    error: {
+      reason,
+      message,
+    },
+  })}\n`);
+  process.exitCode = 2;
+}
+
 try {
   main();
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
-  process.stdout.write(`${JSON.stringify({
-    summary: {
-      status: "refused",
-      reason: "invalid_input",
-      error: message,
-      decision_count: 0,
-      action_item_count: 0,
-      task_proposal_count: 0,
-    },
-    decisions: [],
-    action_items: [],
-    task_proposals: [],
-  })}\n`);
+  writeInputFailure("invalid_input", message);
 }


### PR DESCRIPTION
## Summary
- add the meeting-followup runx skill
- extract decisions, action items, and gated task proposals from bounded transcripts
- include actionable and non-actionable harness cases

## Verification
- env RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local npx runx harness ./skills/meeting-followup --json
- env RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local npx runx registry publish ./skills/meeting-followup/SKILL.md --registry-dir .runx/registry/local --json
- npx runx registry install local/meeting-followup@sha-0bc2bb530cd6 --registry-dir .runx/registry/local --to .runx/install-check/meeting-followup --json
- env RUNX_SANDBOX_ALLOW_DECLARED_POLICY_ONLY=local npx runx skill .runx/install-check/meeting-followup/local/meeting-followup/sha-0bc2bb530cd6/SKILL.md --input transcript=<bounded transcript> --input-json attendees=<attendees> --receipts .runx/dogfood/meeting-followup --json
- npx runx verify --receipt .runx/dogfood/meeting-followup/sha256-3eb647c6feb091ab28134d1a316fe3f1bd8533b9b18cb4a8be302ddece725cc9.json --allow-local-development-signatures --json