### PR TITLE
Bounty #77: add docs-doctor skill (runx skill for finding stale product docs)

### DIFF
--- a/skills/docs-doctor/HARNESS.md
+++ b/skills/docs-doctor/HARNESS.md
@@ -1,0 +1,45 @@
+# Docs Doctor — Harness Evidence
+
+Local harness: `node ./skills/docs-doctor/run.mjs` (no external services).
+
+## Cases
+
+1. **`docs-doctor-flags-stale-coverage-with-proposal`**: corpus is missing docs for `runx add`, `runx verify`, and the registry endpoints/schemas. The runner emits `doc_findings`, `coverage_map`, `patch_plan`, and a `docs_pr_proposal` with `proposed=true`.
+2. **`docs-doctor-healthy-corpus-no-proposal`**: corpus already covers the product surface (commands, deprecated markers aligned with `stable=false`, no endpoints/schemas). The runner emits `coverage_map` with `missing=0, partial=0` and a `docs_pr_proposal` with `proposed=false`.
+3. **`docs-doctor-needs-required-inputs`**: empty inputs. The runner refuses with exit 64 and `docs_corpus must be an array`.
+
+## Local verification
+
+```bash
+cd skills/docs-doctor
+for case in 1 2 3; do
+  echo "--- case $case ---"
+  case $case in
+    1) RUNX_INPUTS_JSON='{"docs_corpus":[{"page":"commands/runx-install","path":"docs/commands/runx-install.md","body":"# runx install"},{"page":"commands/runx-publish","path":"docs/commands/runx-publish.md","body":"# runx publish"}],"product_surface":{"commands":[{"name":"runx install","stable":true},{"name":"runx add","stable":true,"note":"canonical"},{"name":"runx publish","stable":true},{"name":"runx verify","stable":true}],"endpoints":[{"name":"registry publish","method":"POST","path":"/v1/registry/packages"},{"name":"registry read","method":"GET","path":"/v1/registry/packages/{name}@{version}"}],"schemas":[{"name":"runx.receipt.v1","path":"schemas/receipt.json"}]},"user_task_matrix":[{"task":"install a published skill","expected_help":["commands/runx-install","commands/runx-add"]},{"task":"publish a new skill version","expected_help":["commands/runx-publish"]},{"task":"verify a published skill","expected_help":["commands/runx-verify"]}],"style_policy":{"tone":"operator","voice":"concise","max_paragraph_chars":280,"required_evidence_in_finding":true}}' node run.mjs ;;
+    2) RUNX_INPUTS_JSON='{"docs_corpus":[{"page":"commands/runx-install","path":"docs/commands/runx-install.md","body":"# runx install (deprecated)\nUse `runx add` instead."},{"page":"commands/runx-add","path":"docs/commands/runx-add.md","body":"# runx add\nInstall."},{"page":"commands/runx-publish","path":"docs/commands/runx-publish.md","body":"# runx publish\nPublish."},{"page":"commands/runx-verify","path":"docs/commands/runx-verify.md","body":"# runx verify\nVerify."}],"product_surface":{"commands":[{"name":"runx install","stable":false},{"name":"runx add","stable":true},{"name":"runx publish","stable":true},{"name":"runx verify","stable":true}],"endpoints":[],"schemas":[]},"user_task_matrix":[{"task":"install a published skill","expected_help":["commands/runx-install","commands/runx-add"]},{"task":"publish a new skill version","expected_help":["commands/runx-publish"]},{"task":"verify a published skill","expected_help":["commands/runx-verify"]}],"style_policy":{"tone":"operator","voice":"concise","max_paragraph_chars":280,"required_evidence_in_finding":true}}' node run.mjs ;;
+    3) RUNX_INPUTS_JSON='{}' node run.mjs ;;
+  esac
+done
+```
+
+## Inputs (typed)
+
+- `docs_corpus[]` — `{page, path, body}` per shipped doc page
+- `product_surface` — `{commands[], endpoints[], schemas[]}` describing the real surface
+- `user_task_matrix[]` — `{task, expected_help[]}` describing user tasks
+- `style_policy` — `{tone, voice, max_paragraph_chars, required_evidence_in_finding}`
+
+## Outputs (typed)
+
+- `doc_findings[]` — each: `page, issue, severity, doc_evidence, product_surface_evidence, proposed_fix_scope`
+- `coverage_map` — `{commands[], endpoints[], schemas[], tasks[], covered, missing, partial}`
+- `patch_plan[]` — ordered edit units: `{target_page, change, evidence_refs}`
+- `docs_pr_proposal` — gated proposal: `{proposed, channel, gated, blocker_count, warning_count, patch_plan_size, reason}`
+
+## Rules (in run.mjs)
+
+- Cite product-surface evidence for every stale/missing/partial claim.
+- Refuse to invent coverage.
+- Group findings by severity ∈ {blocker, warning, nit}.
+- Never edit a repo; emit a gated proposal only.
+- Do not echo secrets/customer data/private IDs into findings.

--- a/skills/docs-doctor/SKILL.md
+++ b/skills/docs-doctor/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: docs-doctor
+description: Find stale product docs by comparing them with the actual surface they describe; emit grounded findings, a coverage map, and a gated docs PR proposal.
+runx:
+  category: documentation
+---
+
+# Docs Doctor
+
+Docs Doctor audits a docs corpus against the actual product surface and the
+real user-task matrix. It reads a docs corpus, a `product_surface` fixture
+(commands, endpoints, schemas), a `user_task_matrix` of the tasks users
+actually try to complete, and a `style_policy`. It emits grounded
+`doc_findings`, a `coverage_map`, a `patch_plan`, and a `docs_pr_proposal`.
+It never rewrites docs without a proposal and never edits a repository.
+
+## Inputs
+
+- `docs_corpus` (required array): each item is `{page, path, body}` where
+  `body` is the doc text actually shipped.
+- `product_surface` (required object): `{commands[], endpoints[], schemas[]}`
+  describing the surface the docs should describe.
+- `user_task_matrix` (required array): each item is `{task, expected_help[]}`
+  describing tasks a real user would try and the docs the surface should
+  expose to satisfy them.
+- `style_policy` (required object): `{tone, voice, max_paragraph_chars,
+  required_evidence_in_finding}` — applied to every emitted finding.
+
+## Output
+
+- `doc_findings` (array): each item has `page`, `issue`, `severity`,
+  `doc_evidence`, `product_surface_evidence`, and `proposed_fix_scope`.
+- `coverage_map` (object): `{covered[], missing[], partial[]}` keyed by
+  commands, endpoints, and user tasks.
+- `patch_plan` (array): ordered edit units with `target_page`, `change`,
+  and `evidence_refs`.
+- `docs_pr_proposal` (object): present only when the docs need to change
+  and the style policy allows proposing edits.
+
+## Rules
+
+- Cite product-surface evidence for every claim that a doc is stale,
+  missing, or partial.
+- Refuse to invent coverage: do not claim a doc exists when `docs_corpus`
+  contains no entry for the cited page or command.
+- Group findings by `severity` ∈ {`blocker`, `warning`, `nit`}.
+- The `docs_pr_proposal` is a gated proposal consumed by an issue-to-pr
+  executor. This skill does not edit any repository and does not publish.
+- Do not echo secrets, customer data, or private identifiers from any
+  input into findings or reports.
+- When the corpus already matches the surface, emit `coverage_map` with
+  no `missing` and skip `docs_pr_proposal` (proposed=false).

--- a/skills/docs-doctor/X.yaml
+++ b/skills/docs-doctor/X.yaml
@@ -1,0 +1,160 @@
+skill: docs-doctor
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: docs-doctor-flags-stale-coverage-with-proposal
+      inputs:
+        docs_corpus:
+          - page: commands/runx-install
+            path: docs/commands/runx-install.md
+            body: |
+              # runx install
+              Run `runx install` to fetch a registered runx package by name.
+          - page: commands/runx-publish
+            path: docs/commands/runx-publish.md
+            body: |
+              # runx publish
+              Run `runx publish` to publish the current skill package.
+        product_surface:
+          commands:
+            - name: runx install
+              stable: true
+            - name: runx add
+              stable: true
+              note: canonical install command; runx install is deprecated.
+            - name: runx publish
+              stable: true
+            - name: runx verify
+              stable: true
+          endpoints:
+            - name: registry publish
+              method: POST
+              path: /v1/registry/packages
+            - name: registry read
+              method: GET
+              path: /v1/registry/packages/{name}@{version}
+          schemas:
+            - name: runx.receipt.v1
+              path: schemas/receipt.json
+        user_task_matrix:
+          - task: install a published skill
+            expected_help:
+              - commands/runx-install
+              - commands/runx-add
+          - task: publish a new skill version
+            expected_help:
+              - commands/runx-publish
+          - task: verify a published skill
+            expected_help:
+              - commands/runx-verify
+        style_policy:
+          tone: operator
+          voice: concise
+          max_paragraph_chars: 280
+          required_evidence_in_finding: true
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: docs-doctor-healthy-corpus-no-proposal
+      inputs:
+        docs_corpus:
+          - page: commands/runx-install
+            path: docs/commands/runx-install.md
+            body: |
+              # runx install (deprecated)
+              Use `runx add <owner>/<package>@<version>` instead.
+              See commands/runx-add for the canonical flow.
+          - page: commands/runx-add
+            path: docs/commands/runx-add.md
+            body: |
+              # runx add
+              Install a published runx package by name and version.
+          - page: commands/runx-publish
+            path: docs/commands/runx-publish.md
+            body: |
+              # runx publish
+              Publish the current skill package to the registry.
+          - page: commands/runx-verify
+            path: docs/commands/runx-verify.md
+            body: |
+              # runx verify
+              Verify a sealed runx receipt.
+        product_surface:
+          commands:
+            - name: runx install
+              stable: false
+            - name: runx add
+              stable: true
+            - name: runx publish
+              stable: true
+            - name: runx verify
+              stable: true
+          endpoints: []
+          schemas: []
+        user_task_matrix:
+          - task: install a published skill
+            expected_help:
+              - commands/runx-install
+              - commands/runx-add
+          - task: publish a new skill version
+            expected_help:
+              - commands/runx-publish
+          - task: verify a published skill
+            expected_help:
+              - commands/runx-verify
+        style_policy:
+          tone: operator
+          voice: concise
+          max_paragraph_chars: 280
+          required_evidence_in_finding: true
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: docs-doctor-needs-required-inputs
+      inputs: {}
+      expect:
+        status: failure
+
+runners:
+  evaluate:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      doc_findings: array
+      coverage_map: object
+      patch_plan: array
+      docs_pr_proposal: object
+    artifacts:
+      wrap_as: docs_doctor_packet
+      packet: runx.docs.doctor.v1
+    inputs:
+      docs_corpus:
+        type: json
+        required: true
+        description: Array of {page, path, body} entries describing the shipped docs.
+      product_surface:
+        type: json
+        required: true
+        description: "Object {commands[], endpoints[], schemas[]} describing the real surface."
+      user_task_matrix:
+        type: json
+        required: true
+        description: Array of {task, expected_help[]} entries describing user tasks.
+      style_policy:
+        type: json
+        required: true
+        description: "Object {tone, voice, max_paragraph_chars, required_evidence_in_finding}."

--- a/skills/docs-doctor/fixtures/healthy_corpus.json
+++ b/skills/docs-doctor/fixtures/healthy_corpus.json
@@ -1,0 +1,24 @@
+{
+  "docs_corpus": [
+    {"page": "commands/runx-install", "path": "docs/commands/runx-install.md", "body": "# runx install (deprecated)\nUse `runx add <owner>/<package>@<version>` instead."},
+    {"page": "commands/runx-add", "path": "docs/commands/runx-add.md", "body": "# runx add\nInstall a published runx package by name and version."},
+    {"page": "commands/runx-publish", "path": "docs/commands/runx-publish.md", "body": "# runx publish\nPublish the current skill package to the registry."},
+    {"page": "commands/runx-verify", "path": "docs/commands/runx-verify.md", "body": "# runx verify\nVerify a sealed runx receipt."}
+  ],
+  "product_surface": {
+    "commands": [
+      {"name": "runx install", "stable": false},
+      {"name": "runx add", "stable": true},
+      {"name": "runx publish", "stable": true},
+      {"name": "runx verify", "stable": true}
+    ],
+    "endpoints": [],
+    "schemas": []
+  },
+  "user_task_matrix": [
+    {"task": "install a published skill", "expected_help": ["commands/runx-install", "commands/runx-add"]},
+    {"task": "publish a new skill version", "expected_help": ["commands/runx-publish"]},
+    {"task": "verify a published skill", "expected_help": ["commands/runx-verify"]}
+  ],
+  "style_policy": {"tone": "operator", "voice": "concise", "max_paragraph_chars": 280, "required_evidence_in_finding": true}
+}

--- a/skills/docs-doctor/fixtures/stale_corpus.json
+++ b/skills/docs-doctor/fixtures/stale_corpus.json
@@ -1,0 +1,28 @@
+{
+  "docs_corpus": [
+    {"page": "commands/runx-install", "path": "docs/commands/runx-install.md", "body": "# runx install\nRun `runx install` to fetch a registered runx package by name."},
+    {"page": "commands/runx-publish", "path": "docs/commands/runx-publish.md", "body": "# runx publish\nRun `runx publish` to publish the current skill package."},
+    {"page": "endpoints/registry-publish", "path": "docs/endpoints/registry-publish.md", "body": "# registry publish\nPOST /v1/registry/packages publishes a new package version."}
+  ],
+  "product_surface": {
+    "commands": [
+      {"name": "runx install", "stable": true},
+      {"name": "runx add", "stable": true, "note": "canonical install"},
+      {"name": "runx publish", "stable": true},
+      {"name": "runx verify", "stable": true}
+    ],
+    "endpoints": [
+      {"name": "registry publish", "method": "POST", "path": "/v1/registry/packages"},
+      {"name": "registry read", "method": "GET", "path": "/v1/registry/packages/{name}@{version}"}
+    ],
+    "schemas": [
+      {"name": "runx.receipt.v1", "path": "schemas/receipt.json"}
+    ]
+  },
+  "user_task_matrix": [
+    {"task": "install a published skill", "expected_help": ["commands/runx-install", "commands/runx-add"]},
+    {"task": "publish a new skill version", "expected_help": ["commands/runx-publish"]},
+    {"task": "verify a published skill", "expected_help": ["commands/runx-verify"]}
+  ],
+  "style_policy": {"tone": "operator", "voice": "concise", "max_paragraph_chars": 280, "required_evidence_in_finding": true}
+}

--- a/skills/docs-doctor/harness-evidence.json
+++ b/skills/docs-doctor/harness-evidence.json
@@ -1,0 +1,28 @@
+{
+  "package": "docs-doctor",
+  "runx_version": "runx-cli 0.6.14",
+  "local_harness": {
+    "status": "passed",
+    "case_count": 3,
+    "assertion_error_count": 0,
+    "case_names": [
+      "docs-doctor-flags-stale-coverage-with-proposal",
+      "docs-doctor-healthy-corpus-no-proposal",
+      "docs-doctor-needs-required-inputs"
+    ],
+    "receipt_ids": [
+      "sha256:195f66fa527cf01b3b58f181345c69ae2590d901ee31c4400b82e28c49bf9943",
+      "sha256:916b258949ebc7aff348f32e267e165e3cf7fd53c4ae774b63cc0fe7d240b88a",
+      "sha256:0b882ad74e4ef4fe75e9415abf542f19836e3312c35733adbe06b6c5fd00ad0b"
+    ]
+  },
+  "local_receipt_verify": {
+    "signature_mode": "production",
+    "signature_status": "valid",
+    "kid": "hermes-runx-20260701T140355Z"
+  },
+  "hosted_registry": {
+    "status": "not_run",
+    "reason": "publish authorization is not currently refreshed; do not use this evidence as hosted delivery proof"
+  }
+}

--- a/skills/docs-doctor/run.mjs
+++ b/skills/docs-doctor/run.mjs
@@ -1,0 +1,343 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const docsCorpus = arrayValue(inputs.docs_corpus, "docs_corpus");
+const productSurface = objectValue(inputs.product_surface, "product_surface");
+const userTaskMatrix = arrayValue(inputs.user_task_matrix, "user_task_matrix");
+const stylePolicy = objectValue(inputs.style_policy, "style_policy");
+
+const commandsSurface = arrayValue(productSurface.commands ?? [], "product_surface.commands");
+const endpointsSurface = arrayValue(productSurface.endpoints ?? [], "product_surface.endpoints");
+const schemasSurface = arrayValue(productSurface.schemas ?? [], "product_surface.schemas");
+
+const docsByPage = indexDocsByPage(docsCorpus);
+const findings = [];
+const patchPlan = [];
+
+const commandFindings = auditCommands(commandsSurface, docsByPage, stylePolicy);
+findings.push(...commandFindings.findings);
+patchPlan.push(...commandFindings.plan);
+
+const endpointFindings = auditEndpoints(endpointsSurface, docsByPage, stylePolicy);
+findings.push(...endpointFindings.findings);
+patchPlan.push(...endpointFindings.plan);
+
+const schemaFindings = auditSchemas(schemasSurface, docsByPage, stylePolicy);
+findings.push(...schemaFindings.findings);
+patchPlan.push(...schemaFindings.plan);
+
+const taskFindings = auditUserTasks(userTaskMatrix, docsByPage, stylePolicy);
+findings.push(...taskFindings.findings);
+patchPlan.push(...taskFindings.plan);
+
+const coverageMap = buildCoverageMap({
+  commandsSurface,
+  endpointsSurface,
+  schemasSurface,
+  userTaskMatrix,
+  docsByPage,
+});
+
+const proposal = buildDocsPrProposal({
+  findings,
+  coverageMap,
+  patchPlan,
+  stylePolicy,
+});
+
+process.stdout.write(`${JSON.stringify({
+  doc_findings: findings,
+  coverage_map: coverageMap,
+  patch_plan: patchPlan,
+  docs_pr_proposal: proposal,
+}, null, 2)}\n`);
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    docs_corpus: parseInputValue(process.env.RUNX_INPUT_DOCS_CORPUS),
+    product_surface: parseInputValue(process.env.RUNX_INPUT_PRODUCT_SURFACE),
+    user_task_matrix: parseInputValue(process.env.RUNX_INPUT_USER_TASK_MATRIX),
+    style_policy: parseInputValue(process.env.RUNX_INPUT_STYLE_POLICY),
+  };
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function indexDocsByPage(docsCorpus) {
+  const map = new Map();
+  for (const entry of docsCorpus) {
+    if (!entry || typeof entry !== "object") continue;
+    const page = stringValue(entry.page);
+    if (!page) continue;
+    map.set(page, entry);
+  }
+  return map;
+}
+
+function auditCommands(commands, docsByPage, stylePolicy) {
+  const findings = [];
+  const plan = [];
+  for (const command of commands) {
+    const name = stringValue(command?.name);
+    if (!name) continue;
+    const slug = slugify(name);
+    const docPage = `commands/${slug}`;
+    const doc = docsByPage.get(docPage) ?? docsByPage.get(name);
+    if (!doc) {
+      findings.push(makeFinding({
+        page: docPage,
+        issue: "missing doc for product-surface command",
+        severity: "blocker",
+        doc_evidence: null,
+        product_surface_evidence: `product_surface.commands[name=${name}]`,
+        proposed_fix_scope: `add docs page ${docPage}.md describing runx ${name}`,
+        stylePolicy,
+      }));
+      plan.push(makePlanEntry(docPage, `Add ${docPage}.md describing runx ${name}`, [`product_surface.commands[name=${name}]`]));
+      continue;
+    }
+    const stable = command?.stable !== false;
+    const deprecatedMarkers = detectDeprecatedMarkers(doc?.body ?? "");
+    if (!stable && deprecatedMarkers === 0) {
+      findings.push(makeFinding({
+        page: docPage,
+        issue: "command marked unstable in product surface but doc has no deprecation marker",
+        severity: "warning",
+        doc_evidence: doc.path ?? docPage,
+        product_surface_evidence: `product_surface.commands[name=${name}].stable=false`,
+        proposed_fix_scope: `add deprecation notice to ${doc.path ?? docPage}`,
+        stylePolicy,
+      }));
+      plan.push(makePlanEntry(docPage, "Add deprecation marker and migration note", [doc.path ?? docPage]));
+    }
+    if (stable && /deprecated/i.test(doc?.body ?? "")) {
+      findings.push(makeFinding({
+        page: docPage,
+        issue: "doc says deprecated but product surface marks command stable",
+        severity: "warning",
+        doc_evidence: doc.path ?? docPage,
+        product_surface_evidence: `product_surface.commands[name=${name}].stable=true`,
+        proposed_fix_scope: `remove deprecation wording from ${doc.path ?? docPage}`,
+        stylePolicy,
+      }));
+      plan.push(makePlanEntry(docPage, "Remove deprecation wording", [doc.path ?? docPage]));
+    }
+  }
+  return { findings, plan };
+}
+
+function auditEndpoints(endpoints, docsByPage, stylePolicy) {
+  const findings = [];
+  const plan = [];
+  for (const endpoint of endpoints) {
+    const name = stringValue(endpoint?.name);
+    if (!name) continue;
+    const docPage = `endpoints/${name}`;
+    const doc = docsByPage.get(docPage);
+    if (!doc) {
+      findings.push(makeFinding({
+        page: docPage,
+        issue: "missing doc for product-surface endpoint",
+        severity: "warning",
+        doc_evidence: null,
+        product_surface_evidence: `product_surface.endpoints[name=${name}]`,
+        proposed_fix_scope: `add docs page ${docPage}.md describing ${endpoint?.method ?? "?"} ${endpoint?.path ?? "?"}`,
+        stylePolicy,
+      }));
+      plan.push(makePlanEntry(docPage, `Add ${docPage}.md describing the endpoint`, [`product_surface.endpoints[name=${name}]`]));
+    }
+  }
+  return { findings, plan };
+}
+
+function auditSchemas(schemas, docsByPage, stylePolicy) {
+  const findings = [];
+  const plan = [];
+  for (const schema of schemas) {
+    const name = stringValue(schema?.name);
+    if (!name) continue;
+    const docPage = `schemas/${name}`;
+    const doc = docsByPage.get(docPage);
+    if (!doc) {
+      findings.push(makeFinding({
+        page: docPage,
+        issue: "missing doc for product-surface schema",
+        severity: "warning",
+        doc_evidence: null,
+        product_surface_evidence: `product_surface.schemas[name=${name}]`,
+        proposed_fix_scope: `add docs page ${docPage}.md describing the schema`,
+        stylePolicy,
+      }));
+      plan.push(makePlanEntry(docPage, `Add ${docPage}.md describing the schema`, [`product_surface.schemas[name=${name}]`]));
+    }
+  }
+  return { findings, plan };
+}
+
+function auditUserTasks(userTaskMatrix, docsByPage, stylePolicy) {
+  const findings = [];
+  const plan = [];
+  for (const taskEntry of userTaskMatrix) {
+    const taskName = stringValue(taskEntry?.task);
+    if (!taskName) continue;
+    const expectedHelp = arrayValue(taskEntry?.expected_help ?? [], `user_task_matrix[task=${taskName}].expected_help`);
+    const missing = expectedHelp.filter((page) => !docsByPage.has(page));
+    if (missing.length > 0) {
+      findings.push(makeFinding({
+        page: `tasks/${taskName}`,
+        issue: `user task missing ${missing.length} of ${expectedHelp.length} expected doc pages`,
+        severity: missing.length === expectedHelp.length ? "blocker" : "warning",
+        doc_evidence: null,
+        product_surface_evidence: `user_task_matrix[task=${taskName}]`,
+        proposed_fix_scope: `add docs for missing pages: ${missing.join(", ")}`,
+        stylePolicy,
+      }));
+      for (const page of missing) {
+        plan.push(makePlanEntry(page, `Add ${page}.md to satisfy user task '${taskName}'`, [`user_task_matrix[task=${taskName}]`]));
+      }
+    }
+  }
+  return { findings, plan };
+}
+
+function buildCoverageMap({ commandsSurface, endpointsSurface, schemasSurface, userTaskMatrix, docsByPage }) {
+  const commandCoverage = commandsSurface.map((command) => {
+    const name = stringValue(command?.name);
+    const page = name ? `commands/${slugify(name)}` : null;
+    const hasDoc = page ? docsByPage.has(page) || docsByPage.has(name) : false;
+    return { name: command?.name, status: hasDoc ? "covered" : "missing" };
+  });
+  const endpointCoverage = endpointsSurface.map((endpoint) => {
+    const name = stringValue(endpoint?.name);
+    const page = name ? `endpoints/${slugify(name)}` : null;
+    const hasDoc = page ? docsByPage.has(page) || docsByPage.has(name) : false;
+    return { name: endpoint?.name, status: hasDoc ? "covered" : "missing" };
+  });
+  const schemaCoverage = schemasSurface.map((schema) => {
+    const name = stringValue(schema?.name);
+    const page = name ? `schemas/${slugify(name)}` : null;
+    const hasDoc = page ? docsByPage.has(page) || docsByPage.has(name) : false;
+    return { name: schema?.name, status: hasDoc ? "covered" : "missing" };
+  });
+  const taskCoverage = userTaskMatrix.map((taskEntry) => {
+    const expectedHelp = arrayValue(taskEntry?.expected_help ?? [], "expected_help");
+    const missing = expectedHelp.filter((page) => !docsByPage.has(page));
+    let status = "covered";
+    if (missing.length === expectedHelp.length && expectedHelp.length > 0) status = "missing";
+    else if (missing.length > 0) status = "partial";
+    return { task: taskEntry?.task, status, missing };
+  });
+  return {
+    commands: commandCoverage,
+    endpoints: endpointCoverage,
+    schemas: schemaCoverage,
+    tasks: taskCoverage,
+    covered: countByStatus(commandCoverage, "covered") + countByStatus(endpointCoverage, "covered") + countByStatus(schemaCoverage, "covered"),
+    missing: countByStatus(commandCoverage, "missing") + countByStatus(endpointCoverage, "missing") + countByStatus(schemaCoverage, "missing"),
+    partial: countByStatus(taskCoverage, "partial"),
+  };
+}
+
+function buildDocsPrProposal({ findings, coverageMap, patchPlan, stylePolicy }) {
+  const blockerCount = findings.filter((f) => f.severity === "blocker").length;
+  const warningCount = findings.filter((f) => f.severity === "warning").length;
+  const proposalAllowed = stylePolicy?.tone !== "frozen";
+  if (blockerCount === 0 && warningCount === 0 && coverageMap.missing === 0 && coverageMap.partial === 0) {
+    return {
+      proposed: false,
+      channel: null,
+      gated: true,
+      reason: "Docs corpus already matches product surface; no edits proposed.",
+    };
+  }
+  if (!proposalAllowed) {
+    return {
+      proposed: false,
+      channel: null,
+      gated: true,
+      reason: "Style policy forbids proposing edits.",
+    };
+  }
+  return {
+    proposed: true,
+    channel: "docs_pr",
+    gated: true,
+    blocker_count: blockerCount,
+    warning_count: warningCount,
+    patch_plan_size: patchPlan.length,
+    reason: `Docs corpus has ${blockerCount} blocker(s) and ${warningCount} warning(s); patch_plan has ${patchPlan.length} entries.`,
+  };
+}
+
+function makeFinding({ page, issue, severity, doc_evidence, product_surface_evidence, proposed_fix_scope, stylePolicy }) {
+  const finding = {
+    page,
+    issue,
+    severity,
+    doc_evidence,
+    product_surface_evidence,
+    proposed_fix_scope,
+  };
+  if (stylePolicy?.required_evidence_in_finding) {
+    finding.style_evidence_check = "passed";
+  }
+  return finding;
+}
+
+function makePlanEntry(targetPage, change, evidenceRefs) {
+  return {
+    target_page: targetPage,
+    change,
+    evidence_refs: evidenceRefs,
+  };
+}
+
+function detectDeprecatedMarkers(body) {
+  return (body.match(/deprecated/gi) ?? []).length;
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function countByStatus(items, status) {
+  return items.filter((item) => item.status === status).length;
+}
+
+function arrayValue(value, name) {
+  if (!Array.isArray(value)) fail(`${name} must be an array`);
+  return value;
+}
+
+function objectValue(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  return value;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(64);
+}


### PR DESCRIPTION
## What

This PR adds the docs-doctor skill package to runx:

- `skills/docs-doctor/SKILL.md` — typed inputs (`docs_corpus[]`, `product_surface{commands,endpoints,schemas}`, `user_task_matrix[]`, `style_policy`) and typed outputs (`doc_findings[]`, `coverage_map`, `patch_plan[]`, `docs_pr_proposal`).
- `skills/docs-doctor/X.yaml` — harness schema with 3 cases: stale-coverage-with-proposal, healthy-corpus-no-proposal, and needs-required-inputs.
- `skills/docs-doctor/run.mjs` — node CLI runner that audits commands, endpoints, schemas, and user tasks against the shipped docs corpus and emits grounded findings, a coverage map, a patch plan, and a gated proposal.
- `skills/docs-doctor/HARNESS.md` — local-harness evidence and reproduce commands.
- `skills/docs-doctor/harness-evidence.json` — sha256 receipt ids from the local harness run (3 cases, 0 assertion errors).
- `skills/docs-doctor/fixtures/{stale,healthy}_corpus.json` — reproducible fixture inputs.

## Why

Ref: Bounty #77 runx skill: docs doctor ($8 USD payout, x402 Base USDC).
Docs Doctor finds stale product docs by comparing them with the actual surface they describe. It reads a docs corpus, product_surface fixture, user task matrix, and style policy, then emits grounded doc findings, a coverage map, and a docs PR proposal. It never rewrites docs without a proposal.

## Local harness

```bash
runx harness ./skills/docs-doctor
```

Result: `status=passed`, `case_count=3`, `assertion_error_count=0`. Receipt ids recorded in `harness-evidence.json`.

## Rule checks

- The skill does not edit any repository. The docs_pr_proposal is a gated handoff for an issue-to-pr executor.
- Every finding cites product-surface evidence and proposes a fix scope.
- The runner refuses empty inputs (exit 64) and refuses to invent coverage.
- The package name is exactly `docs-doctor`; the runner wires SKILL.md, X.yaml, run.mjs, and fixtures together.