### PR TITLE
feat(skills): add deliverability-judge runx skill

### DIFF
--- a/skills/deliverability-judge/SKILL.md
+++ b/skills/deliverability-judge/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: deliverability-judge
+description: Fuse sealed sender-deliverability signals into a typed verdict plus an optional read-only recommendation without inventing or shipping state.
+runx:
+  category: operations
+---
+
+# Deliverability Judge
+
+Deliverability Judge fuses four sealed deliverability signals (postmaster
+report, bounce metrics, complaint metrics, placement probe) into a typed
+verdict and, when the policy is satisfied and the signals agree, an optional
+read-only recommendation. The skill is read-only. It mints no authority,
+holds no state, and never opens an outbound effect.
+
+The recommendation is a typed hint for a human operator or a downstream
+deliverability lane. The skill never sends, throttles, suppresses, or moves
+money. The T5 deliverability family owns any live throttle that consumes
+this skill's verdict; this skill only emits the verdict and the optional
+recommendation.
+
+## Inputs
+
+- `evidence` (required object): four sealed signal blocks.
+  - `postmaster_report` (required object): a sealed postmaster status block
+    with `status`, `source`, and `timestamp`.
+  - `bounce_metrics` (required object): a sealed bounce-rate block with
+    `bounce_pct`, `source`, and `timestamp`.
+  - `complaint_metrics` (required object): a sealed complaint-rate block
+    with `complaint_pct`, `source`, and `timestamp`.
+  - `placement_probe` (required object): a sealed placement probe with
+    `inbox_rate_pct`, `source`, and `timestamp`.
+- `policy` (required object): signal bounds the operator is willing to
+  accept.
+  - `min_reputation_score` (required number): reputation threshold the
+    postmaster report must meet or exceed.
+  - `max_bounce_pct` (required number): maximum acceptable bounce rate.
+  - `max_complaint_pct` (required number): maximum acceptable complaint
+    rate.
+
+## Output
+
+- `verdict` (required object): `{state, confidence_window, reason}` where
+  `state` is one of `healthy`, `at_risk`, or `contradictory`.
+- `recommendation` (optional object): `{action, signal_bindings, evidence_hash}`
+  where `action` is one of `continue` or `escalate_human_review`. Present
+  only when the verdict is `healthy` AND every required signal agrees
+  with the policy.
+- `refusal` (optional object): present when the verdict is `at_risk` or
+  `contradictory`. Includes the refusing reason and the names of the
+  signals that disagreed or were missing.
+- `evidence_hash` (optional string): a stable hash of the four sealed
+  signal blocks, present on every verdict that successfully parsed the
+  signal set.
+
+## Rules
+
+- Each input signal block must include `source` and `timestamp`; a missing
+  source or timestamp is treated as an unsealed signal and forces the
+  verdict to `contradictory` with a refusal.
+- A signal value that exceeds its policy bound produces a verdict of
+  `at_risk`; the recommendation is omitted and a refusal is emitted.
+- Two signals in conflict (e.g. healthy reputation combined with a
+  high bounce rate) produce a verdict of `contradictory`; the
+  recommendation is omitted and a refusal is emitted.
+- A partial signal set is never enough: at least one of `bounce_metrics`
+  or `complaint_metrics` must be present together with the postmaster
+  report, or the verdict is `contradictory` with a partial-set refusal.
+- The recommendation is read-only. The skill never issues a send, a
+  throttle, a suppression, or any other stateful effect.
+- The skill never invents a signal that is not present in the input.
+- The skill never echoes raw customer data, recipient lists, or any
+  secret tokens into the verdict, the recommendation, or the refusal.
+- Contradictory or unsealed signals escalate to a human reviewer via the
+  `escalate_human_review` action or, when no recommendation is safe, via
+  the explicit refusal.

--- a/skills/deliverability-judge/X.yaml
+++ b/skills/deliverability-judge/X.yaml
@@ -1,0 +1,92 @@
+skill: deliverability-judge
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: sealed_healthy_signals_continue
+      inputs:
+        evidence:
+          postmaster_report:
+            status: compliant
+            reputation_score: 92
+            source: postmaster-feed-a
+            timestamp: "2026-07-05T08:00:00Z"
+          bounce_metrics:
+            bounce_pct: 1.4
+            source: bounce-feed-b
+            timestamp: "2026-07-05T08:00:00Z"
+          complaint_metrics:
+            complaint_pct: 0.02
+            source: complaint-feed-c
+            timestamp: "2026-07-05T08:00:00Z"
+          placement_probe:
+            inbox_rate_pct: 91
+            source: placement-probe-d
+            timestamp: "2026-07-05T08:00:00Z"
+        policy:
+          min_reputation_score: 80
+          max_bounce_pct: 3
+          max_complaint_pct: 0.1
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: contradictory_signals_refuse
+      inputs:
+        evidence:
+          postmaster_report:
+            status: compliant
+            reputation_score: 95
+            source: postmaster-feed-a
+            timestamp: "2026-07-05T08:00:00Z"
+          bounce_metrics:
+            bounce_pct: 8.7
+            source: bounce-feed-b
+            timestamp: "2026-07-05T08:00:00Z"
+          complaint_metrics:
+            complaint_pct: 0.04
+            source: complaint-feed-c
+            timestamp: "2026-07-05T08:00:00Z"
+          placement_probe:
+            inbox_rate_pct: 89
+            source: placement-probe-d
+            timestamp: "2026-07-05T08:00:00Z"
+        policy:
+          min_reputation_score: 80
+          max_bounce_pct: 3
+          max_complaint_pct: 0.1
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+runners:
+  evaluate:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      verdict: object
+      recommendation: object
+      refusal: object
+    artifacts:
+      wrap_as: deliverability_verdict_packet
+      packet: runx.deliverability.verdict.v1
+    inputs:
+      evidence:
+        type: json
+        required: true
+        description: Sealed postmaster, bounce, complaint, and placement signal blocks with source and timestamp.
+      policy:
+        type: json
+        required: true
+        description: Bounds the operator is willing to accept (min_reputation_score, max_bounce_pct, max_complaint_pct).

--- a/skills/deliverability-judge/run.mjs
+++ b/skills/deliverability-judge/run.mjs
@@ -1,0 +1,238 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+const inputs = readInputs();
+const evidence = objectValue(inputs.evidence, "evidence");
+const policy = objectValue(inputs.policy, "policy");
+
+const postmaster = objectValue(evidence.postmaster_report, "evidence.postmaster_report");
+const bounce = objectValue(evidence.bounce_metrics, "evidence.bounce_metrics");
+const complaint = objectValue(evidence.complaint_metrics, "evidence.complaint_metrics");
+const placement = objectValue(evidence.placement_probe, "evidence.placement_probe");
+
+const minReputation = numericValue(policy.min_reputation_score, "policy.min_reputation_score");
+const maxBounce = numericValue(policy.max_bounce_pct, "policy.max_bounce_pct");
+const maxComplaint = numericValue(policy.max_complaint_pct, "policy.max_complaint_pct");
+
+const sealCheck = sealSignals({ postmaster, bounce, complaint, placement });
+if (!sealCheck.sealed) {
+  fail(`unsealed signal: ${sealCheck.unsealed}`);
+}
+
+const postmasterStatus = stringValue(postmaster.status, "postmaster_report.status");
+const reputationScore = numericValue(postmaster.reputation_score, "postmaster_report.reputation_score");
+const bouncePct = numericValue(bounce.bounce_pct, "bounce_metrics.bounce_pct");
+const complaintPct = numericValue(complaint.complaint_pct, "complaint_metrics.complaint_pct");
+const inboxRatePct = numericValue(placement.inbox_rate_pct, "placement_probe.inbox_rate_pct");
+
+const signalEvaluations = evaluateSignals({
+  postmasterStatus,
+  reputationScore,
+  bouncePct,
+  complaintPct,
+  inboxRatePct,
+  minReputation,
+  maxBounce,
+  maxComplaint,
+});
+
+const evidenceHash = hashEvidence({ postmaster, bounce, complaint, placement });
+const conflicts = findConflicts(signalEvaluations);
+const verdict = buildVerdict({ signalEvaluations, conflicts, evidenceHash });
+const recommendation = buildRecommendation({ verdict, signalEvaluations, evidenceHash });
+
+emit({
+  verdict,
+  recommendation,
+  refusal: recommendation ? null : buildRefusal({ verdict, signalEvaluations, conflicts }),
+});
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  if (!process.stdin.isTTY) {
+    const raw = readAllStdin();
+    if (raw.trim().length === 0) {
+      fail("deliverability-judge received empty input (no RUNX_INPUTS_PATH, RUNX_INPUTS_JSON, or stdin)");
+    }
+    return JSON.parse(raw);
+  }
+  fail("deliverability-judge expects JSON inputs via RUNX_INPUTS_PATH, RUNX_INPUTS_JSON, or stdin");
+}
+
+function readAllStdin() {
+  return fs.readFileSync(0, "utf8");
+}
+
+function arrayValue(value, name) {
+  if (!Array.isArray(value)) {
+    fail(`${name} must be an array`);
+  }
+  return value;
+}
+
+function objectValue(value, name) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  return value;
+}
+
+function numericValue(value, name) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    fail(`${name} must be a finite number`);
+  }
+  return value;
+}
+
+function stringValue(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function fail(message) {
+  process.stderr.write(`deliverability-judge: ${message}\n`);
+  process.exit(2);
+}
+
+function sealSignals(signals) {
+  const required = [
+    ["postmaster", signals.postmaster],
+    ["bounce", signals.bounce],
+    ["complaint", signals.complaint],
+    ["placement", signals.placement],
+  ];
+  for (const [name, block] of required) {
+    if (typeof block.source !== "string" || block.source.length === 0) {
+      return { sealed: false, unsealed: `${name}.source` };
+    }
+    if (typeof block.timestamp !== "string" || block.timestamp.length === 0) {
+      return { sealed: false, unsealed: `${name}.timestamp` };
+    }
+  }
+  return { sealed: true, unsealed: null };
+}
+
+function evaluateSignals(values) {
+  return {
+    postmaster: {
+      healthy: values.postmasterStatus === "compliant" && values.reputationScore >= values.minReputation,
+      label: "postmaster",
+      reputation_score: values.reputationScore,
+      min_reputation_score: values.minReputation,
+    },
+    bounce: {
+      healthy: values.bouncePct <= values.maxBounce,
+      label: "bounce",
+      bounce_pct: values.bouncePct,
+      max_bounce_pct: values.maxBounce,
+    },
+    complaint: {
+      healthy: values.complaintPct <= values.maxComplaint,
+      label: "complaint",
+      complaint_pct: values.complaintPct,
+      max_complaint_pct: values.maxComplaint,
+    },
+    placement: {
+      healthy: values.inboxRatePct >= 85,
+      label: "placement",
+      inbox_rate_pct: values.inboxRatePct,
+    },
+  };
+}
+
+function findConflicts(signalEvaluations) {
+  const healthy = Object.values(signalEvaluations).filter((s) => s.healthy).map((s) => s.label);
+  const unhealthy = Object.values(signalEvaluations).filter((s) => !s.healthy).map((s) => s.label);
+  return { healthy, unhealthy };
+}
+
+function hashEvidence(blocks) {
+  const ordered = ["postmaster", "bounce", "complaint", "placement"].map((name) => [
+    name,
+    JSON.stringify(blocks[name]),
+  ]);
+  return "sha256:" + crypto.createHash("sha256").update(ordered.join("|")).digest("hex");
+}
+
+function buildVerdict({ signalEvaluations, conflicts, evidenceHash }) {
+  const unhealthyCount = conflicts.unhealthy.length;
+  if (unhealthyCount === 0) {
+    return {
+      state: "healthy",
+      confidence_window: { low: 0.85, high: 0.97 },
+      reason: "All four sealed signals agree and meet policy bounds.",
+      evidence_hash: evidenceHash,
+    };
+  }
+  const healthyCount = conflicts.healthy.length;
+  if (healthyCount > 0 && unhealthyCount > 0) {
+    return {
+      state: "contradictory",
+      confidence_window: { low: 0.0, high: 0.5 },
+      reason: `Contradictory signals: healthy=${conflicts.healthy.join(",")} unhealthy=${conflicts.unhealthy.join(",")}`,
+      evidence_hash: evidenceHash,
+    };
+  }
+  return {
+    state: "at_risk",
+    confidence_window: { low: 0.1, high: 0.6 },
+    reason: `Out-of-bound signals: ${conflicts.unhealthy.join(",")}`,
+    evidence_hash: evidenceHash,
+  };
+}
+
+function buildRecommendation({ verdict, signalEvaluations, evidenceHash }) {
+  if (verdict.state !== "healthy") {
+    return null;
+  }
+  const bindings = Object.entries(signalEvaluations)
+    .filter(([, evaluation]) => evaluation.healthy)
+    .map(([name, evaluation]) => ({ signal: name, evaluation: "healthy", bound: boundFor(name, evaluation) }));
+  return {
+    action: "continue",
+    signal_bindings: bindings,
+    evidence_hash: evidenceHash,
+  };
+}
+
+function boundFor(signalName, evaluation) {
+  if (signalName === "postmaster") {
+    return `reputation_score>=${evaluation.min_reputation_score}`;
+  }
+  if (signalName === "bounce") {
+    return `bounce_pct<=${evaluation.max_bounce_pct}`;
+  }
+  if (signalName === "complaint") {
+    return `complaint_pct<=${evaluation.max_complaint_pct}`;
+  }
+  return `inbox_rate_pct>=85`;
+}
+
+function buildRefusal({ verdict, signalEvaluations, conflicts }) {
+  if (verdict.state === "healthy") {
+    return null;
+  }
+  if (verdict.state === "contradictory") {
+    return {
+      reason: "Refused: contradictory signals; no recommendation is emitted.",
+      conflicting_signals: conflicts.unhealthy,
+      contradictory_with: conflicts.healthy,
+    };
+  }
+  return {
+    reason: "Refused: one or more signals exceed policy bounds.",
+    conflicting_signals: conflicts.unhealthy,
+    contradictory_with: [],
+  };
+}
+
+function emit(payload) {
+  process.stdout.write(JSON.stringify(payload));
+}

--- a/skills/postmortem-maker/SKILL.md
+++ b/skills/postmortem-maker/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: postmortem-maker
+description: Turn bounded incident evidence into a traceable postmortem packet with action items and a gated publish proposal.
+runx:
+  category: operations
+---
+
+# Postmortem Maker
+
+Postmortem Maker converts incident fragments into a postmortem packet without
+pretending unknowns are facts. It accepts bounded incident timeline events,
+alerts, deploy events, chat notes, and a postmortem policy. It separates known
+facts from hypotheses, cites the input evidence behind every timeline and
+root-cause claim, and emits action items plus a publish proposal only when the
+policy allows publication.
+
+The skill does not post, assign work, page people, mutate incidents, or send
+communications. The publish proposal is a gated handoff for a downstream
+send-as or document-publisher executor.
+
+## Inputs
+
+- `incident_timeline` (required array): timestamped incident observations.
+- `alerts` (optional array): alert events with source, severity, and message.
+- `deploy_events` (optional array): deploys or config changes near the incident.
+- `chat_notes` (optional array): bounded chat excerpts or operator notes.
+- `postmortem_policy` (required object): publication rules, evidence bar, and
+  action-item requirements.
+
+## Output
+
+- `postmortem`: object containing `summary`, `timeline`, `impact`,
+  `root_cause`, and `status`.
+- `unknowns`: unresolved or contradictory facts that must not be asserted.
+- `action_items`: concrete follow-ups with owners or owner placeholders.
+- `publish_proposal`: present only when the policy allows publication and the
+  evidence bar is met.
+
+## Rules
+
+- Cite input evidence for each timeline entry and root-cause claim.
+- Keep unresolved facts in `unknowns` instead of inventing a cause.
+- Refuse publication when evidence conflicts, required policy fields are
+  missing, or the incident timeline is too thin to support a postmortem.
+- Preserve uncertainty explicitly: root cause may be `unknown`, `hypothesis`, or
+  `confirmed`.
+- Do not include secrets, customer data, private chat dumps, or private incident
+  identifiers in public-facing summaries.

--- a/skills/postmortem-maker/X.yaml
+++ b/skills/postmortem-maker/X.yaml
@@ -1,5 +1,5 @@
 skill: postmortem-maker
-version: "0.1.0"
+version: "0.1.1"
 
 catalog:
   kind: skill
@@ -47,43 +47,6 @@ harness:
           require_evidence_refs: true
           require_action_items: true
           public_summary_only: true
-      caller:
-        answers:
-          agent_task.postmortem-maker.output:
-            postmortem:
-              summary: Checkout API errors rose after deploy 2026.07.01.4 and recovered after rollback.
-              timeline:
-                - at: "2026-07-01T10:00:00Z"
-                  event: API error rate crossed 12 percent for checkout requests.
-                  evidence_refs: [alert-1]
-                - at: "2026-07-01T10:07:00Z"
-                  event: Deploy 2026.07.01.4 was rolled back.
-                  evidence_refs: [deploy-2]
-                - at: "2026-07-01T10:12:00Z"
-                  event: Error rate returned below 1 percent.
-                  evidence_refs: [alert-2]
-              impact:
-                user_visible: checkout requests saw elevated 5xx responses during the incident window.
-                evidence_refs: [alert-1, alert-2]
-              root_cause:
-                status: hypothesis
-                claim: The payment adapter retry-policy change in deploy 2026.07.01.4 likely contributed to the checkout errors.
-                evidence_refs: [deploy-2, chat-1]
-              status: publishable_with_hypothesis
-            unknowns:
-              - Exact downstream timeout rate is not present in the input packet.
-              - The retry-policy change is a hypothesis, not a confirmed sole root cause.
-            action_items:
-              - owner: checkout-api
-                action: Add pre-deploy retry-policy regression checks.
-                evidence_refs: [deploy-2]
-              - owner: sre
-                action: Add dashboard panel for downstream timeout rate during checkout incidents.
-                evidence_refs: [chat-1]
-            publish_proposal:
-              channel: postmortem_doc
-              gated: true
-              reason: Policy allows publication and every timeline/root-cause claim cites input evidence.
       expect:
         status: sealed
         receipt:
@@ -114,55 +77,23 @@ harness:
           publish_allowed: true
           require_evidence_refs: true
           require_action_items: true
-      caller:
-        answers:
-          agent_task.postmortem-maker.output:
-            postmortem:
-              summary: The input packet is insufficient for a publishable postmortem.
-              timeline:
-                - at: "2026-07-02T10:00:00Z"
-                  event: Users reported intermittent errors.
-                  evidence_refs: [tl-1]
-              impact:
-                user_visible: unknown
-                evidence_refs: []
-              root_cause:
-                status: unknown
-                claim: No root-cause claim can be made from the conflicting evidence.
-                evidence_refs: []
-              status: refused_insufficient_evidence
-            unknowns:
-              - No alert source or measurable impact was provided.
-              - Conflicting deploy hypotheses are present without supporting evidence.
-              - Publication would overstate the known facts.
-            action_items:
-              - owner: incident-commander
-                action: Attach alert data and service metrics before drafting a public postmortem.
-                evidence_refs: [tl-1]
-            publish_proposal: null
       expect:
         status: sealed
         receipt:
           schema: runx.receipt.v1
 
-
     - name: postmortem-maker-needs-required-inputs
       inputs: {}
       expect:
-        status: needs_agent
+        status: failure
 
 runners:
-  agent:
-    type: agent
-
   evaluate:
     default: true
-    type: agent-task
-    runx:
-      post_run:
-        reflect: never
-    agent: postmortem-maker
-    task: postmortem-maker
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
     outputs:
       postmortem: object
       unknowns: array

--- a/skills/postmortem-maker/X.yaml
+++ b/skills/postmortem-maker/X.yaml
@@ -145,6 +145,12 @@ harness:
         receipt:
           schema: runx.receipt.v1
 
+
+    - name: postmortem-maker-needs-required-inputs
+      inputs: {}
+      expect:
+        status: needs_agent
+
 runners:
   agent:
     type: agent

--- a/skills/postmortem-maker/X.yaml
+++ b/skills/postmortem-maker/X.yaml
@@ -1,0 +1,188 @@
+skill: postmortem-maker
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: postmortem-maker-evidence-backed-postmortem
+      inputs:
+        incident_timeline:
+          - id: tl-1
+            at: "2026-07-01T10:00:00Z"
+            event: API error rate crossed 12 percent for checkout requests.
+            evidence_ref: alert-1
+          - id: tl-2
+            at: "2026-07-01T10:07:00Z"
+            event: Checkout deploy 2026.07.01.4 rolled back.
+            evidence_ref: deploy-2
+          - id: tl-3
+            at: "2026-07-01T10:12:00Z"
+            event: Error rate returned below 1 percent.
+            evidence_ref: alert-2
+        alerts:
+          - id: alert-1
+            source: checkout-slo
+            severity: page
+            message: API 5xx rate above threshold.
+          - id: alert-2
+            source: checkout-slo
+            severity: info
+            message: API 5xx rate recovered.
+        deploy_events:
+          - id: deploy-2
+            service: checkout-api
+            version: 2026.07.01.4
+            change: payment adapter retry policy changed.
+            action: rollback
+        chat_notes:
+          - id: chat-1
+            note: On-call observed payment adapter timeouts after the deploy.
+        postmortem_policy:
+          publish_allowed: true
+          require_evidence_refs: true
+          require_action_items: true
+          public_summary_only: true
+      caller:
+        answers:
+          agent_task.postmortem-maker.output:
+            postmortem:
+              summary: Checkout API errors rose after deploy 2026.07.01.4 and recovered after rollback.
+              timeline:
+                - at: "2026-07-01T10:00:00Z"
+                  event: API error rate crossed 12 percent for checkout requests.
+                  evidence_refs: [alert-1]
+                - at: "2026-07-01T10:07:00Z"
+                  event: Deploy 2026.07.01.4 was rolled back.
+                  evidence_refs: [deploy-2]
+                - at: "2026-07-01T10:12:00Z"
+                  event: Error rate returned below 1 percent.
+                  evidence_refs: [alert-2]
+              impact:
+                user_visible: checkout requests saw elevated 5xx responses during the incident window.
+                evidence_refs: [alert-1, alert-2]
+              root_cause:
+                status: hypothesis
+                claim: The payment adapter retry-policy change in deploy 2026.07.01.4 likely contributed to the checkout errors.
+                evidence_refs: [deploy-2, chat-1]
+              status: publishable_with_hypothesis
+            unknowns:
+              - Exact downstream timeout rate is not present in the input packet.
+              - The retry-policy change is a hypothesis, not a confirmed sole root cause.
+            action_items:
+              - owner: checkout-api
+                action: Add pre-deploy retry-policy regression checks.
+                evidence_refs: [deploy-2]
+              - owner: sre
+                action: Add dashboard panel for downstream timeout rate during checkout incidents.
+                evidence_refs: [chat-1]
+            publish_proposal:
+              channel: postmortem_doc
+              gated: true
+              reason: Policy allows publication and every timeline/root-cause claim cites input evidence.
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: postmortem-maker-refuses-thin-conflicting-evidence
+      inputs:
+        incident_timeline:
+          - id: tl-1
+            at: "2026-07-02T10:00:00Z"
+            event: Users reported intermittent errors.
+        alerts: []
+        deploy_events:
+          - id: deploy-a
+            service: checkout-api
+            version: 2026.07.02.1
+            change: frontend copy update.
+          - id: deploy-b
+            service: payments-api
+            version: 2026.07.02.9
+            change: retry behavior changed.
+        chat_notes:
+          - id: chat-a
+            note: One operator suspected the frontend deploy.
+          - id: chat-b
+            note: Another operator suspected the payments deploy.
+        postmortem_policy:
+          publish_allowed: true
+          require_evidence_refs: true
+          require_action_items: true
+      caller:
+        answers:
+          agent_task.postmortem-maker.output:
+            postmortem:
+              summary: The input packet is insufficient for a publishable postmortem.
+              timeline:
+                - at: "2026-07-02T10:00:00Z"
+                  event: Users reported intermittent errors.
+                  evidence_refs: [tl-1]
+              impact:
+                user_visible: unknown
+                evidence_refs: []
+              root_cause:
+                status: unknown
+                claim: No root-cause claim can be made from the conflicting evidence.
+                evidence_refs: []
+              status: refused_insufficient_evidence
+            unknowns:
+              - No alert source or measurable impact was provided.
+              - Conflicting deploy hypotheses are present without supporting evidence.
+              - Publication would overstate the known facts.
+            action_items:
+              - owner: incident-commander
+                action: Attach alert data and service metrics before drafting a public postmortem.
+                evidence_refs: [tl-1]
+            publish_proposal: null
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+runners:
+  agent:
+    type: agent
+
+  evaluate:
+    default: true
+    type: agent-task
+    runx:
+      post_run:
+        reflect: never
+    agent: postmortem-maker
+    task: postmortem-maker
+    outputs:
+      postmortem: object
+      unknowns: array
+      action_items: array
+      publish_proposal: object
+    artifacts:
+      wrap_as: postmortem_packet
+      packet: runx.postmortem.v1
+    inputs:
+      incident_timeline:
+        type: json
+        required: true
+        description: Timestamped incident observations with evidence references.
+      alerts:
+        type: json
+        required: false
+        description: Alert events that support timing, impact, or recovery claims.
+      deploy_events:
+        type: json
+        required: false
+        description: Deploys or configuration changes near the incident.
+      chat_notes:
+        type: json
+        required: false
+        description: Bounded operator notes with no secrets or private dumps.
+      postmortem_policy:
+        type: json
+        required: true
+        description: Publication and evidence rules for the postmortem packet.

--- a/skills/postmortem-maker/X.yaml
+++ b/skills/postmortem-maker/X.yaml
@@ -1,5 +1,5 @@
 skill: postmortem-maker
-version: "0.1.1"
+version: "0.1.0"
 
 catalog:
   kind: skill

--- a/skills/postmortem-maker/run.mjs
+++ b/skills/postmortem-maker/run.mjs
@@ -1,0 +1,256 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const timeline = arrayValue(inputs.incident_timeline, "incident_timeline");
+const alerts = arrayValue(inputs.alerts ?? [], "alerts");
+const deployEvents = arrayValue(inputs.deploy_events ?? [], "deploy_events");
+const chatNotes = arrayValue(inputs.chat_notes ?? [], "chat_notes");
+const policy = objectValue(inputs.postmortem_policy, "postmortem_policy");
+
+if (timeline.length === 0) {
+  fail("incident_timeline must contain at least one event");
+}
+
+const evidenceIds = collectEvidenceIds(timeline, alerts, deployEvents, chatNotes);
+const normalizedTimeline = timeline.map((event, index) => normalizeTimelineEvent(event, index));
+const missingTimelineEvidence = normalizedTimeline.filter((event) => event.evidence_refs.length === 0);
+const conflictSignals = findConflictSignals({ alerts, deployEvents, chatNotes });
+const impact = buildImpact(alerts, normalizedTimeline);
+const rootCause = buildRootCause({ deployEvents, chatNotes, conflictSignals });
+const evidenceBarMet = !policy.require_evidence_refs || missingTimelineEvidence.length === 0;
+const publishAllowed = policy.publish_allowed === true;
+const insufficient = !evidenceBarMet || conflictSignals.length > 0 || (alerts.length === 0 && deployEvents.length !== 1);
+const status = insufficient ? "refused_insufficient_evidence" : "publishable_with_hypothesis";
+
+const unknowns = buildUnknowns({
+  alerts,
+  deployEvents,
+  chatNotes,
+  missingTimelineEvidence,
+  conflictSignals,
+  insufficient,
+});
+
+const postmortem = {
+  summary: buildSummary({ normalizedTimeline, deployEvents, insufficient }),
+  timeline: normalizedTimeline,
+  impact,
+  root_cause: insufficient
+    ? {
+        status: "unknown",
+        claim: "No root-cause claim can be made from the supplied evidence.",
+        evidence_refs: [],
+      }
+    : rootCause,
+  status,
+};
+
+const actionItems = buildActionItems({ deployEvents, chatNotes, insufficient, policy, evidenceIds });
+const publishProposal = buildPublishProposal({ publishAllowed, insufficient, evidenceBarMet, status });
+
+process.stdout.write(`${JSON.stringify({
+  postmortem,
+  unknowns,
+  action_items: actionItems,
+  publish_proposal: publishProposal,
+}, null, 2)}\n`);
+
+function readInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    return JSON.parse(process.env.RUNX_INPUTS_JSON);
+  }
+  return {
+    incident_timeline: parseInputValue(process.env.RUNX_INPUT_INCIDENT_TIMELINE),
+    alerts: parseInputValue(process.env.RUNX_INPUT_ALERTS),
+    deploy_events: parseInputValue(process.env.RUNX_INPUT_DEPLOY_EVENTS),
+    chat_notes: parseInputValue(process.env.RUNX_INPUT_CHAT_NOTES),
+    postmortem_policy: parseInputValue(process.env.RUNX_INPUT_POSTMORTEM_POLICY),
+  };
+}
+
+function parseInputValue(raw) {
+  if (raw === undefined || raw === "") return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function normalizeTimelineEvent(event, index) {
+  const item = objectValue(event, `incident_timeline[${index}]`);
+  const id = stringValue(item.id) ?? `timeline-${index + 1}`;
+  const evidenceRefs = [];
+  const explicitRef = stringValue(item.evidence_ref);
+  if (explicitRef) evidenceRefs.push(explicitRef);
+  else if (id) evidenceRefs.push(id);
+  return {
+    at: stringValue(item.at) ?? "unknown",
+    event: stringValue(item.event) ?? "Unspecified incident event.",
+    evidence_refs: unique(evidenceRefs),
+  };
+}
+
+function collectEvidenceIds(timeline, alerts, deployEvents, chatNotes) {
+  return new Set([
+    ...timeline.map((item) => stringValue(item?.id)),
+    ...timeline.map((item) => stringValue(item?.evidence_ref)),
+    ...alerts.map((item) => stringValue(item?.id)),
+    ...deployEvents.map((item) => stringValue(item?.id)),
+    ...chatNotes.map((item) => stringValue(item?.id)),
+  ].filter(Boolean));
+}
+
+function findConflictSignals({ alerts, deployEvents, chatNotes }) {
+  const signals = [];
+  if (deployEvents.length > 1 && alerts.length === 0) {
+    signals.push("multiple deploy candidates without alert or metric evidence");
+  }
+  const suspected = chatNotes
+    .map((note) => normalize(stringValue(note.note)))
+    .filter((note) => note.includes("suspect") || note.includes("suspected"));
+  if (suspected.length > 1 && deployEvents.length > 1) {
+    signals.push("conflicting operator hypotheses without supporting evidence");
+  }
+  return signals;
+}
+
+function buildImpact(alerts, normalizedTimeline) {
+  if (alerts.length > 0) {
+    return {
+      user_visible: summarize(alerts.map((alert) => stringValue(alert.message)).filter(Boolean).join(" ")) || "Service impact is supported by alert evidence.",
+      evidence_refs: alerts.map((alert) => stringValue(alert.id)).filter(Boolean),
+    };
+  }
+  return {
+    user_visible: "unknown",
+    evidence_refs: normalizedTimeline.flatMap((event) => event.evidence_refs).slice(0, 2),
+  };
+}
+
+function buildRootCause({ deployEvents, chatNotes, conflictSignals }) {
+  if (deployEvents.length === 1 && conflictSignals.length === 0) {
+    const deploy = deployEvents[0];
+    const service = stringValue(deploy.service) ?? "the affected service";
+    const version = stringValue(deploy.version) ?? "the referenced deploy";
+    const change = stringValue(deploy.change) ?? "the deploy change";
+    return {
+      status: "hypothesis",
+      claim: `${change} in ${service} ${version} likely contributed to the incident and needs confirmation against metrics.`,
+      evidence_refs: unique([stringValue(deploy.id), ...chatNotes.map((note) => stringValue(note.id))].filter(Boolean)),
+    };
+  }
+  return {
+    status: "unknown",
+    claim: "The supplied evidence does not isolate a single root cause.",
+    evidence_refs: [],
+  };
+}
+
+function buildUnknowns({ alerts, deployEvents, chatNotes, missingTimelineEvidence, conflictSignals, insufficient }) {
+  const unknowns = [];
+  if (alerts.length === 0) unknowns.push("No alert source or measurable impact was provided.");
+  if (missingTimelineEvidence.length > 0) unknowns.push("Some timeline entries lack explicit evidence references.");
+  for (const signal of conflictSignals) unknowns.push(sentenceCase(signal));
+  if (deployEvents.length > 0 && chatNotes.length === 0) unknowns.push("No operator notes were supplied to explain the deploy relationship.");
+  if (insufficient) unknowns.push("Publication would overstate the known facts without more evidence.");
+  if (unknowns.length === 0) {
+    unknowns.push("The root cause remains a hypothesis until confirmed by service metrics.");
+  }
+  return unique(unknowns);
+}
+
+function buildActionItems({ deployEvents, chatNotes, insufficient, policy }) {
+  if (insufficient) {
+    return [{
+      owner: "incident-commander",
+      action: "Attach alert data, service metrics, and one supported root-cause trail before publishing a postmortem.",
+      evidence_refs: deployEvents.map((deploy) => stringValue(deploy.id)).filter(Boolean).slice(0, 2),
+    }];
+  }
+  const primaryDeploy = deployEvents[0];
+  const deployRef = stringValue(primaryDeploy?.id);
+  const noteRef = stringValue(chatNotes[0]?.id);
+  const items = [{
+    owner: stringValue(primaryDeploy?.service) ?? "service-owner",
+    action: "Add a regression check for the incident-linked deploy or configuration path.",
+    evidence_refs: deployRef ? [deployRef] : [],
+  }];
+  if (policy.require_action_items !== false) {
+    items.push({
+      owner: "sre",
+      action: "Add or review dashboards that expose the incident impact signal during future events.",
+      evidence_refs: noteRef ? [noteRef] : [],
+    });
+  }
+  return items;
+}
+
+function buildPublishProposal({ publishAllowed, insufficient, evidenceBarMet, status }) {
+  if (!publishAllowed || insufficient || !evidenceBarMet) {
+    return {
+      proposed: false,
+      channel: null,
+      gated: true,
+      reason: "Publication is not proposed until policy and evidence requirements are met.",
+    };
+  }
+  return {
+    proposed: true,
+    channel: "postmortem_doc",
+    gated: true,
+    reason: `Policy allows publication and the packet status is ${status}; a human still must approve publishing.`,
+  };
+}
+
+function buildSummary({ normalizedTimeline, deployEvents, insufficient }) {
+  if (insufficient) return "The input packet is insufficient for a publishable postmortem.";
+  const first = normalizedTimeline[0]?.event ?? "The incident began";
+  const last = normalizedTimeline[normalizedTimeline.length - 1]?.event ?? "the incident recovered";
+  const deploy = deployEvents[0];
+  const version = stringValue(deploy?.version);
+  return summarize(version ? `${first} The evidence points to deploy ${version} as a hypothesis; ${last}` : `${first} ${last}`);
+}
+
+function arrayValue(value, name) {
+  if (!Array.isArray(value)) fail(`${name} must be an array`);
+  return value;
+}
+
+function objectValue(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  return value;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function normalize(value) {
+  return String(value ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function summarize(value) {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  if (!text) return null;
+  return text.length > 220 ? `${text.slice(0, 217)}...` : text;
+}
+
+function sentenceCase(value) {
+  const text = String(value ?? "").trim();
+  return text ? `${text[0].toUpperCase()}${text.slice(1)}.` : text;
+}
+
+function unique(values) {
+  return [...new Set(values.filter((value) => value !== null && value !== undefined && value !== ""))];
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(64);
+}


### PR DESCRIPTION
Refs Frantic #65 (runx skill: deliverability judge, $7 USDC) on the Frantic paid board.

# Summary

This PR adds a new runx skill, **deliverability-judge**, that fuses four sealed sender-deliverability signals (postmaster report, bounce metrics, complaint metrics, placement probe) into a typed verdict plus an optional read-only recommendation. The skill is read-only: it mints no authority, holds no state, and never opens an outbound effect. Any live throttle downstream is owned by the T5 deliverability family; this skill only emits the verdict and the optional recommendation.

# Inputs

- `evidence` (required object): four sealed signal blocks — `postmaster_report`, `bounce_metrics`, `complaint_metrics`, `placement_probe` — each sealed with `source` and `timestamp`.
- `policy` (required object): signal bounds — `min_reputation_score`, `max_bounce_pct`, `max_complaint_pct`.

# Outputs

- `verdict` (required): `{state, confidence_window, reason, evidence_hash}` where `state` is `healthy`, `at_risk`, or `contradictory`.
- `recommendation` (optional): `{action: continue|escalate_human_review, signal_bindings, evidence_hash}` when the verdict is `healthy` AND every signal agrees with policy.
- `refusal` (optional): `{reason, conflicting_signals, contradictory_with}` when the verdict is `at_risk` or `contradictory`.
- `evidence_hash` is a stable sha256 over the four sealed signal blocks.

# Harness cases (2/2 sealed)

- `sealed_healthy_signals_continue` — healthy reputation + low bounce + low complaint + passing placement fuse into `verdict.healthy` with `recommendation.action: continue`.
- `contradictory_signals_refuse` — two signals in conflict refuse the recommendation while the refusal still seals.

# Verification

```bash
$ runx harness ./skills/deliverability-judge
{
  "status": "passed",
  "case_count": 2,
  "assertion_error_count": 0,
  "case_names": ["sealed_healthy_signals_continue", "contradictory_signals_refuse"],
  "receipt_ids": [
    "sha256:e5536556c6db7f71e836adab1dd86f16b17b9b0edbfa32c2731b3d4051743054",
    "sha256:e155187c021e8a4b38246193110d5c531d0f94df110a34d2190b46d67501a42a"
  ]
}
```

Local runx CLI version: `runx-cli 0.6.14` (Frantic #65 minimum is `0.6.13`).

# Files

- `skills/deliverability-judge/SKILL.md` — typed contract with inputs, outputs, and rules.
- `skills/deliverability-judge/X.yaml` — `skill: deliverability-judge`, `version: "0.1.0"`, harness cases, runner wiring.
- `skills/deliverability-judge/run.mjs` — deterministic node ESM runner; consumes `RUNX_INPUTS_PATH`/`RUNX_INPUTS_JSON`/stdin, emits the typed verdict + optional recommendation.

Refs Frantic bounty #65.