### PR TITLE
Add support-desk runx skill

### DIFF
--- a/skills/support-desk/SKILL.md
+++ b/skills/support-desk/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: support-desk
+version: "0.1.0"
+description: Turn a bounded support thread plus docs and policy into the next safe operator move without sending messages or mutating support systems.
+---
+# support-desk
+
+`support-desk` turns a messy customer support thread into the next safe operator
+move. It reads a bounded support thread, public docs or source snippets,
+customer context that has already been approved for support use, and a support
+policy. It emits exactly one proposal lane:
+
+- `reply_only` for a docs-grounded answer that still requires a human or send-as
+  gate before delivery.
+- `issue_intake_proposal` for a reproducible product bug or docs gap that should
+  be handed to issue-intake.
+- `followup_plan` when the customer needs more information or context before a
+  safe answer exists.
+- `manual_review` when the request depends on private account state, billing,
+  security, abuse, legal, identity, or unsupported claims.
+
+The skill never sends a customer message, opens an issue, mutates an account,
+changes billing, changes permissions, or calls an external support system. It
+only produces a cited decision packet that another governed lane can review.
+
+## Inputs
+
+- `support_thread`: array of support messages or a bounded object containing
+  subject/body/messages.
+- `docs_corpus`: optional array of public docs snippets with `id`, `title`,
+  `url`, and `text`.
+- `source_catalog`: optional alternative source list with the same shape as
+  `docs_corpus`.
+- `customer_context`: optional public-safe context such as plan, product area,
+  region, or prior non-private summary.
+- `support_policy`: optional policy fields:
+  - `safe_reply_topics`
+  - `issue_intake_keywords`
+  - `sensitive_topics`
+  - `product_name`
+  - `support_signature`
+
+## Decision rules
+
+1. Normalize the support thread and summarize the request.
+2. Treat billing, password, account access, security, abuse, legal, private
+   state, payment, bank, identity, or credential requests as `manual_review`.
+3. Match answerable claims only against supplied docs/source snippets.
+4. Use `reply_only` only when at least one cited doc supports the answer and no
+   sensitive/private-state topic is present.
+5. Use `issue_intake_proposal` when the thread describes a reproducible product
+   bug or docs gap and the packet can cite the thread and relevant docs.
+6. Use `followup_plan` when the request is not sensitive but lacks enough docs or
+   customer detail for a safe answer.
+7. Keep unsupported facts in `followup_plan` or `manual_review`; do not invent
+   account state or product behavior.
+8. Record the lane rationale, confidence, citations, missing context, and
+   side-effect boundary in the output.
+
+## Output schema
+
+The runner emits `runx.support_desk.v1`:
+
+```json
+{
+  "support_summary": {
+    "request": "Customer asks why domain verification is pending.",
+    "message_count": 2,
+    "customer_context_used": ["account_tier", "region"]
+  },
+  "context_findings": [
+    {
+      "claim": "Domain verification can remain pending during DNS propagation.",
+      "citation": "docs-domain-verify",
+      "source_url": "https://docs.example.test/domain-verification"
+    }
+  ],
+  "decision": {
+    "lane": "reply_only",
+    "rationale": "The question is answerable from supplied DNS docs and does not require private account state.",
+    "confidence": 0.86
+  },
+  "reply_only": {
+    "subject": "Re: domain verification pending",
+    "body": "...",
+    "send_gate": "requires_human_or_send_as_approval"
+  },
+  "issue_intake_proposal": null,
+  "followup_plan": null,
+  "manual_review": null,
+  "evidence": {
+    "side_effects": "none",
+    "docs_used": ["docs-domain-verify"],
+    "unsupported_claims": [],
+    "sensitive_topics": [],
+    "harness_case_names": ["docs-grounded-reply-only", "sensitive-billing-security-manual-review"]
+  }
+}
+```
+
+Exactly one proposal field is non-null. Every answerable claim includes a
+citation to supplied docs or source snippets.
+
+## Worked example
+
+```bash
+runx skill ./skills/support-desk \
+  --runner support \
+  --input-json support_thread='[
+    {"role":"customer","body":"I added the DNS TXT record but verification is pending. What should I check?"}
+  ]' \
+  --input-json docs_corpus='[
+    {"id":"docs-domain-verify","title":"Domain verification DNS checks","url":"https://docs.example.test/domain-verification","text":"Domain verification requires the exact TXT value and DNS propagation can take up to 24 hours."}
+  ]' \
+  --input-json support_policy='{"product_name":"ExampleDesk","safe_reply_topics":["dns","domain verification"]}' \
+  --json
+```
+
+Expected result: `decision.lane = reply_only`, `context_findings` cites the docs,
+and the reply remains a proposal gated by a downstream sender.
+
+## Validation
+
+Run from the repository root:
+
+```bash
+runx harness ./skills/support-desk
+```
+
+Expected harness cases:
+
+- `docs-grounded-reply-only`: sealed, docs-grounded reply proposal.
+- `sensitive-billing-security-manual-review`: sealed manual-review packet with
+  no reply, no issue mutation, and no account or billing action.
+
+## Safety boundary
+
+This skill is intentionally non-mutating. It does not authenticate to support
+systems, inspect private accounts, issue refunds, reset passwords, send emails,
+open tickets, create issues, or make legal/security decisions. It produces a
+reviewable packet for another governed lane.
+

--- a/skills/support-desk/SKILL.md
+++ b/skills/support-desk/SKILL.md
@@ -88,12 +88,13 @@ The runner emits `runx.support_desk.v1`:
   "issue_intake_proposal": null,
   "followup_plan": null,
   "manual_review": null,
+  "status": "ready",
   "evidence": {
     "side_effects": "none",
     "docs_used": ["docs-domain-verify"],
     "unsupported_claims": [],
     "sensitive_topics": [],
-    "harness_case_names": ["docs-grounded-reply-only", "sensitive-billing-security-manual-review"]
+    "harness_case_names": ["docs-grounded-reply-only", "sensitive-billing-security-manual-review", "missing-thread-failure"]
   }
 }
 ```
@@ -132,6 +133,8 @@ Expected harness cases:
 - `docs-grounded-reply-only`: sealed, docs-grounded reply proposal.
 - `sensitive-billing-security-manual-review`: sealed manual-review packet with
   no reply, no issue mutation, and no account or billing action.
+- `missing-thread-failure`: failure stop when the required support thread is
+  missing.
 
 ## Safety boundary
 

--- a/skills/support-desk/X.yaml
+++ b/skills/support-desk/X.yaml
@@ -1,0 +1,125 @@
+skill: support-desk
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: docs-grounded-reply-only
+      runner: support
+      inputs:
+        support_thread:
+          - role: customer
+            at: "2026-07-06T08:00:00Z"
+            body: "I added the DNS TXT record for domain verification but the app still says pending. What should I check next?"
+          - role: agent_note
+            at: "2026-07-06T08:04:00Z"
+            body: "Customer is on Pro plan and has not requested account changes."
+        docs_corpus:
+          - id: docs-domain-verify
+            title: "Domain verification DNS checks"
+            url: "https://docs.example.test/domain-verification"
+            text: "Domain verification requires the exact TXT value from Settings > Sending Domains. DNS propagation can take up to 24 hours. Remove extra quotes only if your DNS host adds them automatically."
+          - id: docs-dkim
+            title: "DKIM setup"
+            url: "https://docs.example.test/dkim"
+            text: "DKIM records must be added as CNAME records. Verification can remain pending until DNS propagation completes."
+        customer_context:
+          account_tier: "pro"
+          region: "test"
+          private_state_available: false
+        support_policy:
+          product_name: "ExampleDesk"
+          safe_reply_topics:
+            - "dns"
+            - "domain verification"
+            - "dkim"
+          issue_intake_keywords:
+            - "error"
+            - "regression"
+            - "500"
+          sensitive_topics:
+            - "refund"
+            - "password"
+            - "security incident"
+            - "legal"
+          support_signature: "ExampleDesk Support"
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+    - name: sensitive-billing-security-manual-review
+      runner: support
+      inputs:
+        support_thread:
+          - role: customer
+            at: "2026-07-06T09:00:00Z"
+            body: "Please refund the annual invoice and reset the owner password. I think someone else accessed the account."
+        docs_corpus: []
+        customer_context:
+          account_tier: "unknown"
+          private_state_available: false
+        support_policy:
+          product_name: "ExampleDesk"
+          safe_reply_topics:
+            - "dns"
+            - "setup"
+          sensitive_topics:
+            - "refund"
+            - "password"
+            - "security"
+            - "account access"
+            - "legal"
+          support_signature: "ExampleDesk Support"
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+
+runners:
+  support:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      support_summary: object
+      context_findings: object
+      decision: object
+      reply_only: object
+      issue_intake_proposal: object
+      followup_plan: object
+      manual_review: object
+      evidence: object
+    artifacts:
+      wrap_as: support_desk_packet
+      packet: runx.support_desk.v1
+    inputs:
+      support_thread:
+        type: json
+        required: true
+        description: "Support thread messages or a bounded support request object."
+      docs_corpus:
+        type: json
+        required: false
+        description: "Bounded public docs snippets with id, title, url, and text."
+      source_catalog:
+        type: json
+        required: false
+        description: "Alternative bounded source catalog when docs_corpus is unavailable."
+      customer_context:
+        type: json
+        required: false
+        description: "Public-safe customer context already approved for support review."
+      support_policy:
+        type: json
+        required: false
+        description: "Support policy defining safe topics, sensitive topics, and escalation rules."

--- a/skills/support-desk/X.yaml
+++ b/skills/support-desk/X.yaml
@@ -83,6 +83,12 @@ harness:
           schema: runx.receipt.v1
           state: sealed
 
+    - name: missing-thread-failure
+      runner: support
+      inputs: {}
+      expect:
+        status: failure
+
 runners:
   support:
     default: true
@@ -98,6 +104,7 @@ runners:
       issue_intake_proposal: object
       followup_plan: object
       manual_review: object
+      status: string
       evidence: object
     artifacts:
       wrap_as: support_desk_packet

--- a/skills/support-desk/evidence/evidence.json
+++ b/skills/support-desk/evidence/evidence.json
@@ -1,0 +1,65 @@
+{
+    "schema":  "frantic.runx.skill.evidence.v1",
+    "package":  "support-desk",
+    "owner":  "rohitmulani63-ops",
+    "registry_ref":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
+    "public_url":  "https://runx.ai/x/rohitmulani63-ops/support-desk",
+    "pr_url":  "https://github.com/runxhq/runx/pull/265",
+    "source_url":  "https://github.com/rohitmulani63-ops/runx/tree/support-desk-frantic-78/skills/support-desk",
+    "runx_cli":  "0.6.14",
+    "validation":  {
+                       "local_inspect":  "passed",
+                       "linux_harness":  {
+                                             "status":  "passed",
+                                             "case_count":  3,
+                                             "receipt_ids":  [
+                                                                 "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411",
+                                                                 "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11",
+                                                                 "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
+                                                             ],
+                                             "case_names":  [
+                                                                "docs-grounded-reply-only",
+                                                                "sensitive-billing-security-manual-review",
+                                                                "missing-thread-failure"
+                                                            ],
+                                             "assertion_error_count":  0
+                                         },
+                       "remote_registry_read":  "passed",
+                       "published_registry_digest":  "c2e1e44e5dd7add82720c61f0445c95169e79d70756555d4934b2d08aa9d94a7",
+                       "profile_digest":  "8df2799d678d25297a520a9161853d1abb352d248f20b4622a5c3754425fca3b"
+                   },
+    "dogfood":  {
+                    "kind":  "post_publish",
+                    "package":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
+                    "public_url":  "https://runx.ai/x/rohitmulani63-ops/support-desk",
+                    "command":  "runx skill rohitmulani63-ops/support-desk@sha-0b7352252dca support --registry https://api.runx.ai -R .runx/support-desk-published-receipts --json",
+                    "receipt_ref":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                    "receipt_status":  "sealed",
+                    "decision_lane":  "reply_only",
+                    "sends_message":  false,
+                    "opens_ticket":  false,
+                    "mutates_account":  false,
+                    "citations":  [
+                                      {
+                                          "id":  "docs-domain-verify",
+                                          "url":  "https://docs.example.test/domain-verification"
+                                      }
+                                  ]
+                },
+    "verification":  {
+                         "command":  "runx verify sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c --receipt-dir .runx/support-desk-published-receipts --json",
+                         "valid":  true,
+                         "signature_mode":  "production",
+                         "root_receipt_id":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                         "findings":  [
+
+                                      ]
+                     },
+    "safety":  {
+                   "external_side_effects":  "none",
+                   "no_customer_message_sent":  true,
+                   "no_ticket_opened":  true,
+                   "no_account_mutation":  true,
+                   "no_billing_or_security_action":  true
+               }
+}

--- a/skills/support-desk/evidence/evidence.json
+++ b/skills/support-desk/evidence/evidence.json
@@ -1,65 +1,182 @@
 {
     "schema":  "frantic.runx.skill.evidence.v1",
+    "summary":  "support-desk is published, installable, harness-checked, dogfooded from the hosted registry package, and verified with a sealed runx receipt.",
     "package":  "support-desk",
     "owner":  "rohitmulani63-ops",
+    "version":  "sha-0b7352252dca",
     "registry_ref":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
-    "public_url":  "https://runx.ai/x/rohitmulani63-ops/support-desk",
+    "public_url":  "https://runx.ai/x/rohitmulani63-ops/support-desk@sha-0b7352252dca",
     "pr_url":  "https://github.com/runxhq/runx/pull/265",
     "source_url":  "https://github.com/rohitmulani63-ops/runx/tree/support-desk-frantic-78/skills/support-desk",
-    "runx_cli":  "0.6.14",
-    "validation":  {
-                       "local_inspect":  "passed",
-                       "linux_harness":  {
-                                             "status":  "passed",
-                                             "case_count":  3,
-                                             "receipt_ids":  [
-                                                                 "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411",
-                                                                 "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11",
-                                                                 "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
-                                                             ],
-                                             "case_names":  [
-                                                                "docs-grounded-reply-only",
-                                                                "sensitive-billing-security-manual-review",
-                                                                "missing-thread-failure"
-                                                            ],
-                                             "assertion_error_count":  0
-                                         },
-                       "remote_registry_read":  "passed",
-                       "published_registry_digest":  "c2e1e44e5dd7add82720c61f0445c95169e79d70756555d4934b2d08aa9d94a7",
-                       "profile_digest":  "8df2799d678d25297a520a9161853d1abb352d248f20b4622a5c3754425fca3b"
-                   },
+    "runx_version_output":  "runx-cli 0.6.14",
+    "observations":  [
+                         {
+                             "output":  "runx-cli 0.6.14",
+                             "command":  "runx --version",
+                             "kind":  "runx_version"
+                         },
+                         {
+                             "version":  "sha-0b7352252dca",
+                             "package_name":  "support-desk",
+                             "registry_ref":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
+                             "owner":  "rohitmulani63-ops",
+                             "kind":  "publisher"
+                         },
+                         {
+                             "source_url":  "https://github.com/rohitmulani63-ops/runx/tree/support-desk-frantic-78/skills/support-desk",
+                             "skill_md":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/support-desk-frantic-78/skills/support-desk/SKILL.md",
+                             "public_url":  "https://runx.ai/x/rohitmulani63-ops/support-desk@sha-0b7352252dca",
+                             "kind":  "public_artifacts",
+                             "verification_json":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/support-desk-frantic-78/skills/support-desk/evidence/verification.json",
+                             "x_yaml":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/support-desk-frantic-78/skills/support-desk/X.yaml",
+                             "report":  "https://raw.githubusercontent.com/rohitmulani63-ops/runx/support-desk-frantic-78/skills/support-desk/evidence/report.md",
+                             "pr_url":  "https://github.com/runxhq/runx/pull/265"
+                         },
+                         {
+                             "hosted_harness_status":  "passed",
+                             "method":  "runx login --provider github --for publish; runx registry publish ./skills/support-desk/SKILL.md --registry https://api.runx.ai",
+                             "profile_digest":  "8df2799d678d25297a520a9161853d1abb352d248f20b4622a5c3754425fca3b",
+                             "digest":  "c2e1e44e5dd7add82720c61f0445c95169e79d70756555d4934b2d08aa9d94a7",
+                             "kind":  "publish"
+                         },
+                         {
+                             "status":  "success",
+                             "command":  "runx registry install rohitmulani63-ops/support-desk@sha-0b7352252dca --registry https://api.runx.ai --to .runx/support-desk-clean-install --json",
+                             "kind":  "clean_install"
+                         },
+                         {
+                             "status":  "passed",
+                             "command":  "runx harness ./skills/support-desk --json",
+                             "harness_cases":  [
+                                                   {
+                                                       "status":  "sealed",
+                                                       "name":  "docs-grounded-reply-only",
+                                                       "receipt_id":  "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411"
+                                                   },
+                                                   {
+                                                       "status":  "sealed",
+                                                       "name":  "sensitive-billing-security-manual-review",
+                                                       "receipt_id":  "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11"
+                                                   },
+                                                   {
+                                                       "status":  "failure",
+                                                       "name":  "missing-thread-failure",
+                                                       "receipt_id":  "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
+                                                   }
+                                               ],
+                             "case_names":  [
+                                                "docs-grounded-reply-only",
+                                                "sensitive-billing-security-manual-review",
+                                                "missing-thread-failure"
+                                            ],
+                             "kind":  "local_harness"
+                         },
+                         {
+                             "input":  {
+                                           "customer_context":  "public-safe pro tier context",
+                                           "support_thread":  "DNS TXT/domain verification pending support request",
+                                           "support_policy":  "ExampleDesk DNS/domain-verification safe reply policy",
+                                           "docs_corpus":  "docs-domain-verify public snippet"
+                                       },
+                             "receipt_ref":  "runx:receipt:sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                             "kind":  "dogfood",
+                             "cited_docs":  [
+                                                "docs-domain-verify"
+                                            ],
+                             "harness_cases":  [
+                                                   {
+                                                       "status":  "sealed",
+                                                       "name":  "docs-grounded-reply-only",
+                                                       "receipt_id":  "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411"
+                                                   },
+                                                   {
+                                                       "status":  "sealed",
+                                                       "name":  "sensitive-billing-security-manual-review",
+                                                       "receipt_id":  "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11"
+                                                   },
+                                                   {
+                                                       "status":  "failure",
+                                                       "name":  "missing-thread-failure",
+                                                       "receipt_id":  "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
+                                                   }
+                                               ],
+                             "command":  "runx skill rohitmulani63-ops/support-desk@sha-0b7352252dca support --registry https://api.runx.ai -R .runx/support-desk-published-receipts --json",
+                             "package":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
+                             "proposal_type":  "reply_only",
+                             "decision_lane":  "reply_only",
+                             "verify_verdict":  "passed"
+                         },
+                         {
+                             "followup_plan":  null,
+                             "manual_review":  null,
+                             "support_summary":  {
+                                                     "customer_context_used":  [
+                                                                                   "account_tier",
+                                                                                   "private_state_available"
+                                                                               ],
+                                                     "latest_customer_message":  "I added the TXT record for domain verification but the sending domain still says pending. What should I check before opening a ticket?",
+                                                     "message_count":  1,
+                                                     "request":  "I added the TXT record for domain verification but the sending domain still says pending. What should I check before opening a ticket?"
+                                                 },
+                             "decision":  {
+                                              "confidence":  0.8,
+                                              "lane":  "reply_only",
+                                              "rationale":  "The thread is answerable from supplied docs/source snippets and does not require private account state."
+                                          },
+                             "kind":  "support_summary",
+                             "context_findings":  [
+                                                      {
+                                                          "citation":  "docs-domain-verify",
+                                                          "claim":  "Domain verification requires the exact TXT value from Settings \u003e Sending Domains.",
+                                                          "overlap_score":  3,
+                                                          "source_title":  "Domain verification DNS checks",
+                                                          "source_url":  "https://docs.example.test/domain-verification"
+                                                      }
+                                                  ]
+                         },
+                         {
+                             "mutates_account":  false,
+                             "billing_security_legal_actions":  "none",
+                             "sends_message":  false,
+                             "external_support_system_calls":  "none",
+                             "kind":  "side_effects",
+                             "opens_ticket":  false
+                         },
+                         {
+                             "valid":  true,
+                             "signature_mode":  "production",
+                             "command":  "runx verify sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c --receipt-dir .runx/support-desk-published-receipts --json",
+                             "root_receipt_id":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                             "kind":  "receipt_verify"
+                         }
+                     ],
     "dogfood":  {
-                    "kind":  "post_publish",
                     "package":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
-                    "public_url":  "https://runx.ai/x/rohitmulani63-ops/support-desk",
+                    "input":  {
+                                  "customer_context":  "public-safe pro tier context",
+                                  "support_thread":  "DNS TXT/domain verification pending support request",
+                                  "support_policy":  "ExampleDesk DNS/domain-verification safe reply policy",
+                                  "docs_corpus":  "docs-domain-verify public snippet"
+                              },
                     "command":  "runx skill rohitmulani63-ops/support-desk@sha-0b7352252dca support --registry https://api.runx.ai -R .runx/support-desk-published-receipts --json",
-                    "receipt_ref":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
-                    "receipt_status":  "sealed",
-                    "decision_lane":  "reply_only",
-                    "sends_message":  false,
-                    "opens_ticket":  false,
-                    "mutates_account":  false,
-                    "citations":  [
-                                      {
-                                          "id":  "docs-domain-verify",
-                                          "url":  "https://docs.example.test/domain-verification"
-                                      }
-                                  ]
-                },
-    "verification":  {
-                         "command":  "runx verify sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c --receipt-dir .runx/support-desk-published-receipts --json",
-                         "valid":  true,
-                         "signature_mode":  "production",
-                         "root_receipt_id":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
-                         "findings":  [
-
+                    "receipt_ref":  "runx:receipt:sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                    "verify_verdict":  "passed",
+                    "harness_cases":  [
+                                          {
+                                              "status":  "sealed",
+                                              "name":  "docs-grounded-reply-only",
+                                              "receipt_id":  "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411"
+                                          },
+                                          {
+                                              "status":  "sealed",
+                                              "name":  "sensitive-billing-security-manual-review",
+                                              "receipt_id":  "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11"
+                                          },
+                                          {
+                                              "status":  "failure",
+                                              "name":  "missing-thread-failure",
+                                              "receipt_id":  "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
+                                          }
                                       ]
-                     },
-    "safety":  {
-                   "external_side_effects":  "none",
-                   "no_customer_message_sent":  true,
-                   "no_ticket_opened":  true,
-                   "no_account_mutation":  true,
-                   "no_billing_or_security_action":  true
-               }
+                }
 }

--- a/skills/support-desk/evidence/report.md
+++ b/skills/support-desk/evidence/report.md
@@ -1,0 +1,27 @@
+# support-desk Frantic delivery report
+
+## Summary
+- Added support-desk, a non-mutating Runx skill that turns bounded support threads plus docs/policy into one safe operator proposal lane.
+- Published package: ohitmulani63-ops/support-desk@sha-0b7352252dca.
+- Public URL: https://runx.ai/x/rohitmulani63-ops/support-desk
+- PR: https://github.com/runxhq/runx/pull/265
+
+## Safety boundary
+- Does not send customer messages.
+- Does not open tickets or GitHub issues.
+- Does not mutate accounts, billing, credentials, permissions, legal, or security state.
+- Sensitive/private-state requests route to manual review.
+
+## Validation
+- unx-cli 0.6.14.
+- unx skill inspect ./skills/support-desk -j passed.
+- Docker/Linux harness passed with 3 cases:
+  - docs-grounded-reply-only
+  - sensitive-billing-security-manual-review
+  - missing-thread-failure
+- Hosted package dogfood run passed from ohitmulani63-ops/support-desk@sha-0b7352252dca.
+- Dogfood receipt: sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c.
+- unx verify on the dogfood receipt returned alid: true.
+
+## Dogfood result
+The post-publish dogfood run produced a eply_only proposal grounded in docs-domain-verify, with no side effects and no account mutation.

--- a/skills/support-desk/evidence/report.md
+++ b/skills/support-desk/evidence/report.md
@@ -1,27 +1,42 @@
 # support-desk Frantic delivery report
 
 ## Summary
-- Added support-desk, a non-mutating Runx skill that turns bounded support threads plus docs/policy into one safe operator proposal lane.
+- Added support-desk, a non-mutating Runx skill for turning bounded support threads plus docs/policy into one safe operator proposal lane.
 - Published package: ohitmulani63-ops/support-desk@sha-0b7352252dca.
-- Public URL: https://runx.ai/x/rohitmulani63-ops/support-desk
+- Public URL: https://runx.ai/x/rohitmulani63-ops/support-desk@sha-0b7352252dca
 - PR: https://github.com/runxhq/runx/pull/265
+- Source: https://github.com/rohitmulani63-ops/runx/tree/support-desk-frantic-78/skills/support-desk
+
+## What changed
+- skills/support-desk/X.yaml declares the package, inputs, outputs, and harness.
+- skills/support-desk/SKILL.md documents operator use, safety boundary, output schema, validation, and install/run flow.
+- skills/support-desk/run.mjs implements reply_only, issue_intake_proposal, followup_plan, and manual_review lanes.
+- Evidence files live under skills/support-desk/evidence/.
 
 ## Safety boundary
 - Does not send customer messages.
 - Does not open tickets or GitHub issues.
 - Does not mutate accounts, billing, credentials, permissions, legal, or security state.
 - Sensitive/private-state requests route to manual review.
+- Unsupported claims remain followup/manual instead of being invented.
 
 ## Validation
-- unx-cli 0.6.14.
-- unx skill inspect ./skills/support-desk -j passed.
+- unx --version: unx-cli 0.6.14.
+- unx skill inspect ./skills/support-desk -j: passed.
 - Docker/Linux harness passed with 3 cases:
-  - docs-grounded-reply-only
-  - sensitive-billing-security-manual-review
-  - missing-thread-failure
-- Hosted package dogfood run passed from ohitmulani63-ops/support-desk@sha-0b7352252dca.
-- Dogfood receipt: sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c.
-- unx verify on the dogfood receipt returned alid: true.
+  - docs-grounded-reply-only: sealed
+  - sensitive-billing-security-manual-review: sealed
+  - missing-thread-failure: failure stop
+- Clean install passed with unx registry install rohitmulani63-ops/support-desk@sha-0b7352252dca --registry https://api.runx.ai.
+- Hosted registry read resolves owner, version, digest, and profile digest.
+- Post-publish dogfood run used ohitmulani63-ops/support-desk@sha-0b7352252dca, not the local folder.
+- Dogfood receipt: unx:receipt:sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c.
+- unx verify on that dogfood receipt returned alid: true.
 
 ## Dogfood result
-The post-publish dogfood run produced a eply_only proposal grounded in docs-domain-verify, with no side effects and no account mutation.
+The post-publish dogfood run produced a eply_only proposal grounded in docs-domain-verify, with no side effects, no customer send, no ticket open, and no account mutation.
+
+## New user flow
+1. Install: unx add rohitmulani63-ops/support-desk@sha-0b7352252dca --registry https://api.runx.ai.
+2. Run with bounded support_thread, docs_corpus or source_catalog, customer_context, and support_policy.
+3. Verify the dogfood receipt with unx verify sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c --receipt-dir .runx/support-desk-published-receipts --json.

--- a/skills/support-desk/evidence/verification.json
+++ b/skills/support-desk/evidence/verification.json
@@ -2,24 +2,38 @@
     "schema":  "frantic.runx.skill.verification.v1",
     "package":  "support-desk",
     "registry_ref":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
-    "runx_cli":  "0.6.14",
+    "runx_version_output":  "runx-cli 0.6.14",
     "inspect_status":  "ok",
+    "clean_install":  {
+                          "command":  "runx registry install rohitmulani63-ops/support-desk@sha-0b7352252dca --registry https://api.runx.ai --to .runx/support-desk-clean-install --json",
+                          "status":  "success"
+                      },
     "linux_harness":  {
                           "status":  "passed",
                           "case_count":  3,
-                          "receipt_ids":  [
-                                              "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411",
-                                              "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11",
-                                              "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
-                                          ],
-                          "case_names":  [
-                                             "docs-grounded-reply-only",
-                                             "sensitive-billing-security-manual-review",
-                                             "missing-thread-failure"
-                                         ],
-                          "assertion_error_count":  0
+                          "harness_cases":  [
+                                                {
+                                                    "status":  "sealed",
+                                                    "name":  "docs-grounded-reply-only",
+                                                    "receipt_id":  "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411"
+                                                },
+                                                {
+                                                    "status":  "sealed",
+                                                    "name":  "sensitive-billing-security-manual-review",
+                                                    "receipt_id":  "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11"
+                                                },
+                                                {
+                                                    "status":  "failure",
+                                                    "name":  "missing-thread-failure",
+                                                    "receipt_id":  "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
+                                                }
+                                            ]
                       },
-    "dogfood_receipt":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+    "dogfood":  {
+                    "receipt_ref":  "runx:receipt:sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                    "status":  "sealed",
+                    "decision_lane":  "reply_only"
+                },
     "verify":  {
                    "receipt_dir":  "/work/.runx/support-desk-published-receipts",
                    "signature_mode":  "production",

--- a/skills/support-desk/evidence/verification.json
+++ b/skills/support-desk/evidence/verification.json
@@ -1,0 +1,42 @@
+{
+    "schema":  "frantic.runx.skill.verification.v1",
+    "package":  "support-desk",
+    "registry_ref":  "rohitmulani63-ops/support-desk@sha-0b7352252dca",
+    "runx_cli":  "0.6.14",
+    "inspect_status":  "ok",
+    "linux_harness":  {
+                          "status":  "passed",
+                          "case_count":  3,
+                          "receipt_ids":  [
+                                              "sha256:fa8bdcf974289750a08b84663c51b623fdc22e6de98b407616da6b3eca144411",
+                                              "sha256:0f52142c5e456b2e2fa6b612fea084df95e148688b52f577d6556b79052bbe11",
+                                              "sha256:bc89a596e7a4a14e50bf40d99e3f1ca9d47b32abc84df1911979a9f9351ea53a"
+                                          ],
+                          "case_names":  [
+                                             "docs-grounded-reply-only",
+                                             "sensitive-billing-security-manual-review",
+                                             "missing-thread-failure"
+                                         ],
+                          "assertion_error_count":  0
+                      },
+    "dogfood_receipt":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+    "verify":  {
+                   "receipt_dir":  "/work/.runx/support-desk-published-receipts",
+                   "signature_mode":  "production",
+                   "trees":  [
+                                 {
+                                     "root_receipt_id":  "sha256:2675b5c3409619563fe800988f32d1f591bba2962a5091a60fb230058389e36c",
+                                     "receipt_count":  1,
+                                     "parent_missing":  null,
+                                     "valid":  true,
+                                     "findings":  [
+
+                                                  ]
+                                 }
+                             ],
+                   "unreadable_files":  [
+
+                                        ],
+                   "valid":  true
+               }
+}

--- a/skills/support-desk/run.mjs
+++ b/skills/support-desk/run.mjs
@@ -1,0 +1,312 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const supportThread = normalizeThread(inputs.support_thread);
+const docs = normalizeDocs(inputs.docs_corpus ?? inputs.source_catalog ?? []);
+const customerContext = objectValue(inputs.customer_context ?? {}, "customer_context");
+const policy = objectValue(inputs.support_policy ?? {}, "support_policy");
+
+if (supportThread.length === 0) {
+  fail("support_thread must contain at least one message");
+}
+
+const threadText = supportThread.map((m) => `${m.role}: ${m.body}`).join("\n");
+const normalized = normalize(threadText);
+const sensitiveTopics = matchedSensitiveTopics(normalized, policy);
+const bugSignals = matchedSignals(normalized, listFrom(policy.issue_intake_keywords, ["bug", "error", "500", "broken", "regression", "crash", "failed"]));
+const safeTopics = matchedSignals(normalized, listFrom(policy.safe_reply_topics, ["dns", "domain verification", "dkim", "setup", "configure", "docs"]));
+const contextFindings = buildContextFindings(normalized, docs);
+const missingContext = buildMissingContext({ docs, contextFindings, sensitiveTopics, safeTopics, bugSignals });
+const summary = buildSupportSummary(supportThread, customerContext);
+const lane = chooseLane({ sensitiveTopics, docs, contextFindings, safeTopics, bugSignals, normalized });
+const confidence = confidenceFor({ lane, sensitiveTopics, contextFindings, safeTopics, bugSignals });
+const decision = {
+  lane,
+  rationale: rationaleFor(lane, { sensitiveTopics, contextFindings, safeTopics, bugSignals, missingContext }),
+  confidence,
+};
+
+const productName = stringValue(policy.product_name) ?? "the product";
+const signature = stringValue(policy.support_signature) ?? "Support";
+const proposal = buildProposal(lane, { supportThread, summary, contextFindings, missingContext, sensitiveTopics, productName, signature, bugSignals });
+
+const result = {
+  support_summary: summary,
+  context_findings: contextFindings,
+  decision,
+  reply_only: proposal.reply_only,
+  issue_intake_proposal: proposal.issue_intake_proposal,
+  followup_plan: proposal.followup_plan,
+  manual_review: proposal.manual_review,
+  evidence: {
+    side_effects: "none",
+    docs_used: contextFindings.map((finding) => finding.citation),
+    cited_docs_count: new Set(contextFindings.map((finding) => finding.citation)).size,
+    unsupported_claims: missingContext,
+    sensitive_topics: sensitiveTopics,
+    thread_evidence: supportThread.map((message, index) => ({ index, role: message.role, at: message.at ?? null })),
+    customer_context_keys: Object.keys(customerContext).sort(),
+    proposal_type: lane,
+    sends_message: false,
+    opens_ticket: false,
+    mutates_account: false,
+    harness_case_names: ["docs-grounded-reply-only", "sensitive-billing-security-manual-review"],
+  },
+};
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    support_thread: parseInputValue(process.env.RUNX_INPUT_SUPPORT_THREAD),
+    docs_corpus: parseInputValue(process.env.RUNX_INPUT_DOCS_CORPUS),
+    source_catalog: parseInputValue(process.env.RUNX_INPUT_SOURCE_CATALOG),
+    customer_context: parseInputValue(process.env.RUNX_INPUT_CUSTOMER_CONTEXT),
+    support_policy: parseInputValue(process.env.RUNX_INPUT_SUPPORT_POLICY),
+  };
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function normalizeThread(raw) {
+  if (Array.isArray(raw)) {
+    return raw.map((message, index) => normalizeMessage(message, index)).filter((message) => message.body);
+  }
+  if (raw && typeof raw === "object") {
+    if (Array.isArray(raw.messages)) {
+      return raw.messages.map((message, index) => normalizeMessage(message, index)).filter((message) => message.body);
+    }
+    const body = [raw.subject, raw.body, raw.text].filter(Boolean).join("\n");
+    return body ? [normalizeMessage({ role: "customer", body, at: raw.at }, 0)] : [];
+  }
+  if (typeof raw === "string" && raw.trim()) {
+    return [normalizeMessage({ role: "customer", body: raw }, 0)];
+  }
+  return [];
+}
+
+function normalizeMessage(message, index) {
+  const object = message && typeof message === "object" ? message : { body: String(message ?? "") };
+  return {
+    role: stringValue(object.role) ?? (index === 0 ? "customer" : "note"),
+    body: stringValue(object.body ?? object.text ?? object.message) ?? "",
+    at: stringValue(object.at ?? object.created_at),
+  };
+}
+
+function normalizeDocs(raw) {
+  const list = Array.isArray(raw) ? raw : raw && typeof raw === "object" ? Object.values(raw) : [];
+  return list.map((doc, index) => {
+    const object = doc && typeof doc === "object" ? doc : { text: String(doc ?? "") };
+    const id = stringValue(object.id ?? object.key ?? object.slug) ?? `source-${index + 1}`;
+    return {
+      id,
+      title: stringValue(object.title ?? object.name) ?? id,
+      url: stringValue(object.url ?? object.href ?? object.source_url) ?? `artifact://${id}`,
+      text: stringValue(object.text ?? object.body ?? object.content ?? object.summary) ?? "",
+    };
+  }).filter((doc) => doc.text.trim());
+}
+
+function objectValue(value, name) {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "object" || Array.isArray(value)) fail(`${name} must be an object`);
+  return value;
+}
+
+function stringValue(value) {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text || undefined;
+}
+
+function listFrom(value, fallback) {
+  if (Array.isArray(value)) return value.map((item) => normalize(String(item))).filter(Boolean);
+  return fallback;
+}
+
+function normalize(value) {
+  return String(value ?? "").toLowerCase().replace(/[^a-z0-9@:/._\-\s]/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function matchedSensitiveTopics(text, policy) {
+  const defaults = ["refund", "billing", "invoice", "payment", "password", "reset", "mfa", "2fa", "security", "abuse", "legal", "account access", "delete account", "bank", "stripe", "token", "credential", "private key", "id verification"];
+  return matchedSignals(text, listFrom(policy.sensitive_topics, defaults));
+}
+
+function matchedSignals(text, signals) {
+  const found = [];
+  for (const signal of signals) {
+    const normalizedSignal = normalize(signal);
+    if (normalizedSignal && text.includes(normalizedSignal) && !found.includes(normalizedSignal)) found.push(normalizedSignal);
+  }
+  return found;
+}
+
+function buildContextFindings(text, docs) {
+  const findings = [];
+  for (const doc of docs) {
+    const docText = normalize(`${doc.title} ${doc.text}`);
+    const score = overlapScore(text, docText);
+    if (score === 0) continue;
+    const claim = claimFromDoc(doc, text);
+    findings.push({ claim, citation: doc.id, source_title: doc.title, source_url: doc.url, overlap_score: score });
+  }
+  return findings.sort((a, b) => b.overlap_score - a.overlap_score).slice(0, 4);
+}
+
+function overlapScore(a, b) {
+  const important = ["dns", "domain", "verification", "verify", "dkim", "cname", "txt", "propagation", "setup", "configure", "error", "failed", "bug", "docs"];
+  return important.filter((term) => a.includes(term) && b.includes(term)).length;
+}
+
+function claimFromDoc(doc, text) {
+  const docText = doc.text.trim();
+  const firstSentence = docText.split(/(?<=[.!?])\s+/)[0] || docText;
+  if (text.includes("dns") || text.includes("domain") || text.includes("verification")) {
+    return firstSentence.slice(0, 220);
+  }
+  return `${doc.title}: ${firstSentence}`.slice(0, 220);
+}
+
+function buildMissingContext({ docs, contextFindings, sensitiveTopics, safeTopics, bugSignals }) {
+  const missing = [];
+  if (docs.length === 0) missing.push("No supplied docs_corpus or source_catalog to cite.");
+  if (contextFindings.length === 0 && sensitiveTopics.length === 0) missing.push("No supplied source snippet supports an answerable claim.");
+  if (safeTopics.length === 0 && bugSignals.length === 0 && sensitiveTopics.length === 0) missing.push("Thread does not match a known safe reply, issue intake, or escalation topic.");
+  if (sensitiveTopics.length > 0) missing.push("Request depends on sensitive/private-state handling and must remain manual.");
+  return missing;
+}
+
+function buildSupportSummary(thread, customerContext) {
+  const customerMessages = thread.filter((message) => /customer|user/i.test(message.role));
+  const primary = customerMessages[0] ?? thread[0];
+  return {
+    request: summarize(primary.body),
+    message_count: thread.length,
+    customer_context_used: Object.keys(customerContext).sort(),
+    latest_customer_message: summarize((customerMessages[customerMessages.length - 1] ?? primary).body),
+  };
+}
+
+function chooseLane({ sensitiveTopics, docs, contextFindings, safeTopics, bugSignals, normalized }) {
+  if (sensitiveTopics.length > 0) return "manual_review";
+  if (bugSignals.length > 0) return "issue_intake_proposal";
+  if (contextFindings.length > 0 && (safeTopics.length > 0 || docs.length > 0)) return "reply_only";
+  if (normalized.length < 40 || docs.length === 0) return "followup_plan";
+  return "manual_review";
+}
+
+function confidenceFor({ lane, sensitiveTopics, contextFindings, safeTopics, bugSignals }) {
+  if (lane === "manual_review" && sensitiveTopics.length > 0) return 0.91;
+  if (lane === "reply_only") return Math.min(0.92, 0.68 + contextFindings.length * 0.08 + safeTopics.length * 0.04);
+  if (lane === "issue_intake_proposal") return Math.min(0.86, 0.62 + bugSignals.length * 0.08 + contextFindings.length * 0.04);
+  if (lane === "followup_plan") return 0.72;
+  return 0.58;
+}
+
+function rationaleFor(lane, details) {
+  if (lane === "reply_only") return "The thread is answerable from supplied docs/source snippets and does not require private account state.";
+  if (lane === "issue_intake_proposal") return "The thread describes a product problem that should be handed to issue-intake as a proposal, not opened directly.";
+  if (lane === "followup_plan") return `More context is needed before a safe answer exists: ${details.missingContext.join("; ")}`;
+  return `Manual review is required: ${details.sensitiveTopics.join(", ") || details.missingContext.join("; ") || "unsupported support request"}.`;
+}
+
+function buildProposal(lane, context) {
+  return {
+    reply_only: lane === "reply_only" ? buildReplyProposal(context) : null,
+    issue_intake_proposal: lane === "issue_intake_proposal" ? buildIssueProposal(context) : null,
+    followup_plan: lane === "followup_plan" ? buildFollowupPlan(context) : null,
+    manual_review: lane === "manual_review" ? buildManualReview(context) : null,
+  };
+}
+
+function buildReplyProposal({ supportThread, contextFindings, productName, signature }) {
+  const customerName = firstName(extractCustomerName(supportThread));
+  const greeting = customerName ? `Hi ${customerName},` : "Hi,";
+  const bullets = contextFindings.map((finding) => `- ${finding.claim} (${finding.citation})`);
+  return {
+    subject: "Re: support request",
+    body: [
+      greeting,
+      "",
+      `Thanks for the note. Based on the supplied ${productName} docs, the safest next checks are:`,
+      ...bullets,
+      "",
+      "This reply is a proposal only and should be reviewed before sending.",
+      "",
+      "Thanks,",
+      signature,
+    ].join("\n"),
+    citations: contextFindings.map((finding) => ({ id: finding.citation, url: finding.source_url })),
+    send_gate: "requires_human_or_send_as_approval",
+    external_side_effects: "none",
+  };
+}
+
+function buildIssueProposal({ summary, contextFindings, bugSignals }) {
+  return {
+    title: `Support intake: ${summary.request}`.slice(0, 120),
+    problem: summary.latest_customer_message,
+    evidence: contextFindings.map((finding) => ({ claim: finding.claim, citation: finding.citation, url: finding.source_url })),
+    labels: ["support-intake", ...bugSignals].slice(0, 6),
+    handoff_gate: "issue_intake_must_review_before_opening",
+    external_side_effects: "none",
+  };
+}
+
+function buildFollowupPlan({ missingContext, contextFindings }) {
+  return {
+    reason: "A safe answer needs more evidence or customer detail.",
+    questions: missingContext.length > 0 ? missingContext : ["Please provide the exact product area, error text, and public docs/source snippet to cite."],
+    usable_context: contextFindings.map((finding) => ({ claim: finding.claim, citation: finding.citation })),
+    external_side_effects: "none",
+  };
+}
+
+function buildManualReview({ sensitiveTopics, missingContext, summary }) {
+  return {
+    reason: sensitiveTopics.length > 0 ? `Sensitive/private-state topics detected: ${sensitiveTopics.join(", ")}.` : "Unsupported or ambiguous support request.",
+    summary: summary.request,
+    blocked_actions: ["send_customer_reply", "open_ticket", "mutate_account", "change_billing", "reset_credentials"],
+    next_operator_step: missingContext.length > 0 ? missingContext[0] : "Route to an authorized support operator with the correct private-system access.",
+    external_side_effects: "none",
+  };
+}
+
+function summarize(text) {
+  const normalizedText = String(text ?? "").replace(/\s+/g, " ").trim();
+  if (!normalizedText) return "No support text supplied.";
+  return normalizedText.length > 180 ? `${normalizedText.slice(0, 177)}...` : normalizedText;
+}
+
+function extractCustomerName(thread) {
+  for (const message of thread) {
+    const match = message.body.match(/(?:from|name)[:\s]+([A-Z][a-zA-Z-]+)/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function firstName(value) {
+  const text = stringValue(value);
+  return text ? text.split(/\s+/)[0] : null;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/skills/support-desk/run.mjs
+++ b/skills/support-desk/run.mjs
@@ -29,8 +29,10 @@ const decision = {
 const productName = stringValue(policy.product_name) ?? "the product";
 const signature = stringValue(policy.support_signature) ?? "Support";
 const proposal = buildProposal(lane, { supportThread, summary, contextFindings, missingContext, sensitiveTopics, productName, signature, bugSignals });
+const status = lane === "followup_plan" && missingContext.length > 0 ? "needs_agent" : "ready";
 
 const result = {
+  status,
   support_summary: summary,
   context_findings: contextFindings,
   decision,
@@ -50,7 +52,7 @@ const result = {
     sends_message: false,
     opens_ticket: false,
     mutates_account: false,
-    harness_case_names: ["docs-grounded-reply-only", "sensitive-billing-security-manual-review"],
+    harness_case_names: ["docs-grounded-reply-only", "sensitive-billing-security-manual-review", "missing-thread-failure"],
   },
 };
 


### PR DESCRIPTION
Summary
- Add the support-desk runx skill package under skills/support-desk.
- Classifies bounded support threads into reply_only, issue_intake_proposal, followup_plan, or manual_review.
- Keeps the skill proposal-only: it does not send messages, open tickets, mutate accounts, or touch billing/security state.

Validation
- runx-cli 0.6.14
- runx skill inspect ./skills/support-desk -j
- Docker/Linux: runx harness ./skills/support-desk --json passed with docs-grounded-reply-only and sensitive-billing-security-manual-review.

Happy to adjust the packet if you want a different output shape or lane naming.