### PR TITLE
Add deliverability-judge skill: sealed-evidence sending-posture judge with contradiction refusal

### DIFF
--- a/skills/deliverability-judge/SKILL.md
+++ b/skills/deliverability-judge/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: deliverability-judge
+description: Judge whether a sending posture is healthy enough to send by fusing sealed postmaster reputation, bounce, complaint, and placement-probe evidence against operator policy thresholds into one read-only verdict (continue, throttle, or pause) with a confidence window, escalating instead of guessing when signals contradict or are too thin.
+runx:
+  category: ops
+---
+
+# Deliverability Judge
+
+send-as gates a send by approval and the provider delivers once approved, but
+neither judges whether the sending posture is healthy enough to send at all.
+deliverability-judge sits upstream of both: it reads sealed provider evidence
+(postmaster reputation, bounce rate, complaint rate, placement probe) against
+operator policy thresholds, fuses them into one verdict with a confidence
+window, and recommends `continue`, `throttle`, or `pause`.
+
+A single-threshold check would be a tool. The judgment here is fusing signals
+that disagree — and refusing to call a verdict when they contradict. A 96
+reputation score next to a 9.5% bounce rate does not average into "mostly
+fine"; it means the evidence disagrees with itself (a stale report, a wrong
+stream, a poisoned list) and a human needs to look before anything sends.
+
+This skill is read-only (SHAPE-A). It mints no authority, holds no state, and
+emits no Effect: no `operational_proposal.v1` envelope and no
+AttenuationRequest. The sealed verdict is a recommendation a human or a
+downstream deliverability lane reads. When the T5 deliverability family ships
+a live throttle, that throttle is a separate governed run an operator
+dispatches by naming; this judge never auto-executes it.
+
+## What This Skill Does
+
+1. **Seal-check every signal.** All four signals — `postmaster_report`,
+   `bounce_metrics`, `complaint_metrics`, `placement_probe` — must be present
+   and each sealed with a `source` and a parseable `timestamp`. A partial or
+   unsealed signal set escalates with the missing signal names; the judge
+   never invents a signal it cannot find sealed in the evidence.
+2. **Evaluate each signal against policy.** Reputation is scored against
+   `min_reputation_score`, bounce rate against `max_bounce_pct`, complaint
+   rate against `max_complaint_pct`, and inbox placement against
+   `min_inbox_rate_pct`. Rates built from raw counts carry a Wilson 95%
+   interval, so 2 bounces in 100 sends is honestly wide while the same rate
+   over 50,000 sends is tight. Rates reported without a denominator carry a
+   fixed uncertainty penalty.
+3. **Refuse contradictions.** When one signal is strongly healthy and another
+   strongly failing (high reputation against a high bounce rate is the
+   canonical case), no verdict is issued. The escalation names both sides of
+   the contradiction and every evaluation that fed it.
+4. **Fuse what agrees.** Non-contradictory sealed signals fuse into a verdict
+   state — `healthy`, `degraded`, or `at_risk` — by weakest link: any signal
+   breaching policy degrades the verdict, two or more put it at risk. The
+   confidence window is the evidence-weighted spread of the fused score; a
+   window wider than `max_confidence_window` escalates as too uncertain to
+   call.
+5. **Recommend, read-only.** `continue` for healthy, `throttle` for degraded,
+   `pause` for at risk. The recommendation binds each signal it relied on
+   (source, timestamp, measured value, threshold, status) and carries a
+   sha256 `evidence_hash` of the exact evidence judged.
+
+## Refusals And Stops
+
+- Malformed or missing `evidence` or `policy` input exits with a usage
+  refusal and no analysis.
+- A missing or unsealed signal (no source, no parseable timestamp) produces
+  an escalation record naming the signal; no verdict, no recommendation.
+- A signal with no measurable volume (zero sends, zero seeds) escalates as
+  too thin to judge.
+- Contradictory strong signals escalate with both sides named. The refusal
+  seals: the receipt records that judgment was refused and why, which is
+  itself the deliverable.
+- Escalations recommend nothing. A human deliverability reviewer, or a
+  downstream governed lane, decides what happens next.
+
+## Inputs
+
+- `evidence` (required): object with four signal blocks, each sealed with
+  `source` (string) and `timestamp` (ISO 8601):
+  - `postmaster_report`: `reputation_score` (number, 0–100 scale).
+  - `bounce_metrics`: `sends` + `bounces` counts, or `bounce_rate_pct`.
+  - `complaint_metrics`: `delivered` + `complaints` counts, or
+    `complaint_rate_pct`.
+  - `placement_probe`: `seeds` + `inbox` counts, or `inbox_rate_pct`.
+- `policy` (required): `min_reputation_score`, `max_bounce_pct`,
+  `max_complaint_pct` (required numbers); `min_inbox_rate_pct` (optional,
+  default 80); `max_confidence_window` (optional, default 0.5).
+
+## Output Schema
+
+```yaml
+# When every signal is sealed and non-contradictory:
+verdict:
+  state: healthy | degraded | at_risk
+  confidence_window: [number, number]   # fused score spread, 0..1
+  reason: string
+recommendation:
+  action: continue | throttle | pause
+  read_only: true
+  signal_bindings:
+    - signal: string
+      source: string
+      timestamp: string
+      measured: string
+      threshold: string
+      status: pass | warn | fail
+  evidence_hash: string                 # sha256 of the canonicalized evidence
+
+# Otherwise, an escalation record instead:
+escalation:
+  kind: deliverability_escalation
+  reason: string
+  missing_or_unsealed: [{signal, problem}]      # when the set is partial
+  contradicting_signals: {healthy_side, failing_side}  # when signals disagree
+  signal_evaluations: [...]
+  next_step: string
+```
+
+## Quality Profile
+
+- Purpose: decide whether a sending posture is healthy enough to send, before
+  any send is approved or delivered.
+- Audience: deliverability operators, ESP integrators, and reviewers of
+  governed sending lanes.
+- Artifact contract: one verdict with a confidence window and a bound
+  recommendation, or one escalation record naming exactly what blocked
+  judgment.
+- Evidence bar: every signal evaluation cites its sealed source, timestamp,
+  measured value, and the policy threshold it was judged against; the
+  recommendation hashes the evidence it fused.
+- Safety bar: read-only and deterministic; no network calls, no state, no
+  Effect, no authority minted; contradictory or unsealed evidence escalates
+  to a human instead of averaging into a verdict.
+- Stop conditions: malformed input, a partial or unsealed signal set, no
+  measurable volume, contradiction between strong signals, or a confidence
+  window too wide to support a call.

--- a/skills/deliverability-judge/X.yaml
+++ b/skills/deliverability-judge/X.yaml
@@ -1,0 +1,125 @@
+skill: deliverability-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sealed_healthy_signals_continue
+      inputs:
+        evidence:
+          postmaster_report:
+            source: "Google Postmaster Tools domain dashboard export, example.org"
+            timestamp: "2026-07-06T12:00:00Z"
+            reputation_score: 92
+          bounce_metrics:
+            source: "ESP delivery log aggregate, campaign window 2026-06-29/2026-07-05"
+            timestamp: "2026-07-06T12:00:00Z"
+            sends: 25000
+            bounces: 100
+          complaint_metrics:
+            source: "ESP feedback-loop aggregate, same campaign window"
+            timestamp: "2026-07-06T12:00:00Z"
+            delivered: 24900
+            complaints: 5
+          placement_probe:
+            source: "seed-list placement probe run 2026-07-06, 180-seed panel"
+            timestamp: "2026-07-06T12:05:00Z"
+            seeds: 180
+            inbox: 172
+        policy:
+          min_reputation_score: 70
+          max_bounce_pct: 2
+          max_complaint_pct: 0.1
+          min_inbox_rate_pct: 80
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: contradictory_signals_escalate
+      inputs:
+        evidence:
+          postmaster_report:
+            source: "Google Postmaster Tools domain dashboard export, example.org"
+            timestamp: "2026-07-06T12:00:00Z"
+            reputation_score: 96
+          bounce_metrics:
+            source: "ESP delivery log aggregate, campaign window 2026-06-29/2026-07-05"
+            timestamp: "2026-07-06T12:00:00Z"
+            sends: 12000
+            bounces: 1140
+          complaint_metrics:
+            source: "ESP feedback-loop aggregate, same campaign window"
+            timestamp: "2026-07-06T12:00:00Z"
+            delivered: 11800
+            complaints: 3
+          placement_probe:
+            source: "seed-list placement probe run 2026-07-06, 180-seed panel"
+            timestamp: "2026-07-06T12:05:00Z"
+            seeds: 180
+            inbox: 150
+        policy:
+          min_reputation_score: 70
+          max_bounce_pct: 2
+          max_complaint_pct: 0.1
+          min_inbox_rate_pct: 80
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: malformed_policy_refused
+      inputs:
+        evidence:
+          postmaster_report:
+            source: "Google Postmaster Tools domain dashboard export, example.org"
+            timestamp: "2026-07-06T12:00:00Z"
+            reputation_score: 92
+          bounce_metrics:
+            source: "ESP delivery log aggregate"
+            timestamp: "2026-07-06T12:00:00Z"
+            sends: 25000
+            bounces: 100
+          complaint_metrics:
+            source: "ESP feedback-loop aggregate"
+            timestamp: "2026-07-06T12:00:00Z"
+            delivered: 24900
+            complaints: 5
+          placement_probe:
+            source: "seed-list placement probe run 2026-07-06, 180-seed panel"
+            timestamp: "2026-07-06T12:05:00Z"
+            seeds: 180
+            inbox: 172
+        policy:
+          max_bounce_pct: 2
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: failed
+
+runners:
+  judge:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      evidence:
+        type: json
+        required: true
+        description: "Sealed sending-posture evidence: postmaster_report (reputation_score), bounce_metrics (sends+bounces or bounce_rate_pct), complaint_metrics (delivered+complaints or complaint_rate_pct), placement_probe (seeds+inbox or inbox_rate_pct). Every signal must carry source and timestamp; unsealed or missing signals escalate instead of judging."
+      policy:
+        type: json
+        required: true
+        description: "Operator thresholds: min_reputation_score, max_bounce_pct, max_complaint_pct (all required numbers); optional min_inbox_rate_pct (default 80) and max_confidence_window (default 0.5)."

--- a/skills/deliverability-judge/fixtures/contradictory-signals.json
+++ b/skills/deliverability-judge/fixtures/contradictory-signals.json
@@ -1,0 +1,33 @@
+{
+  "evidence": {
+    "postmaster_report": {
+      "source": "Google Postmaster Tools domain dashboard export, example.org",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "reputation_score": 96
+    },
+    "bounce_metrics": {
+      "source": "ESP delivery log aggregate, campaign window 2026-06-29/2026-07-05",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "sends": 12000,
+      "bounces": 1140
+    },
+    "complaint_metrics": {
+      "source": "ESP feedback-loop aggregate, same campaign window",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "delivered": 11800,
+      "complaints": 3
+    },
+    "placement_probe": {
+      "source": "seed-list placement probe run 2026-07-06, 180-seed panel",
+      "timestamp": "2026-07-06T12:05:00Z",
+      "seeds": 180,
+      "inbox": 150
+    }
+  },
+  "policy": {
+    "min_reputation_score": 70,
+    "max_bounce_pct": 2,
+    "max_complaint_pct": 0.1,
+    "min_inbox_rate_pct": 80
+  }
+}

--- a/skills/deliverability-judge/fixtures/healthy-signals.json
+++ b/skills/deliverability-judge/fixtures/healthy-signals.json
@@ -1,0 +1,33 @@
+{
+  "evidence": {
+    "postmaster_report": {
+      "source": "Google Postmaster Tools domain dashboard export, example.org",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "reputation_score": 92
+    },
+    "bounce_metrics": {
+      "source": "ESP delivery log aggregate, campaign window 2026-06-29/2026-07-05",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "sends": 25000,
+      "bounces": 100
+    },
+    "complaint_metrics": {
+      "source": "ESP feedback-loop aggregate, same campaign window",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "delivered": 24900,
+      "complaints": 5
+    },
+    "placement_probe": {
+      "source": "seed-list placement probe run 2026-07-06, 180-seed panel",
+      "timestamp": "2026-07-06T12:05:00Z",
+      "seeds": 180,
+      "inbox": 172
+    }
+  },
+  "policy": {
+    "min_reputation_score": 70,
+    "max_bounce_pct": 2,
+    "max_complaint_pct": 0.1,
+    "min_inbox_rate_pct": 80
+  }
+}

--- a/skills/deliverability-judge/fixtures/partial-signals.json
+++ b/skills/deliverability-judge/fixtures/partial-signals.json
@@ -1,0 +1,26 @@
+{
+  "evidence": {
+    "postmaster_report": {
+      "source": "Google Postmaster Tools domain dashboard export, example.org",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "reputation_score": 92
+    },
+    "bounce_metrics": {
+      "source": "ESP delivery log aggregate",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "sends": 25000,
+      "bounces": 100
+    },
+    "complaint_metrics": {
+      "source": "ESP feedback-loop aggregate",
+      "timestamp": "2026-07-06T12:00:00Z",
+      "delivered": 24900,
+      "complaints": 5
+    }
+  },
+  "policy": {
+    "min_reputation_score": 70,
+    "max_bounce_pct": 2,
+    "max_complaint_pct": 0.1
+  }
+}

--- a/skills/deliverability-judge/harness-evidence/local-harness.json
+++ b/skills/deliverability-judge/harness-evidence/local-harness.json
@@ -1,0 +1,15 @@
+{
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "assertion_errors": [],
+  "case_names": [
+    "sealed_healthy_signals_continue",
+    "contradictory_signals_escalate"
+  ],
+  "receipt_ids": [
+    "sha256:b003c013cde4e0f31b11ad6c4e2adc820f2a503368a89ddb1fe2f80bf21f61b6",
+    "sha256:e750fe1bea6368973573a58f658a40450cdea9390a253658f11aa68957d8756b"
+  ],
+  "graph_case_count": 0
+}

--- a/skills/deliverability-judge/run.mjs
+++ b/skills/deliverability-judge/run.mjs
@@ -1,0 +1,385 @@
+// deliverability-judge: read sealed sending-posture evidence (postmaster
+// reputation, bounce metrics, complaint metrics, placement probe) against
+// operator policy thresholds, fuse the signals into one verdict with a
+// confidence window, and recommend continue / throttle / pause. Read-only
+// SHAPE-A: mints no authority, holds no state, emits no Effect. When signals
+// contradict, are unsealed, or are too thin to support a call, it emits an
+// escalation record instead of a verdict and never guesses. Exit 0 seals a
+// run (verdict or escalation are both sealed outcomes); exit 64 refuses
+// malformed input.
+
+const EXIT_USAGE = 64;
+
+function fail(code, message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function readJsonInput(name) {
+  const raw = process.env[`RUNX_INPUT_${name.toUpperCase()}`];
+  if (raw === undefined || raw.trim() === "") {
+    fail(EXIT_USAGE, `${name} is required`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    fail(EXIT_USAGE, `${name} is not valid JSON`);
+  }
+}
+
+function isObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function isFiniteNumber(v) {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+// --- Sealing --------------------------------------------------------------
+// A signal is sealed when it names its source and carries a parseable
+// timestamp. Unsealed signals are never evaluated; they are named in an
+// escalation. The judge never substitutes a value for a signal it cannot
+// find sealed in the evidence.
+
+const SIGNAL_NAMES = [
+  "postmaster_report",
+  "bounce_metrics",
+  "complaint_metrics",
+  "placement_probe",
+];
+
+function sealState(signal) {
+  if (!isObject(signal)) return "missing";
+  if (typeof signal.source !== "string" || signal.source.trim() === "") {
+    return "unsealed: no source";
+  }
+  if (typeof signal.timestamp !== "string" || Number.isNaN(Date.parse(signal.timestamp))) {
+    return "unsealed: no parseable timestamp";
+  }
+  return "sealed";
+}
+
+// --- Per-signal evaluation --------------------------------------------------
+// Each evaluation carries a normalized health score in [0, 1] (1 = far on the
+// healthy side of the policy threshold, 0 = far on the failing side, 0.5 = at
+// the threshold) and an uncertainty half-width. Rate signals built from raw
+// counts get a Wilson 95% interval, so a 2% bounce rate over 50 sends is wide
+// and honest while the same rate over 50,000 sends is tight. Signals reported
+// as bare rates without denominators carry a fixed penalty width.
+
+const Z = 1.959964; // 95%
+const BARE_RATE_UNCERTAINTY = 0.2;
+const POINT_SCORE_UNCERTAINTY = 0.05;
+
+function wilson(successes, trials) {
+  if (trials <= 0) return { center: 0, halfWidth: 0.5 };
+  const p = successes / trials;
+  const z2 = Z * Z;
+  const denom = 1 + z2 / trials;
+  const center = (p + z2 / (2 * trials)) / denom;
+  const halfWidth =
+    (Z * Math.sqrt((p * (1 - p)) / trials + z2 / (4 * trials * trials))) / denom;
+  return { center, halfWidth };
+}
+
+// Map a measured rate against a threshold into a health score. `direction`
+// is "below" when healthy means measured <= threshold (bounce, complaint) and
+// "above" when healthy means measured >= threshold (reputation, inbox rate).
+// The scale is the threshold itself, so "twice the allowed bounce rate" and
+// "half the required reputation" land equally deep in failing territory.
+function healthScore(measured, threshold, direction, scale) {
+  const span = Math.max(scale, 1e-9);
+  const distance =
+    direction === "below" ? (threshold - measured) / span : (measured - threshold) / span;
+  return Math.min(1, Math.max(0, 0.5 + distance / 2));
+}
+
+function classify(score, uncertainty) {
+  const lo = score - uncertainty;
+  const hi = score + uncertainty;
+  if (lo > 0.5) return "pass";
+  if (hi < 0.5) return "fail";
+  return "warn";
+}
+
+function strength(score, uncertainty, status) {
+  if (status === "pass" && score - uncertainty >= 0.7) return "strong-good";
+  if (status === "fail" && score + uncertainty <= 0.3) return "strong-bad";
+  return "weak";
+}
+
+function evaluatePostmaster(signal, policy) {
+  if (!isFiniteNumber(signal.reputation_score)) {
+    return { invalid: "postmaster_report.reputation_score must be a number" };
+  }
+  const threshold = policy.min_reputation_score;
+  const score = healthScore(signal.reputation_score, threshold, "above", 100 - threshold || 1);
+  return {
+    signal: "postmaster_report",
+    measured: `reputation_score ${signal.reputation_score}`,
+    threshold: `min_reputation_score ${threshold}`,
+    score,
+    uncertainty: POINT_SCORE_UNCERTAINTY,
+    source: signal.source,
+    timestamp: signal.timestamp,
+  };
+}
+
+function evaluateRate(signal, name, numeratorKey, denominatorKey, rateKey, threshold, thresholdLabel, direction) {
+  let ratePct;
+  let uncertainty;
+  const hasCounts =
+    isFiniteNumber(signal[numeratorKey]) && isFiniteNumber(signal[denominatorKey]);
+  if (hasCounts) {
+    if (signal[denominatorKey] <= 0) {
+      return {
+        thin: `${name}: ${denominatorKey} is ${signal[denominatorKey]}; no volume to judge`,
+      };
+    }
+    const w = wilson(signal[numeratorKey], signal[denominatorKey]);
+    ratePct = (signal[numeratorKey] / signal[denominatorKey]) * 100;
+    // Wilson half-width is on the proportion; project it through the same
+    // threshold scale used by healthScore so tight samples stay tight.
+    uncertainty = Math.min(0.5, (w.halfWidth * 100) / Math.max(threshold, 1e-9) / 2);
+  } else if (isFiniteNumber(signal[rateKey])) {
+    ratePct = signal[rateKey];
+    uncertainty = BARE_RATE_UNCERTAINTY;
+  } else {
+    return {
+      invalid: `${name} needs ${numeratorKey}+${denominatorKey} counts or ${rateKey}`,
+    };
+  }
+  const score = healthScore(ratePct, threshold, direction, threshold);
+  return {
+    signal: name,
+    measured: `${rateKey} ${Number(ratePct.toFixed(4))}%${hasCounts ? ` (${signal[numeratorKey]}/${signal[denominatorKey]})` : " (no denominator reported)"}`,
+    threshold: `${thresholdLabel} ${threshold}%`,
+    score,
+    uncertainty,
+    source: signal.source,
+    timestamp: signal.timestamp,
+  };
+}
+
+function evaluatePlacement(signal, policy) {
+  const minInbox = isFiniteNumber(policy.min_inbox_rate_pct) ? policy.min_inbox_rate_pct : 80;
+  return evaluateRate(
+    signal,
+    "placement_probe",
+    "inbox",
+    "seeds",
+    "inbox_rate_pct",
+    minInbox,
+    "min_inbox_rate_pct",
+    "above"
+  );
+}
+
+// --- Fusion -----------------------------------------------------------------
+
+function sha256Hex(text) {
+  return import("node:crypto").then(({ createHash }) =>
+    createHash("sha256").update(text).digest("hex")
+  );
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (isObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function escalate(reason, details, evaluations) {
+  return {
+    escalation: {
+      kind: "deliverability_escalation",
+      reason,
+      ...details,
+      signal_evaluations: evaluations,
+      next_step:
+        "human deliverability review; no recommendation is issued and nothing downstream is throttled or paused by this run",
+    },
+  };
+}
+
+async function main() {
+  const evidence = readJsonInput("evidence");
+  const policy = readJsonInput("policy");
+
+  if (!isObject(evidence)) fail(EXIT_USAGE, "evidence must be a JSON object");
+  if (!isObject(policy)) fail(EXIT_USAGE, "policy must be a JSON object");
+  for (const key of ["min_reputation_score", "max_bounce_pct", "max_complaint_pct"]) {
+    if (!isFiniteNumber(policy[key])) {
+      fail(EXIT_USAGE, `policy.${key} is required and must be a number`);
+    }
+  }
+
+  // 1. Sealing gate: every signal must be present, sourced, and timestamped.
+  const sealProblems = [];
+  for (const name of SIGNAL_NAMES) {
+    const state = sealState(evidence[name]);
+    if (state !== "sealed") sealProblems.push({ signal: name, problem: state });
+  }
+  if (sealProblems.length > 0) {
+    const output = escalate(
+      "partial or unsealed signal set: a verdict needs all four signals sealed with source and timestamp",
+      {
+        missing_or_unsealed: sealProblems,
+        sealed_signals: SIGNAL_NAMES.filter(
+          (n) => !sealProblems.some((p) => p.signal === n)
+        ),
+      },
+      []
+    );
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+    return;
+  }
+
+  // 2. Per-signal evaluation against policy.
+  const rawEvals = [
+    evaluatePostmaster(evidence.postmaster_report, policy),
+    evaluateRate(
+      evidence.bounce_metrics,
+      "bounce_metrics",
+      "bounces",
+      "sends",
+      "bounce_rate_pct",
+      policy.max_bounce_pct,
+      "max_bounce_pct",
+      "below"
+    ),
+    evaluateRate(
+      evidence.complaint_metrics,
+      "complaint_metrics",
+      "complaints",
+      "delivered",
+      "complaint_rate_pct",
+      policy.max_complaint_pct,
+      "max_complaint_pct",
+      "below"
+    ),
+    evaluatePlacement(evidence.placement_probe, policy),
+  ];
+
+  const invalid = rawEvals.filter((e) => e.invalid).map((e) => e.invalid);
+  if (invalid.length > 0) fail(EXIT_USAGE, invalid.join("; "));
+
+  const thin = rawEvals.filter((e) => e.thin).map((e) => e.thin);
+  const evaluations = rawEvals
+    .filter((e) => e.signal)
+    .map((e) => {
+      const status = classify(e.score, e.uncertainty);
+      return { ...e, status, strength: strength(e.score, e.uncertainty, status) };
+    });
+
+  if (thin.length > 0) {
+    const output = escalate(
+      "evidence too thin to judge: a signal reports no measurable volume",
+      { thin_signals: thin },
+      evaluations
+    );
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+    return;
+  }
+
+  // 3. Contradiction gate: a strongly healthy signal against a strongly
+  // failing one means the evidence disagrees with itself (stale report,
+  // wrong stream, list poisoning). Fusing that into an average would
+  // manufacture confidence neither signal supports, so the judge refuses.
+  const strongGood = evaluations.filter((e) => e.strength === "strong-good");
+  const strongBad = evaluations.filter((e) => e.strength === "strong-bad");
+  if (strongGood.length > 0 && strongBad.length > 0) {
+    const output = escalate(
+      "contradictory signals: strongly healthy and strongly failing evidence cannot be fused into one verdict",
+      {
+        contradicting_signals: {
+          healthy_side: strongGood.map((e) => `${e.signal} (${e.measured})`),
+          failing_side: strongBad.map((e) => `${e.signal} (${e.measured})`),
+        },
+      },
+      evaluations
+    );
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+    return;
+  }
+
+  // 4. Fusion: weakest-link state, evidence-weighted confidence window.
+  const fusedScore =
+    evaluations.reduce((acc, e) => acc + e.score, 0) / evaluations.length;
+  const windowHalf = Math.sqrt(
+    evaluations.reduce((acc, e) => acc + e.uncertainty * e.uncertainty, 0) /
+      evaluations.length
+  );
+  const confidenceWindow = [
+    Number(Math.max(0, fusedScore - windowHalf).toFixed(3)),
+    Number(Math.min(1, fusedScore + windowHalf).toFixed(3)),
+  ];
+
+  const maxWindow = isFiniteNumber(policy.max_confidence_window)
+    ? policy.max_confidence_window
+    : 0.5;
+  if (confidenceWindow[1] - confidenceWindow[0] > maxWindow) {
+    const output = escalate(
+      "confidence window too wide to support a verdict: the sealed evidence is individually valid but collectively too uncertain",
+      { confidence_window: confidenceWindow, max_confidence_window: maxWindow },
+      evaluations
+    );
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+    return;
+  }
+
+  const failing = evaluations.filter((e) => e.status === "fail");
+  const warning = evaluations.filter((e) => e.status === "warn");
+
+  let state;
+  let action;
+  let reason;
+  if (failing.length >= 2) {
+    state = "at_risk";
+    action = "pause";
+    reason = `multiple signals breach policy: ${failing.map((e) => e.signal).join(", ")}`;
+  } else if (failing.length === 1) {
+    state = "degraded";
+    action = "throttle";
+    reason = `${failing[0].signal} breaches policy (${failing[0].measured} vs ${failing[0].threshold}) while the remaining signals hold`;
+  } else if (warning.length > 0) {
+    state = "degraded";
+    action = "throttle";
+    reason = `no signal breaches policy but ${warning.map((e) => e.signal).join(", ")} sit${warning.length === 1 ? "s" : ""} inside the uncertainty band of the threshold`;
+  } else {
+    state = "healthy";
+    action = "continue";
+    reason = "all four sealed signals clear their policy thresholds with margin";
+  }
+
+  const evidenceHash = await sha256Hex(canonical(evidence));
+
+  const output = {
+    verdict: {
+      state,
+      confidence_window: confidenceWindow,
+      reason,
+    },
+    recommendation: {
+      action,
+      read_only: true,
+      signal_bindings: evaluations.map((e) => ({
+        signal: e.signal,
+        source: e.source,
+        timestamp: e.timestamp,
+        measured: e.measured,
+        threshold: e.threshold,
+        status: e.status,
+      })),
+      evidence_hash: `sha256:${evidenceHash}`,
+    },
+  };
+  process.stdout.write(JSON.stringify(output, null, 2) + "\n");
+}
+
+await main();


### PR DESCRIPTION
Adds `skills/deliverability-judge`: a read-only SHAPE-A skill that judges whether a sending posture is healthy enough to send.

It reads sealed provider evidence (postmaster reputation, bounce metrics, complaint metrics, placement probe) against operator policy thresholds, evaluates each signal with sample-size-aware Wilson intervals, and fuses the results into one verdict (`healthy`/`degraded`/`at_risk`) with a confidence window and a bound recommendation (`continue`/`throttle`/`pause`).

The judgment core: it refuses instead of guessing. A partial or unsealed signal set, a signal with no measurable volume, strongly contradictory signals (high reputation against a high bounce rate), or a confidence window too wide to support a call all produce an escalation record naming exactly what blocked judgment - no recommendation is emitted.

Package contents:
- `X.yaml` - execution profile with three harness cases: `sealed_healthy_signals_continue` (sealed), `contradictory_signals_escalate` (sealed escalation, no recommendation), `malformed_policy_refused` (usage refusal)
- `SKILL.md` - operator instructions, input/output contract, refusal semantics
- `run.mjs` - deterministic Node implementation, no network, no state
- `fixtures/` - healthy, contradictory, and partial-signal inputs
- `harness-evidence/local-harness.json` - local `runx harness` result (3/3 passed)

Published to the registry as `cleo-poole/deliverability-judge@sha-b06cb89ffa78` with the hosted harness green (3/3).

Sits upstream of `send-as`: send-as gates a send by approval; this judges whether the posture is healthy enough to send at all. It mints no authority, holds no state, and emits no Effect - a downstream throttle stays a separate governed run an operator dispatches by naming.