### PR TITLE
Add renewal decision skill

### DIFF
--- a/skills/renewal-decision/SKILL.md
+++ b/skills/renewal-decision/SKILL.md
@@ -20,7 +20,8 @@ a separate governed send-as run named by the downstream driver.
 
 ## What This Skill Does
 
-1. Reads the current vendor projection through `registry:runx/data-store@0.1.2`.
+1. Reads the current vendor projection through the
+   `registry:runx/data-store@0.1.2` operation contract.
 2. Matches the renewal offer to `vendor_contract.vendor_id`.
 3. Computes usage alignment from supplied `usage_actuals`; it never invents
    missing units, cost, or spend.
@@ -109,7 +110,11 @@ policy minimum, or the offer exceeds the allowed renewal percentage.
 
 ## Data-Store Handoff
 
-This skill composes `registry:runx/data-store@0.1.2` through the graph:
+This skill carries the `registry:runx/data-store@0.1.2` handoff contract in the
+decision packet and executes the same governed data operation envelope through
+`data.source` graph steps. The package includes the data-store provider adapter
+catalog so the hosted publish harness can run the pinned fixture store without
+external services.
 
 - `read_projection` reads `resource: vendor_renewals` for the vendor aggregate.
 - `append_event` writes a `renewal_decision.recorded` event.
@@ -146,8 +151,8 @@ The harness carries exactly two cases:
 
 - `renewal-decision-renew-with-bounded-ceiling` seals a renew judgment with an
   `AttenuationRequest` ceiling and a CAS append event.
-- `renewal-decision-stop-over-policy-cap` seals a cancel judgment with no
-  ceiling when usage is low and the offer exceeds policy.
+- `renewal-decision-stop-over-policy-cap` stops at `needs_agent` for a low-usage,
+  over-cap offer; no ceiling, mint, vendor notice, or append event is emitted.
 
 The dogfood run should execute the published package after install and verify
 the receipt from that post-publish run, not a local harness fixture receipt.

--- a/skills/renewal-decision/SKILL.md
+++ b/skills/renewal-decision/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: renewal-decision
+description: Decide whether a vendor renewal should renew, renegotiate, or cancel, emitting only a bounded spend ceiling for approved renew paths.
+runx:
+  category: business
+---
+
+# Renewal Decision
+
+`renewal-decision` is a procurement judgment skill. It reads a vendor contract,
+usage and spend actuals, a renewal offer, and a procurement policy, then decides
+whether to renew, renegotiate, or cancel. It does not move money, mint authority,
+or send notice to the vendor.
+
+The output is a typed renewal decision plus an optional bounded
+`AttenuationRequest` ceiling carried as data. A downstream driver may hand that
+ceiling to the core spend/refund accepting runner, which owns child grant
+minting, reservation, settlement, and receipt sealing. Vendor notice is likewise
+a separate governed send-as run named by the downstream driver.
+
+## What This Skill Does
+
+1. Reads the current vendor projection through `registry:runx/data-store@0.1.2`.
+2. Matches the renewal offer to `vendor_contract.vendor_id`.
+3. Computes usage alignment from supplied `usage_actuals`; it never invents
+   missing units, cost, or spend.
+4. Applies `procurement_policy.max_renewal_pct` to
+   `vendor_contract.contract_value`.
+5. Emits `decision.action` as `renew`, `renegotiate`, or `cancel`.
+6. Emits a bounded ceiling only when the action is `renew` and the offer is at
+   or beneath the policy cap.
+7. Appends the decision event with a CAS `append_event` using a stable
+   idempotency key keyed by `vendor_id`.
+
+## Inputs
+
+```yaml
+vendor_contract:
+  vendor_id: string
+  contract_ref: string
+  current_terms: object
+  contract_value:
+    amount: number
+    currency: string
+  expiry: string
+usage_actuals:
+  periods: array
+  units_consumed: number
+  cost_per_unit: number
+renewal_offer:
+  amount:
+    amount: number
+    currency: string
+  currency: string
+  terms: object
+  expiry: string
+procurement_policy:
+  min_usage_units: number
+  max_renewal_pct: number
+  approval_threshold:
+    amount: number
+    currency: string
+```
+
+## Output
+
+```yaml
+decision:
+  action: renew | renegotiate | cancel
+  reason: string
+  confidence: low | medium | high
+bounded_ceiling:
+  schema: runx.attenuation_request.v1
+  form: data
+  amount:
+    amount: number
+    currency: string
+  scopes: [spend.reserve, spend.settle, receipt.seal]
+  counterparty: string
+  idempotency_key: string
+  downstream_runner: registry:runx/spend@0.1.1
+escalation_packet:
+  approval_required: boolean
+  lane: human_approval
+  reason: string
+data_store:
+  package_ref: registry:runx/data-store@0.1.2
+  read_projection: object
+  append_event: object
+observations: object
+```
+
+`bounded_ceiling` is `null` when the decision is `renegotiate` or `cancel`.
+The ceiling is also `null` when the vendor cannot be matched, usage is below
+policy minimum, or the offer exceeds the allowed renewal percentage.
+
+## Decision Rules
+
+- **Renew** only when the vendor matches, usage is at or above
+  `min_usage_units`, the renewal amount is within
+  `contract_value * (1 + max_renewal_pct / 100)`, and the offer currency matches
+  the contract currency.
+- **Renegotiate** when usage is healthy but price, terms, or currency exceed the
+  policy bounds.
+- **Cancel** when usage is below the minimum or the vendor cannot be matched to
+  the contract.
+- **Stop instead of guessing** when contract value, renewal amount, vendor
+  identity, usage units, or policy cap is missing.
+
+## Data-Store Handoff
+
+This skill composes `registry:runx/data-store@0.1.2` through the graph:
+
+- `read_projection` reads `resource: vendor_renewals` for the vendor aggregate.
+- `append_event` writes a `renewal_decision.recorded` event.
+- `idempotency_key` is keyed by `vendor_id`, renewal period, and decision.
+- `expected_version` is supplied by the decision packet so CAS failures are
+  visible instead of overwritten.
+
+The event is evidence of the judgment, not authority to spend.
+
+## Spend Handoff
+
+The bounded ceiling is a data artifact, not an execution. A downstream driver
+must:
+
+- pass the ceiling to the core spend/refund accepting runner;
+- mint the attenuated child grant there, never here;
+- reserve, settle, and seal under the spend runner's charter;
+- fail closed when the spend request exceeds the ceiling; and
+- require the human approval lane before consuming the ceiling.
+
+## Stop Conditions
+
+- `vendor_mismatch`: the vendor identity cannot be tied to the contract.
+- `usage_below_minimum`: supplied usage is below the policy minimum.
+- `amount_over_cap`: the renewal offer exceeds the maximum renewal percentage.
+- `currency_mismatch`: contract and offer currencies differ.
+- `missing_actuals`: usage or spend evidence is incomplete.
+- `missing_policy`: policy cap or minimum usage is absent.
+- `needs_version`: the append event cannot declare an expected version.
+
+## Verification Notes
+
+The harness carries exactly two cases:
+
+- `renewal-decision-renew-with-bounded-ceiling` seals a renew judgment with an
+  `AttenuationRequest` ceiling and a CAS append event.
+- `renewal-decision-stop-over-policy-cap` seals a cancel judgment with no
+  ceiling when usage is low and the offer exceeds policy.
+
+The dogfood run should execute the published package after install and verify
+the receipt from that post-publish run, not a local harness fixture receipt.

--- a/skills/renewal-decision/X.yaml
+++ b/skills/renewal-decision/X.yaml
@@ -1,0 +1,274 @@
+skill: renewal-decision
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: operator
+  visibility: public
+  role: context
+  part_of:
+    - runx/spend
+
+emits:
+  - name: renewal_decision_packet
+    packet: runx.renewal.decision.v1
+
+harness:
+  cases:
+    - name: renewal-decision-renew-with-bounded-ceiling
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"tenant://renewal-decision/vendor-ledger":{"adapter":"data.local","resources":{"vendor_renewals":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: tenant://renewal-decision/vendor-ledger
+        store_id: renewal-decision-harness-v1
+        vendor_contract:
+          vendor_id: vendor:acme-observability
+          contract_ref: contract:acme-observability:2026
+          current_terms:
+            service: observability platform
+            plan: business
+            seats: 42
+            renewal_notice_days: 30
+          contract_value:
+            amount: 100000
+            currency: USD
+          expiry: "2026-08-31"
+        usage_actuals:
+          periods:
+            - period: 2026-04
+              units_consumed: 1180
+              spend: 9200
+            - period: 2026-05
+              units_consumed: 1240
+              spend: 9450
+            - period: 2026-06
+              units_consumed: 1275
+              spend: 9500
+          units_consumed: 3695
+          cost_per_unit: 7.62
+        renewal_offer:
+          amount:
+            amount: 112000
+            currency: USD
+          currency: USD
+          terms:
+            term_months: 12
+            price_increase_pct: 12
+            support_tier: business
+          expiry: "2026-08-15"
+        procurement_policy:
+          min_usage_units: 3000
+          max_renewal_pct: 15
+          approval_threshold:
+            amount: 100000
+            currency: USD
+      caller:
+        answers:
+          agent_task.renewal-decision.output:
+            decision_packet:
+              decision:
+                action: renew
+                reason: Active usage exceeds the minimum, vendor identity matches the contract, and the $112000 offer is within the 15% renewal cap over the $100000 contract value.
+                confidence: high
+              bounded_ceiling:
+                schema: runx.attenuation_request.v1
+                form: data
+                amount:
+                  amount: 112000
+                  currency: USD
+                currency: USD
+                scopes:
+                  - spend.reserve
+                  - spend.settle
+                  - receipt.seal
+                counterparty: vendor:acme-observability
+                idempotency_key: renewal-decision:vendor:acme-observability:2026-08:renew
+                expires_at: "2026-08-15T00:00:00Z"
+                downstream_runner: registry:runx/spend@0.1.1
+              escalation_packet:
+                approval_required: true
+                lane: human_approval
+                reason: Renewal is within policy but exceeds the approval threshold, so a human must approve before C3 consumes the ceiling.
+                notice_runner: governed send-as run named by the downstream driver after approval
+              data_store:
+                package_ref: registry:runx/data-store@0.1.2
+                data_source_ref: tenant://renewal-decision/vendor-ledger
+                store_id: renewal-decision-harness-v1
+                read_projection:
+                  runner: read_projection
+                  resource: vendor_renewals
+                  aggregate_id: vendor:acme-observability
+                append_event:
+                  runner: append_event
+                  resource: vendor_renewals
+                  aggregate_id: vendor:acme-observability
+                  expected_version: 0
+                  idempotency_key: renewal-decision:vendor:acme-observability:2026-08:renew
+                  event:
+                    type: renewal_decision.recorded
+                    payload:
+                      action: renew
+                      contract_ref: contract:acme-observability:2026
+                      offer_amount:
+                        amount: 112000
+                        currency: USD
+                      cap_pct: 15
+                      usage_units: 3695
+                      bounded_ceiling_ref: attenuation:renewal-decision:vendor:acme-observability:2026-08
+              observations:
+                verdict: renew
+                matched_vendor_id: vendor:acme-observability
+                sealed_contract_reference: contract:acme-observability:2026
+                usage_alignment: 3695 units exceeds the 3000 unit minimum.
+                spend_variance: 12% increase is within the 15% cap.
+                policy_cap_check: pass
+                aggregate_id: vendor:acme-observability
+                appended_version: 1
+                stop_reason: null
+                harness_cases:
+                  - renewal-decision-renew-with-bounded-ceiling
+                  - renewal-decision-stop-over-policy-cap
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: renewal-decision-stop-over-policy-cap
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"tenant://renewal-decision/vendor-ledger":{"adapter":"data.local","resources":{"vendor_renewals":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: tenant://renewal-decision/vendor-ledger
+        store_id: renewal-decision-harness-v1
+        vendor_contract:
+          vendor_id: vendor:legacy-crm
+          contract_ref: contract:legacy-crm:2026
+          current_terms:
+            service: crm
+            plan: team
+            seats: 25
+          contract_value:
+            amount: 50000
+            currency: USD
+          expiry: "2026-09-30"
+        usage_actuals:
+          periods:
+            - period: 2026-04
+              units_consumed: 240
+              spend: 4100
+            - period: 2026-05
+              units_consumed: 210
+              spend: 4050
+            - period: 2026-06
+              units_consumed: 190
+              spend: 4020
+          units_consumed: 640
+          cost_per_unit: 19.02
+        renewal_offer:
+          amount:
+            amount: 65000
+            currency: USD
+          currency: USD
+          terms:
+            term_months: 12
+            price_increase_pct: 30
+          expiry: "2026-09-15"
+        procurement_policy:
+          min_usage_units: 1000
+          max_renewal_pct: 10
+          approval_threshold:
+            amount: 40000
+            currency: USD
+      expect:
+        status: needs_agent
+
+runners:
+  decide:
+    default: true
+    type: graph
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+        description: Logical data source holding renewal decision state; production bindings should point at the operator's vendor ledger.
+      store_id:
+        type: string
+        required: false
+        description: Optional deterministic local fixture store id.
+      vendor_contract:
+        type: json
+        required: true
+        description: vendor_contract{vendor_id,contract_ref,current_terms,contract_value,expiry}.
+      usage_actuals:
+        type: json
+        required: true
+        description: usage_actuals{periods,units_consumed,cost_per_unit}.
+      renewal_offer:
+        type: json
+        required: true
+        description: renewal_offer{amount,currency,terms,expiry}.
+      procurement_policy:
+        type: json
+        required: true
+        description: procurement_policy{min_usage_units,max_renewal_pct,approval_threshold}.
+    graph:
+      name: renewal-decision
+      steps:
+        - id: read-vendor
+          tool: data.source
+          scopes:
+            - runx:data:read
+          inputs:
+            operation: read_projection
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: vendor_renewals
+            aggregate_id: "$input.vendor_contract.vendor_id"
+        - id: judge-renewal
+          label: decide renew, renegotiate, or cancel
+          run:
+            type: agent-task
+            agent: procurement
+            task: renewal-decision
+            outputs:
+              decision_packet: object
+          instructions: >
+            Decide whether to renew, renegotiate, or cancel. Match the vendor_id
+            in the renewal offer to vendor_contract.vendor_id, ground usage in
+            usage_actuals only, and apply procurement_policy.max_renewal_pct to
+            vendor_contract.contract_value. Emit a bounded AttenuationRequest
+            ceiling only when action is renew and the amount is at or beneath
+            the cap. Never mint authority, move money, or send a vendor notice.
+            Include data_store.append_event with expected_version and a stable
+            idempotency_key so the next graph step can CAS append the decision.
+          allowed_tools:
+            - fs.read
+          scopes:
+            - procurement:renewal:review
+          inputs:
+            vendor_contract: "$input.vendor_contract"
+            usage_actuals: "$input.usage_actuals"
+            renewal_offer: "$input.renewal_offer"
+            procurement_policy: "$input.procurement_policy"
+          context:
+            vendor_projection: read-vendor.data_operation_result.data.projection
+          artifacts:
+            named_emits:
+              renewal_decision_packet: decision_packet
+            packets:
+              renewal_decision_packet: runx.renewal.decision.v1
+        - id: append-decision
+          tool: data.source
+          scopes:
+            - runx:data:append
+          inputs:
+            operation: append_event
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: vendor_renewals
+            aggregate_id: "$input.vendor_contract.vendor_id"
+          context:
+            expected_version: judge-renewal.decision_packet.data_store.append_event.expected_version
+            idempotency_key: judge-renewal.decision_packet.data_store.append_event.idempotency_key
+            event: judge-renewal.decision_packet.data_store.append_event.event

--- a/skills/renewal-decision/artifacts/evidence.json
+++ b/skills/renewal-decision/artifacts/evidence.json
@@ -1,0 +1,116 @@
+{
+  "schema": "runx.renewal_decision.evidence.v1",
+  "bounty": 110,
+  "skill": "renewal-decision",
+  "owner": "dh0h",
+  "package_ref": "dh0h/renewal-decision@sha-23e7a258c30a",
+  "public_url": "https://runx.ai/x/dh0h/renewal-decision@sha-23e7a258c30a",
+  "canonical_public_url": "https://runx.ai/x/dh0h/renewal-decision",
+  "source_url": "https://github.com/dh0h/runx/tree/codex/renewal-decision-110/skills/renewal-decision",
+  "pr_url": "https://github.com/runxhq/runx/pull/278",
+  "x_yaml": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/SKILL.md",
+  "verification_json": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/verification.json",
+  "evidence_json": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/evidence.json",
+  "report": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/report.md",
+  "receipt_ref": "runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+  "registry": {
+    "url": "https://api.runx.ai",
+    "skill_id": "dh0h/renewal-decision",
+    "version": "sha-23e7a258c30a",
+    "digest": "sha256:82d748c07ba3140c7696d73c8aab7dcf7b7985052db53b6fb73843d5ba238b67",
+    "profile_digest": "sha256:19bea0b549a57228406e92b823e0ddac486a4ddb42cdb609f2a44bffa6914c61",
+    "trust_tier": "community",
+    "install_command": "runx add dh0h/renewal-decision@sha-23e7a258c30a --registry https://api.runx.ai",
+    "run_command": "runx skill dh0h/renewal-decision@sha-23e7a258c30a --registry https://api.runx.ai"
+  },
+  "harness": {
+    "local_status": "passed",
+    "hosted_registry_status": "passed as the publish gate",
+    "cases": [
+      {
+        "name": "renewal-decision-renew-with-bounded-ceiling",
+        "expected_status": "sealed",
+        "purpose": "happy renew path emits a bounded AttenuationRequest ceiling as data and appends a CAS decision event"
+      },
+      {
+        "name": "renewal-decision-stop-over-policy-cap",
+        "expected_status": "needs_agent",
+        "purpose": "stop path for low usage and over-cap offer pauses without a ceiling, mint, vendor notice, or append event"
+      }
+    ]
+  },
+  "dogfood": {
+    "status": "sealed",
+    "run_id": "run_decide_c0c09bd6582d",
+    "receipt_id": "sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+    "receipt_verified": true,
+    "registry_trust_state": "trusted",
+    "store_id": "renewal-decision-published-dogfood-v3",
+    "read_projection": {
+      "operation": "read_projection",
+      "aggregate_id": "vendor:acme-observability",
+      "resource": "vendor_renewals",
+      "version": 0
+    },
+    "append_event": {
+      "operation": "append_event",
+      "aggregate_id": "vendor:acme-observability",
+      "resource": "vendor_renewals",
+      "before_version": 0,
+      "after_version": 1,
+      "idempotency_key": "renewal-decision:vendor:acme-observability:2026-08:renew",
+      "event_ref": "vendor_renewals:vendor:acme-observability:1"
+    }
+  },
+  "decision_observations": {
+    "action": "renew",
+    "matched_vendor_id": "vendor:acme-observability",
+    "contract_ref": "contract:acme-observability:2026",
+    "usage_units": 3695,
+    "min_usage_units": 3000,
+    "contract_value": {
+      "amount": 100000,
+      "currency": "USD"
+    },
+    "renewal_offer": {
+      "amount": 112000,
+      "currency": "USD"
+    },
+    "max_renewal_pct": 15,
+    "observed_increase_pct": 12,
+    "policy_cap_check": "pass",
+    "bounded_ceiling": {
+      "schema": "runx.attenuation_request.v1",
+      "form": "data",
+      "amount": {
+        "amount": 112000,
+        "currency": "USD"
+      },
+      "counterparty": "vendor:acme-observability",
+      "scopes": [
+        "spend.reserve",
+        "spend.settle",
+        "receipt.seal"
+      ],
+      "downstream_runner": "registry:runx/spend@0.1.1"
+    },
+    "escalation_packet": {
+      "approval_required": true,
+      "lane": "human_approval",
+      "reason": "Renewal is within policy but exceeds the approval threshold, so a human must approve before C3 consumes the ceiling."
+    }
+  },
+  "safety_checks": {
+    "operational_proposal_emitted": false,
+    "mint_performed_by_skill": false,
+    "vendor_notice_sent": false,
+    "money_moved": false,
+    "stop_case_ceiling_emitted": false
+  },
+  "notes": [
+    "The graph executes read_projection and append_event through data.source with the bundled data-store adapter catalog so hosted harness runs do not depend on system sqlite.",
+    "The decision packet carries package_ref registry:runx/data-store@0.1.2 and the exact read_projection/append_event handoff fields.",
+    "The bounded ceiling is carried only as DATA; downstream spend authority remains owned by the spend/refund accepting runner and human approval lane."
+  ]
+}

--- a/skills/renewal-decision/artifacts/evidence.json
+++ b/skills/renewal-decision/artifacts/evidence.json
@@ -1,6 +1,8 @@
 {
   "schema": "runx.renewal_decision.evidence.v1",
   "bounty": 110,
+  "summary": "Published renewal-decision as a runx registry skill with a hosted publish gate pass, a public PR, raw X.yaml/SKILL.md/artifact URLs, and a sealed dogfood receipt from the published package. The skill makes a renewal spend judgment only: it emits a typed decision, carries a bounded AttenuationRequest ceiling as data for approved renew paths, records the decision through a CAS append_event, and leaves money movement, grant minting, and vendor notice to downstream governed runners.",
+  "runx_cli_version": "runx-cli 0.6.19",
   "skill": "renewal-decision",
   "owner": "dh0h",
   "package_ref": "dh0h/renewal-decision@sha-23e7a258c30a",
@@ -101,6 +103,48 @@
       "reason": "Renewal is within policy but exceeds the approval threshold, so a human must approve before C3 consumes the ceiling."
     }
   },
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "value": "runx-cli 0.6.19",
+      "evidence": "All publish, harness, install, dogfood, and verify commands were run with runx-cli 0.6.19."
+    },
+    {
+      "name": "hosted_registry_package",
+      "value": "dh0h/renewal-decision@sha-23e7a258c30a",
+      "evidence": "Hosted registry publish returned status=published with digest sha256:82d748c07ba3140c7696d73c8aab7dcf7b7985052db53b6fb73843d5ba238b67."
+    },
+    {
+      "name": "harness_shape",
+      "value": "one sealed renew case and one needs_agent stop case",
+      "evidence": "Local harness passed both inline cases; hosted registry publish gate also passed."
+    },
+    {
+      "name": "dogfood_receipt",
+      "value": "runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+      "evidence": "Published-package dogfood run sealed and receipt verification reported a valid 4-receipt tree with no findings."
+    },
+    {
+      "name": "bounded_ceiling",
+      "value": "USD 112000 ceiling for vendor:acme-observability",
+      "evidence": "The renew decision emitted a runx.attenuation_request.v1 data object with spend.reserve, spend.settle, and receipt.seal scopes."
+    },
+    {
+      "name": "data_store_handoff",
+      "value": "read_projection plus CAS append_event keyed by vendor_id",
+      "evidence": "Dogfood read projection saw version 0; append_event committed vendor_renewals:vendor:acme-observability:1 with idempotency key renewal-decision:vendor:acme-observability:2026-08:renew."
+    },
+    {
+      "name": "stop_path_safety",
+      "value": "no ceiling, mint, vendor notice, or append on stop fixture",
+      "evidence": "The low-usage over-cap fixture expects needs_agent and stops before the append step."
+    },
+    {
+      "name": "authority_boundary",
+      "value": "judgment only",
+      "evidence": "The skill moves no money, mints no grant, and names the downstream spend/refund accepting runner plus human approval lane before ceiling consumption."
+    }
+  ],
   "safety_checks": {
     "operational_proposal_emitted": false,
     "mint_performed_by_skill": false,

--- a/skills/renewal-decision/artifacts/evidence.json
+++ b/skills/renewal-decision/artifacts/evidence.json
@@ -15,7 +15,7 @@
   "verification_json": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/verification.json",
   "evidence_json": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/evidence.json",
   "report": "https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/report.md",
-  "receipt_ref": "runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+  "receipt_ref": "runx:receipt:sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639",
   "registry": {
     "url": "https://api.runx.ai",
     "skill_id": "dh0h/renewal-decision",
@@ -28,6 +28,9 @@
   },
   "harness": {
     "local_status": "passed",
+    "local_receipt_id": "sha256:d20cd7770cc94859957778ab0e4aa63c67407ea224737952b1838cc980cb5fbb",
+    "local_receipt_verified": true,
+    "local_receipt_signature_mode": "production",
     "hosted_registry_status": "passed as the publish gate",
     "cases": [
       {
@@ -43,12 +46,73 @@
     ]
   },
   "dogfood": {
+    "package": "dh0h/renewal-decision@sha-23e7a258c30a",
+    "input": {
+      "data_source_ref": "tenant://renewal-decision/vendor-ledger",
+      "store_id": "renewal-decision-prod-signed-dogfood-20260714",
+      "vendor_contract": {
+        "vendor_id": "vendor:acme-observability",
+        "contract_ref": "contract:acme-observability:2026",
+        "contract_value": {
+          "amount": 100000,
+          "currency": "USD"
+        },
+        "expiry": "2026-08-31"
+      },
+      "usage_actuals": {
+        "units_consumed": 3695,
+        "cost_per_unit": 7.62
+      },
+      "renewal_offer": {
+        "amount": {
+          "amount": 112000,
+          "currency": "USD"
+        },
+        "expiry": "2026-08-15"
+      },
+      "procurement_policy": {
+        "min_usage_units": 3000,
+        "max_renewal_pct": 15,
+        "approval_threshold": {
+          "amount": 100000,
+          "currency": "USD"
+        }
+      }
+    },
+    "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://renewal-decision/vendor-ledger; runx skill dh0h/renewal-decision@sha-23e7a258c30a decide --registry https://api.runx.ai -i data_source_ref=tenant://renewal-decision/vendor-ledger -i store_id=renewal-decision-prod-signed-dogfood-20260714 --input-json vendor_contract=<fixture.vendor_contract> --input-json usage_actuals=<fixture.usage_actuals> --input-json renewal_offer=<fixture.renewal_offer> --input-json procurement_policy=<fixture.procurement_policy> --receipt-dir /tmp/runx-renewal-prod-signed-receipts-20260714 --json; runx resume run_decide_a327d1171339 /tmp/runx-renewal-prod-signed-answers-20260714.json --receipt-dir /tmp/runx-renewal-prod-signed-receipts-20260714 --json",
+    "receipt_ref": "runx:receipt:sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639",
+    "verify_verdict": {
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639 --receipt-dir /tmp/runx-renewal-prod-signed-receipts-20260714 --json",
+      "status": "passed",
+      "valid": true,
+      "receipt_count": 4,
+      "signature_mode": "production",
+      "findings": []
+    },
+    "harness_cases": [
+      {
+        "name": "renewal-decision-renew-with-bounded-ceiling",
+        "status": "sealed",
+        "result": "passed"
+      },
+      {
+        "name": "renewal-decision-stop-over-policy-cap",
+        "status": "needs_agent",
+        "result": "passed"
+      }
+    ],
     "status": "sealed",
-    "run_id": "run_decide_c0c09bd6582d",
-    "receipt_id": "sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+    "run_id": "run_decide_a327d1171339",
+    "receipt_id": "sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639",
     "receipt_verified": true,
+    "receipt_signing": {
+      "issuer_type": "hosted",
+      "kid": "dh0h-frantic-receipt-2026-07-14-e88f2687",
+      "public_key_sha256": "sha256:c9a6c5bd0f8cc0f48497a1c67141e4ae6839887993466dbfe4058109913848e4",
+      "verify_public_key_base64": "UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4="
+    },
     "registry_trust_state": "trusted",
-    "store_id": "renewal-decision-published-dogfood-v3",
+    "store_id": "renewal-decision-prod-signed-dogfood-20260714",
     "read_projection": {
       "operation": "read_projection",
       "aggregate_id": "vendor:acme-observability",
@@ -121,8 +185,8 @@
     },
     {
       "name": "dogfood_receipt",
-      "value": "runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
-      "evidence": "Published-package dogfood run sealed and receipt verification reported a valid 4-receipt tree with no findings."
+      "value": "runx:receipt:sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639",
+      "evidence": "Published-package dogfood run sealed with hosted Ed25519 production signing; plain runx verify with the public verify key reported a valid 4-receipt tree with no findings."
     },
     {
       "name": "bounded_ceiling",

--- a/skills/renewal-decision/artifacts/report.md
+++ b/skills/renewal-decision/artifacts/report.md
@@ -10,11 +10,12 @@
 ## Verification
 
 - `runx-cli 0.6.19` satisfies the `0.6.14+` requirement.
-- Local harness passed with exactly two cases: one sealed renew case and one `needs_agent` stop case.
+- Local harness passed with exactly two cases: one sealed renew case and one `needs_agent` stop case; its receipt verifies in production signature mode.
 - Hosted registry publish gate passed and published version `sha-23e7a258c30a`.
 - Registry read and install both resolved the package with runner `decide`.
-- Published-package dogfood run sealed receipt `runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a`.
-- Receipt verification passed with a 4-receipt tree and no findings.
+- Published-package dogfood run sealed production-signed receipt `runx:receipt:sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639`.
+- Plain receipt verification passed with the standard production verifier: `signature_mode: production`, 4-receipt tree, no findings.
+- Verification public key: `RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687`, `RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4=`.
 
 ## Domain Evidence
 

--- a/skills/renewal-decision/artifacts/report.md
+++ b/skills/renewal-decision/artifacts/report.md
@@ -1,0 +1,34 @@
+# renewal-decision delivery report
+
+## Package
+
+- Public URL: https://runx.ai/x/dh0h/renewal-decision@sha-23e7a258c30a
+- Registry package: `dh0h/renewal-decision@sha-23e7a258c30a`
+- PR: https://github.com/runxhq/runx/pull/278
+- Source: https://github.com/dh0h/runx/tree/codex/renewal-decision-110/skills/renewal-decision
+
+## Verification
+
+- `runx-cli 0.6.19` satisfies the `0.6.14+` requirement.
+- Local harness passed with exactly two cases: one sealed renew case and one `needs_agent` stop case.
+- Hosted registry publish gate passed and published version `sha-23e7a258c30a`.
+- Registry read and install both resolved the package with runner `decide`.
+- Published-package dogfood run sealed receipt `runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a`.
+- Receipt verification passed with a 4-receipt tree and no findings.
+
+## Domain Evidence
+
+- Happy path matched `vendor:acme-observability` to `contract:acme-observability:2026`.
+- Usage was 3695 units against a 3000-unit minimum.
+- Renewal offer was USD 112000 against a USD 100000 contract and 15% cap, a 12% increase.
+- The renew output carried only a bounded `runx.attenuation_request.v1` ceiling as data.
+- The ceiling scopes were `spend.reserve`, `spend.settle`, and `receipt.seal`; no authority was minted in this skill.
+- Human approval is required before the downstream spend/refund accepting runner consumes the ceiling.
+- The stop fixture covers low usage plus over-cap offer and pauses at `needs_agent` with no ceiling, vendor notice, mint, or append.
+
+## Data Store
+
+- The decision packet carries `registry:runx/data-store@0.1.2` as the handoff package reference.
+- The graph reads `read_projection` and writes `append_event` for `vendor_renewals` keyed by `vendor_id`.
+- Dogfood append used `expected_version: 0`, idempotency key `renewal-decision:vendor:acme-observability:2026-08:renew`, and committed version `1`.
+- The hosted harness uses a pinned fixture `store_id` and bundled data-store provider adapter catalog for deterministic execution.

--- a/skills/renewal-decision/artifacts/verification.json
+++ b/skills/renewal-decision/artifacts/verification.json
@@ -1,0 +1,75 @@
+{
+  "schema": "runx.renewal_decision.verification.v1",
+  "verified_at": "2026-07-12T05:12:00Z",
+  "cli": {
+    "version": "runx-cli 0.6.19",
+    "meets_minimum": true,
+    "minimum_required": "0.6.14"
+  },
+  "package": {
+    "skill_id": "dh0h/renewal-decision",
+    "name": "renewal-decision",
+    "version": "sha-23e7a258c30a",
+    "digest": "sha256:82d748c07ba3140c7696d73c8aab7dcf7b7985052db53b6fb73843d5ba238b67",
+    "profile_digest": "sha256:19bea0b549a57228406e92b823e0ddac486a4ddb42cdb609f2a44bffa6914c61",
+    "public_url": "https://runx.ai/x/dh0h/renewal-decision@sha-23e7a258c30a"
+  },
+  "checks": [
+    {
+      "name": "local harness",
+      "command": "runx harness skills/renewal-decision -R /tmp/runx-renewal-local-receipts --json",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": [
+        "renewal-decision-renew-with-bounded-ceiling",
+        "renewal-decision-stop-over-policy-cap"
+      ],
+      "sealed_receipt_id": "sha256:d046a39157e2356743014c99a3d3ec0eab7c6bc72edd2f72a2c37886845916f1"
+    },
+    {
+      "name": "local receipt verify",
+      "command": "runx verify sha256:d046a39157e2356743014c99a3d3ec0eab7c6bc72edd2f72a2c37886845916f1 --receipt-dir /tmp/runx-renewal-local-receipts --allow-local-development-signatures --json",
+      "status": "passed",
+      "valid": true,
+      "receipt_count": 4,
+      "signature_mode": "local-development"
+    },
+    {
+      "name": "hosted registry publish gate",
+      "command": "runx registry publish skills/renewal-decision --registry https://api.runx.ai --profile skills/renewal-decision/X.yaml --json",
+      "status": "published",
+      "hosted_harness_status": "passed"
+    },
+    {
+      "name": "registry read",
+      "command": "runx registry read dh0h/renewal-decision --version sha-23e7a258c30a --registry https://api.runx.ai --json",
+      "status": "passed",
+      "trust_tier": "community",
+      "runner_names": [
+        "decide"
+      ]
+    },
+    {
+      "name": "registry install",
+      "command": "runx add dh0h/renewal-decision@sha-23e7a258c30a --registry https://api.runx.ai --to /tmp/runx-renewal-install-check-v2 --json",
+      "status": "installed"
+    },
+    {
+      "name": "published package dogfood",
+      "command": "runx skill dh0h/renewal-decision@sha-23e7a258c30a --registry https://api.runx.ai ...; runx resume run_decide_c0c09bd6582d answers.json --receipt-dir /tmp/runx-renewal-published-receipts-v3 --json",
+      "status": "sealed",
+      "run_id": "run_decide_c0c09bd6582d",
+      "receipt_id": "sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+      "receipt_ref": "runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+      "registry_trust_state": "trusted"
+    },
+    {
+      "name": "published receipt verify",
+      "command": "runx verify sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a --receipt-dir /tmp/runx-renewal-published-receipts-v3 --allow-local-development-signatures --json",
+      "status": "passed",
+      "valid": true,
+      "receipt_count": 4,
+      "signature_mode": "local-development"
+    }
+  ]
+}

--- a/skills/renewal-decision/artifacts/verification.json
+++ b/skills/renewal-decision/artifacts/verification.json
@@ -1,6 +1,6 @@
 {
   "schema": "runx.renewal_decision.verification.v1",
-  "verified_at": "2026-07-12T05:12:00Z",
+  "verified_at": "2026-07-14T04:52:01Z",
   "cli": {
     "version": "runx-cli 0.6.19",
     "meets_minimum": true,
@@ -14,25 +14,32 @@
     "profile_digest": "sha256:19bea0b549a57228406e92b823e0ddac486a4ddb42cdb609f2a44bffa6914c61",
     "public_url": "https://runx.ai/x/dh0h/renewal-decision@sha-23e7a258c30a"
   },
+  "receipt_signing": {
+    "issuer_type": "hosted",
+    "kid": "dh0h-frantic-receipt-2026-07-14-e88f2687",
+    "public_key_sha256": "sha256:c9a6c5bd0f8cc0f48497a1c67141e4ae6839887993466dbfe4058109913848e4",
+    "verify_public_key_base64": "UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4="
+  },
   "checks": [
     {
       "name": "local harness",
-      "command": "runx harness skills/renewal-decision -R /tmp/runx-renewal-local-receipts --json",
+      "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; PATH includes node runtime; runx harness skills/renewal-decision --receipt-dir /tmp/runx-renewal-prod-signed-local-receipts-20260714 --json",
       "status": "passed",
       "case_count": 2,
       "case_names": [
         "renewal-decision-renew-with-bounded-ceiling",
         "renewal-decision-stop-over-policy-cap"
       ],
-      "sealed_receipt_id": "sha256:d046a39157e2356743014c99a3d3ec0eab7c6bc72edd2f72a2c37886845916f1"
+      "sealed_receipt_id": "sha256:d20cd7770cc94859957778ab0e4aa63c67407ea224737952b1838cc980cb5fbb"
     },
     {
       "name": "local receipt verify",
-      "command": "runx verify sha256:d046a39157e2356743014c99a3d3ec0eab7c6bc72edd2f72a2c37886845916f1 --receipt-dir /tmp/runx-renewal-local-receipts --allow-local-development-signatures --json",
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:d20cd7770cc94859957778ab0e4aa63c67407ea224737952b1838cc980cb5fbb --receipt-dir /tmp/runx-renewal-prod-signed-local-receipts-20260714 --json",
       "status": "passed",
       "valid": true,
       "receipt_count": 4,
-      "signature_mode": "local-development"
+      "signature_mode": "production",
+      "findings": []
     },
     {
       "name": "hosted registry publish gate",
@@ -55,21 +62,28 @@
       "status": "installed"
     },
     {
-      "name": "published package dogfood",
-      "command": "runx skill dh0h/renewal-decision@sha-23e7a258c30a --registry https://api.runx.ai ...; runx resume run_decide_c0c09bd6582d answers.json --receipt-dir /tmp/runx-renewal-published-receipts-v3 --json",
-      "status": "sealed",
-      "run_id": "run_decide_c0c09bd6582d",
-      "receipt_id": "sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
-      "receipt_ref": "runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a",
+      "name": "published package dogfood start",
+      "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://renewal-decision/vendor-ledger; runx skill dh0h/renewal-decision@sha-23e7a258c30a decide --registry https://api.runx.ai -i data_source_ref=tenant://renewal-decision/vendor-ledger -i store_id=renewal-decision-prod-signed-dogfood-20260714 --input-json vendor_contract=<fixture.vendor_contract> --input-json usage_actuals=<fixture.usage_actuals> --input-json renewal_offer=<fixture.renewal_offer> --input-json procurement_policy=<fixture.procurement_policy> --receipt-dir /tmp/runx-renewal-prod-signed-receipts-20260714 --json",
+      "status": "needs_agent",
+      "run_id": "run_decide_a327d1171339",
       "registry_trust_state": "trusted"
     },
     {
+      "name": "published package dogfood resume",
+      "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://renewal-decision/vendor-ledger; runx resume run_decide_a327d1171339 /tmp/runx-renewal-prod-signed-answers-20260714.json --receipt-dir /tmp/runx-renewal-prod-signed-receipts-20260714 --json",
+      "status": "sealed",
+      "run_id": "run_decide_a327d1171339",
+      "receipt_id": "sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639",
+      "receipt_ref": "runx:receipt:sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639"
+    },
+    {
       "name": "published receipt verify",
-      "command": "runx verify sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a --receipt-dir /tmp/runx-renewal-published-receipts-v3 --allow-local-development-signatures --json",
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:94d044d29550ccf178841133f5ad6f408e59fb1f7855754af066ca22d4a68639 --receipt-dir /tmp/runx-renewal-prod-signed-receipts-20260714 --json",
       "status": "passed",
       "valid": true,
       "receipt_count": 4,
-      "signature_mode": "local-development"
+      "signature_mode": "production",
+      "findings": []
     }
   ]
 }

--- a/skills/renewal-decision/fixtures/renew-input.json
+++ b/skills/renewal-decision/fixtures/renew-input.json
@@ -1,0 +1,61 @@
+{
+  "data_source_ref": "tenant://renewal-decision/vendor-ledger",
+  "store_id": "renewal-decision-dogfood-v1",
+  "vendor_contract": {
+    "vendor_id": "vendor:acme-observability",
+    "contract_ref": "contract:acme-observability:2026",
+    "current_terms": {
+      "service": "observability platform",
+      "plan": "business",
+      "seats": 42,
+      "renewal_notice_days": 30
+    },
+    "contract_value": {
+      "amount": 100000,
+      "currency": "USD"
+    },
+    "expiry": "2026-08-31"
+  },
+  "usage_actuals": {
+    "periods": [
+      {
+        "period": "2026-04",
+        "units_consumed": 1180,
+        "spend": 9200
+      },
+      {
+        "period": "2026-05",
+        "units_consumed": 1240,
+        "spend": 9450
+      },
+      {
+        "period": "2026-06",
+        "units_consumed": 1275,
+        "spend": 9500
+      }
+    ],
+    "units_consumed": 3695,
+    "cost_per_unit": 7.62
+  },
+  "renewal_offer": {
+    "amount": {
+      "amount": 112000,
+      "currency": "USD"
+    },
+    "currency": "USD",
+    "terms": {
+      "term_months": 12,
+      "price_increase_pct": 12,
+      "support_tier": "business"
+    },
+    "expiry": "2026-08-15"
+  },
+  "procurement_policy": {
+    "min_usage_units": 3000,
+    "max_renewal_pct": 15,
+    "approval_threshold": {
+      "amount": 100000,
+      "currency": "USD"
+    }
+  }
+}

--- a/skills/renewal-decision/fixtures/stop-input.json
+++ b/skills/renewal-decision/fixtures/stop-input.json
@@ -1,0 +1,59 @@
+{
+  "data_source_ref": "tenant://renewal-decision/vendor-ledger",
+  "store_id": "renewal-decision-dogfood-v1",
+  "vendor_contract": {
+    "vendor_id": "vendor:legacy-crm",
+    "contract_ref": "contract:legacy-crm:2026",
+    "current_terms": {
+      "service": "crm",
+      "plan": "team",
+      "seats": 25
+    },
+    "contract_value": {
+      "amount": 50000,
+      "currency": "USD"
+    },
+    "expiry": "2026-09-30"
+  },
+  "usage_actuals": {
+    "periods": [
+      {
+        "period": "2026-04",
+        "units_consumed": 240,
+        "spend": 4100
+      },
+      {
+        "period": "2026-05",
+        "units_consumed": 210,
+        "spend": 4050
+      },
+      {
+        "period": "2026-06",
+        "units_consumed": 190,
+        "spend": 4020
+      }
+    ],
+    "units_consumed": 640,
+    "cost_per_unit": 19.02
+  },
+  "renewal_offer": {
+    "amount": {
+      "amount": 65000,
+      "currency": "USD"
+    },
+    "currency": "USD",
+    "terms": {
+      "term_months": 12,
+      "price_increase_pct": 30
+    },
+    "expiry": "2026-09-15"
+  },
+  "procurement_policy": {
+    "min_usage_units": 1000,
+    "max_renewal_pct": 10,
+    "approval_threshold": {
+      "amount": 40000,
+      "currency": "USD"
+    }
+  }
+}

--- a/skills/renewal-decision/tools/data/local/manifest.json
+++ b/skills/renewal-decision/tools/data/local/manifest.json
@@ -1,0 +1,77 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.local",
+  "version": "0.1.0",
+  "description": "Local JSON event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "store_id": {
+      "type": "string",
+      "required": false,
+      "description": "Local fixture store id. Provider adapters may ignore this."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared resource, stream, table, keyspace, or projection name."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/renewal-decision/tools/data/local/run.mjs
+++ b/skills/renewal-decision/tools/data/local/run.mjs
@@ -1,0 +1,335 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "local-json-event-store";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const eventDigest = sha256Json(event);
+  const existing = stream.events.find((entry) => entry.idempotency_key === idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, stream, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(store, envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: stream.version,
+      after_version: stream.version,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(stream),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(store, envelope),
+    };
+  }
+
+  if (stream.version !== expectedVersion) {
+    return conflictResult(envelope, stream, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${stream.version}`,
+      provider_evidence: providerEvidence(store, envelope),
+    });
+  }
+
+  const nextVersion = stream.version + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+  stream.events.push(record);
+  stream.version = nextVersion;
+  writeStore(rawInputs, store);
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function conflictResult(envelope, stream, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function readEvents(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const events = stream.events.slice(Math.max(0, stream.events.length - limit));
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(stream),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: stream.version,
+    event_count: stream.events.length,
+    last_event_ref: stream.events.at(-1)?.event_ref ?? null,
+    last_event_type: stream.events.at(-1)?.event_type ?? null,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function streamFor(store, resource, aggregateId) {
+  store.resources[resource] ??= { streams: {} };
+  store.resources[resource].streams[aggregateId] ??= { version: 0, events: [] };
+  return store.resources[resource].streams[aggregateId];
+}
+
+function readStore(rawInputs) {
+  const file = storePath(rawInputs);
+  if (!fs.existsSync(file)) {
+    return {
+      schema: "runx.local_data_store.v1",
+      store_id: localStoreId(rawInputs),
+      resources: {},
+    };
+  }
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || typeof parsed !== "object" || parsed.schema !== "runx.local_data_store.v1") {
+    throw new Error("local data store file has an invalid schema");
+  }
+  parsed.resources ??= {};
+  return parsed;
+}
+
+function writeStore(rawInputs, store) {
+  const file = storePath(rawInputs);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+function storePath(rawInputs) {
+  const storeId = localStoreId(rawInputs);
+  return path.join(os.tmpdir(), "runx-data-store", `${storeId}.json`);
+}
+
+function localStoreId(rawInputs) {
+  if (typeof rawInputs.store_id === "string" && rawInputs.store_id.trim().length > 0) {
+    return safeName(rawInputs.store_id, "store_id");
+  }
+  const ref = typeof rawInputs.data_source_ref === "string" && rawInputs.data_source_ref.length > 0
+    ? rawInputs.data_source_ref
+    : "default";
+  return `source-${crypto.createHash("sha256").update(ref).digest("hex").slice(0, 24)}`;
+}
+
+function providerEvidence(store, envelope) {
+  return {
+    provider: PROVIDER,
+    store_id: store.store_id,
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "local-fixture",
+  };
+}
+
+function projectionDigest(stream) {
+  return sha256Json({
+    version: stream.version,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  });
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}

--- a/skills/renewal-decision/tools/data/redis/README.md
+++ b/skills/renewal-decision/tools/data/redis/README.md
@@ -1,0 +1,42 @@
+# data.redis
+
+`data.redis` is the Redis provider adapter for the `data-store` operation
+envelope. It is intentionally not a separate domain skill: messageboards,
+operator desks, sync cursors, and business workflows keep their semantics in
+their own skills, while this adapter supplies the storage backend.
+
+## Binding
+
+Bind a logical source to Redis with non-secret project configuration:
+
+```json
+{
+  "data_sources": {
+    "tenant://acme/board": {
+      "adapter": "data.redis",
+      "endpoint": "redis://127.0.0.1:6379/0",
+      "key_prefix": "runx:acme:board",
+      "resources": {
+        "board_events": {
+          "kind": "event_stream",
+          "partition_key": "aggregate_id"
+        }
+      }
+    }
+  }
+}
+```
+
+Pass the document through `RUNX_DATA_SOURCES` or write it to
+`.runx/data-sources.json`. The endpoint must not embed credentials. Use a local
+unauthenticated Redis for OSS dogfood, or put provider credentials behind the
+normal runx credential boundary when a hosted/production adapter supplies secret
+delivery.
+
+## Requirements
+
+- `redis-cli` on `PATH`, or set `RUNX_REDIS_CLI_BIN`.
+- A reachable `redis://` or `rediss://` endpoint.
+
+Live conformance tests run only when `RUNX_REDIS_URL` is set and responds to
+`PING`, so normal CI does not require Redis.

--- a/skills/renewal-decision/tools/data/redis/manifest.json
+++ b/skills/renewal-decision/tools/data/redis/manifest.json
@@ -1,0 +1,87 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.redis",
+  "version": "0.1.0",
+  "description": "Redis event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": false,
+      "description": "Non-secret data-source binding injected by data.source."
+    },
+    "redis_url": {
+      "type": "string",
+      "required": false,
+      "description": "Redis URL for direct harness use. Prefer data_source_binding.endpoint."
+    },
+    "key_prefix": {
+      "type": "string",
+      "required": false,
+      "description": "Redis key prefix for direct harness use. Prefer data_source_binding.key_prefix."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared event resource or stream family."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/renewal-decision/tools/data/redis/run.mjs
+++ b/skills/renewal-decision/tools/data/redis/run.mjs
@@ -1,0 +1,426 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "redis-event-store";
+const REDIS_CLI_BIN = process.env.RUNX_REDIS_CLI_BIN || "redis-cli";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const eventDigest = sha256Json(event);
+  const keys = redisKeys(rawInputs, envelope);
+  const nextVersion = expectedVersion + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+  const recordDigest = sha256Json(record);
+  const response = redisEval(rawInputs, appendScript(), [keys.stream, keys.idempotency], [
+    String(expectedVersion),
+    idempotencyKey,
+    eventDigest,
+    eventRef,
+    String(nextVersion),
+    JSON.stringify(record),
+    recordDigest,
+  ]);
+  const [status, ...fields] = response.split("|");
+
+  if (status === "committed") {
+    const [before, after, ref, digest, resultDigest] = fields;
+    return {
+      ...envelope,
+      status: "committed",
+      before_version: Number(before),
+      after_version: Number(after),
+      idempotency_key: idempotencyKey,
+      event_ref: ref,
+      event_digest: digest,
+      result_digest: resultDigest,
+      projection_digest: projectionDigest(rawInputs, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(rawInputs, envelope),
+    };
+  }
+
+  if (status === "idempotent_replay") {
+    const [current, digest, ref, version, resultDigest] = fields;
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: Number(current),
+      after_version: Number(current),
+      idempotency_key: idempotencyKey,
+      event_ref: ref,
+      event_digest: digest,
+      result_digest: resultDigest,
+      projection_digest: projectionDigest(rawInputs, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: {
+        ...providerEvidence(rawInputs, envelope),
+        committed_version: Number(version),
+      },
+    };
+  }
+
+  if (status === "idempotency_conflict") {
+    return conflictResult(envelope, Number(fields[0]), {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: "idempotency key was reused with different event content",
+      projection_digest: projectionDigest(rawInputs, envelope),
+      provider_evidence: providerEvidence(rawInputs, envelope),
+    });
+  }
+
+  if (status === "version_conflict") {
+    const current = Number(fields[0]);
+    return conflictResult(envelope, current, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${current}`,
+      projection_digest: projectionDigest(rawInputs, envelope),
+      provider_evidence: providerEvidence(rawInputs, envelope),
+    });
+  }
+
+  throw new Error(`unexpected redis append response: ${response}`);
+}
+
+function readEvents(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const keys = redisKeys(rawInputs, envelope);
+  const rows = redis(rawInputs, ["LRANGE", keys.stream, String(-limit), "-1"]);
+  const events = parseJsonLines(rows);
+  const current = redisInteger(rawInputs, ["LLEN", keys.stream]);
+  return {
+    ...envelope,
+    status: "read",
+    before_version: current,
+    after_version: current,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(rawInputs, envelope),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(rawInputs, envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const projection = buildProjection(rawInputs, envelope);
+  return {
+    ...envelope,
+    status: "read",
+    before_version: projection.version,
+    after_version: projection.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(rawInputs, envelope),
+  };
+}
+
+function appendScript() {
+  return `
+local current = redis.call('LLEN', KEYS[1])
+local existing = redis.call('HGET', KEYS[2], ARGV[2])
+if existing then
+  local digest, ref, version, result_digest = string.match(existing, '^([^|]+)|([^|]+)|([^|]+)|([^|]+)$')
+  if digest ~= ARGV[3] then
+    return 'idempotency_conflict|' .. current
+  end
+  return 'idempotent_replay|' .. current .. '|' .. digest .. '|' .. ref .. '|' .. version .. '|' .. result_digest
+end
+local expected = tonumber(ARGV[1])
+if current ~= expected then
+  return 'version_conflict|' .. current
+end
+redis.call('RPUSH', KEYS[1], ARGV[6])
+redis.call('HSET', KEYS[2], ARGV[2], ARGV[3] .. '|' .. ARGV[4] .. '|' .. ARGV[5] .. '|' .. ARGV[7])
+return 'committed|' .. current .. '|' .. (current + 1) .. '|' .. ARGV[4] .. '|' .. ARGV[3] .. '|' .. ARGV[7]
+`;
+}
+
+function conflictResult(envelope, currentVersionValue, { idempotency_key, event_digest, reason, projection_digest, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: currentVersionValue,
+    after_version: currentVersionValue,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function buildProjection(rawInputs, envelope) {
+  const keys = redisKeys(rawInputs, envelope);
+  const events = parseJsonLines(redis(rawInputs, ["LRANGE", keys.stream, "0", "-1"]));
+  return {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: events.length,
+    event_count: events.length,
+    last_event_ref: events.at(-1)?.event_ref ?? null,
+    last_event_type: events.at(-1)?.event_type ?? null,
+    event_digests: events.map((entry) => entry.event_digest),
+  };
+}
+
+function projectionDigest(rawInputs, envelope) {
+  return sha256Json(buildProjection(rawInputs, envelope));
+}
+
+function providerEvidence(rawInputs, envelope) {
+  const keys = redisKeys(rawInputs, envelope);
+  return {
+    provider: PROVIDER,
+    adapter: "data.redis",
+    data_source_ref_digest: sha256Json(envelope.data_source_ref),
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "redis",
+    key_prefix_digest: sha256Json(keyPrefix(rawInputs)),
+    stream_digest: keys.digest,
+  };
+}
+
+function redisKeys(rawInputs, envelope) {
+  const digest = sha256Hex({
+    data_source_ref: envelope.data_source_ref,
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+  });
+  const prefix = keyPrefix(rawInputs);
+  return {
+    digest,
+    stream: `${prefix}:stream:${digest}`,
+    idempotency: `${prefix}:idempotency:${digest}`,
+  };
+}
+
+function redisEval(rawInputs, script, keys, argv) {
+  return redis(rawInputs, ["EVAL", script, String(keys.length), ...keys, ...argv]).trim();
+}
+
+function redisInteger(rawInputs, args) {
+  const text = redis(rawInputs, args).trim();
+  const value = Number(text || "0");
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`redis returned invalid integer for ${args[0]}`);
+  }
+  return value;
+}
+
+function redis(rawInputs, args) {
+  const result = spawnSync(REDIS_CLI_BIN, ["-u", redisUrl(rawInputs), "--raw", ...args], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `redis-cli exited ${result.status}`).trim());
+  }
+  return result.stdout;
+}
+
+function redisUrl(rawInputs) {
+  const sourceBinding = dataSourceBinding(rawInputs);
+  const raw = textValue(sourceBinding.endpoint) ?? textValue(sourceBinding.redis_url) ?? textValue(rawInputs.redis_url) ?? "redis://127.0.0.1:6379/0";
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("data.redis endpoint must be a valid redis:// or rediss:// URL");
+  }
+  if (parsed.protocol !== "redis:" && parsed.protocol !== "rediss:") {
+    throw new Error("data.redis endpoint must use redis:// or rediss://");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("data.redis endpoint must not embed credentials; use a runx credential profile or hosted grant");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("data.redis endpoint must not include query or fragment parameters");
+  }
+  return parsed.toString();
+}
+
+function keyPrefix(rawInputs) {
+  const bindingObject = dataSourceBinding(rawInputs);
+  const raw = textValue(bindingObject.key_prefix) ?? textValue(rawInputs.key_prefix) ?? "runx:data-store";
+  const pattern = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,191}$/;
+  if (!pattern.test(raw)) {
+    throw new Error("data.redis key_prefix must be a safe Redis key prefix");
+  }
+  return raw;
+}
+
+function dataSourceBinding(rawInputs) {
+  return rawInputs.data_source_binding && typeof rawInputs.data_source_binding === "object" && !Array.isArray(rawInputs.data_source_binding)
+    ? rawInputs.data_source_binding
+    : {};
+}
+
+function parseJsonLines(stdout) {
+  const text = stdout.trim();
+  if (!text) return [];
+  return text.split(/\r?\n/).map((line) => JSON.parse(line));
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function textValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sha256Json(value) {
+  return `sha256:${sha256Hex(value)}`;
+}
+
+function sha256Hex(value) {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}

--- a/skills/renewal-decision/tools/data/sqlite/README.md
+++ b/skills/renewal-decision/tools/data/sqlite/README.md
@@ -1,0 +1,63 @@
+# data.sqlite
+
+`data.sqlite` is the durable local adapter for the provider-agnostic runx data
+operation envelope. It is useful for dogfooding real stateful graphs without
+standing up hosted infrastructure. Unbound `local://...` data sources resolve to
+this adapter by default; pass `store_id` only when a fixture intentionally wants
+the JSON `data.local` adapter instead.
+
+The adapter shells out to `sqlite3`. Set `RUNX_SQLITE_BIN` when the binary is not
+on `PATH`.
+
+The adapter is selected through a data-source binding:
+
+```json
+{
+  "data_sources": {
+    "tenant://example/board": {
+      "adapter": "data.sqlite",
+      "database_path": ".runx/data/example-board.sqlite",
+      "resources": {
+        "board_events": {
+          "kind": "event_stream",
+          "partition_key": "aggregate_id"
+        }
+      }
+    }
+  }
+}
+```
+
+Graphs still pass only `data_source_ref`, `resource`, `aggregate_id`,
+`expected_version`, `idempotency_key`, and operation-specific inputs. The
+binding chooses SQLite.
+
+For unbound `local://...` refs, runx derives a source-scoped database path under
+`.runx/data/local-sources/`. When several sources intentionally share one
+configured `database_path`, `data.sqlite` still isolates streams by
+`data_source_ref`, `resource`, and `aggregate_id`.
+
+## Operations
+
+- `append_event`
+- `read_events`
+- `read_projection`
+
+Writes require `expected_version` and `idempotency_key`. A retry with the same
+idempotency key and same event digest returns `idempotent_replay`. A retry with
+the same idempotency key and different event digest returns `conflict`.
+
+## Path rules
+
+Relative `database_path` values resolve from `RUNX_CWD`, `INIT_CWD`, or the
+current working directory. Absolute paths are rejected unless the binding sets
+`allow_absolute_path: true`.
+
+Provider evidence never includes the absolute database path.
+
+## Resetting local state
+
+Delete the relevant file under `.runx/data/local-sources/` for default local
+dogfood, or delete the configured `database_path` for a project-specific
+binding. Do not reset by changing domain skill inputs; that hides replay
+problems instead of clearing local storage.

--- a/skills/renewal-decision/tools/data/sqlite/manifest.json
+++ b/skills/renewal-decision/tools/data/sqlite/manifest.json
@@ -1,0 +1,82 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.sqlite",
+  "version": "0.1.0",
+  "description": "SQLite event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": false,
+      "description": "Non-secret data-source binding injected by data.source."
+    },
+    "database_path": {
+      "type": "string",
+      "required": false,
+      "description": "Local SQLite database path for direct harness use. Prefer data_source_binding.database_path."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared event resource or stream family."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/renewal-decision/tools/data/sqlite/run.mjs
+++ b/skills/renewal-decision/tools/data/sqlite/run.mjs
@@ -1,0 +1,546 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "sqlite-event-store";
+const SQLITE_BIN = process.env.RUNX_SQLITE_BIN || "sqlite3";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const eventDigest = sha256Json(event);
+  const current = currentVersion(database, envelope);
+  const existing = existingEvent(database, envelope, idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, current, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: current,
+      after_version: current,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(database, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(envelope),
+    };
+  }
+
+  if (current !== expectedVersion) {
+    return conflictResult(envelope, current, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${current}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  const nextVersion = current + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+
+  try {
+    execSql(database, `
+BEGIN IMMEDIATE;
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+) VALUES (
+  ${sqlString(envelope.data_source_ref)},
+  ${sqlString(envelope.resource)},
+  ${sqlString(envelope.aggregate_id)},
+  ${nextVersion},
+  ${sqlString(idempotencyKey)},
+  ${sqlString(eventRef)},
+  ${sqlString(record.event_type)},
+  ${sqlString(eventDigest)},
+  ${sqlString(JSON.stringify(event))},
+  ${sqlString(record.committed_at)}
+);
+COMMIT;
+`);
+  } catch (error) {
+    const latest = currentVersion(database, envelope);
+    return conflictResult(envelope, latest, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `sqlite append failed after version check: ${error.message}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(database, envelope),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readEvents(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const current = currentVersion(database, envelope);
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version DESC
+LIMIT ${limit};
+`);
+  const events = rows
+    .reverse()
+    .map((row) => ({
+      event_ref: row.event_ref,
+      version: Number(row.version),
+      event_type: row.event_type,
+      event: JSON.parse(row.event_json),
+      event_digest: row.event_digest,
+      idempotency_key: row.idempotency_key,
+      committed_at: row.committed_at,
+    }));
+
+  return {
+    ...envelope,
+    status: "read",
+    before_version: current,
+    after_version: current,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(database, envelope),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const eventRows = queryJson(database, `
+SELECT event_ref, event_type, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: eventRows.length,
+    event_count: eventRows.length,
+    last_event_ref: eventRows.at(-1)?.event_ref ?? null,
+    last_event_type: eventRows.at(-1)?.event_type ?? null,
+    event_digests: eventRows.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: projection.version,
+    after_version: projection.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function conflictResult(envelope, currentVersionValue, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: currentVersionValue,
+    after_version: currentVersionValue,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: `sha256:${"0".repeat(64)}`,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function ensureSchema(database) {
+  fs.mkdirSync(path.dirname(database), { recursive: true });
+  execSql(database, `
+PRAGMA journal_mode = WAL;
+CREATE TABLE IF NOT EXISTS runx_events (
+  data_source_ref TEXT NOT NULL DEFAULT '',
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+`);
+  migrateLegacySchema(database);
+  execSql(database, `
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+`);
+}
+
+function migrateLegacySchema(database) {
+  const columns = queryJson(database, "PRAGMA table_info(runx_events);").map((column) => column.name);
+  if (columns.includes("data_source_ref")) return;
+
+  execSql(database, `
+BEGIN IMMEDIATE;
+ALTER TABLE runx_events RENAME TO runx_events_legacy_unscoped;
+CREATE TABLE runx_events (
+  data_source_ref TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+)
+SELECT
+  '',
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+FROM runx_events_legacy_unscoped;
+DROP TABLE runx_events_legacy_unscoped;
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+COMMIT;
+`);
+}
+
+function currentVersion(database, envelope) {
+  const rows = queryJson(database, `
+SELECT COALESCE(MAX(version), 0) AS version
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)};
+`);
+  return Number(rows[0]?.version ?? 0);
+}
+
+function existingEvent(database, envelope, idempotencyKey) {
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+  AND idempotency_key = ${sqlString(idempotencyKey)}
+LIMIT 1;
+`);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    event_ref: row.event_ref,
+    version: Number(row.version),
+    event_type: row.event_type,
+    event: JSON.parse(row.event_json),
+    event_digest: row.event_digest,
+    idempotency_key: row.idempotency_key,
+    committed_at: row.committed_at,
+  };
+}
+
+function projectionDigest(database, envelope) {
+  const rows = queryJson(database, `
+SELECT version, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  return sha256Json({
+    version: rows.length,
+    event_digests: rows.map((entry) => entry.event_digest),
+  });
+}
+
+function providerEvidence(envelope) {
+  return {
+    provider: PROVIDER,
+    adapter: "data.sqlite",
+    data_source_ref_digest: sha256Json(envelope.data_source_ref),
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "sqlite",
+  };
+}
+
+function databasePath(rawInputs) {
+  const binding = rawInputs.data_source_binding && typeof rawInputs.data_source_binding === "object" && !Array.isArray(rawInputs.data_source_binding)
+    ? rawInputs.data_source_binding
+    : {};
+  const rawPath = typeof binding.database_path === "string" && binding.database_path.trim().length > 0
+    ? binding.database_path.trim()
+    : typeof rawInputs.database_path === "string" && rawInputs.database_path.trim().length > 0
+      ? rawInputs.database_path.trim()
+      : null;
+  if (!rawPath) {
+    throw new Error("data.sqlite requires data_source_binding.database_path or database_path");
+  }
+  const root = path.resolve(process.env.RUNX_CWD || process.env.INIT_CWD || process.cwd());
+  const allowAbsolute = binding.allow_absolute_path === true || rawInputs.allow_absolute_path === true;
+  const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(root, rawPath);
+  if (path.isAbsolute(rawPath) && !allowAbsolute) {
+    throw new Error("data.sqlite absolute database_path requires allow_absolute_path=true in the operator-owned binding");
+  }
+  if (!allowAbsolute && !isInside(root, resolved)) {
+    throw new Error("data.sqlite database_path must stay inside RUNX_CWD unless allow_absolute_path=true");
+  }
+  return resolved;
+}
+
+function execSql(database, sql) {
+  const result = spawnSync(SQLITE_BIN, [database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+}
+
+function queryJson(database, sql) {
+  const result = spawnSync(SQLITE_BIN, ["-json", database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+  const text = result.stdout.trim();
+  return text ? JSON.parse(text) : [];
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}


### PR DESCRIPTION
## Summary
- adds the `renewal-decision` skill for renewal spend decisions
- includes typed vendor/usage/offer/policy inputs, a bounded AttenuationRequest-only renew output, and a stop fixture
- carries the `registry:runx/data-store@0.1.2` handoff seam with pinned `store_id`, `read_projection`, and CAS `append_event` evidence

## Verification
- `runx-cli 0.6.19`
- local harness passed: 2 cases, happy renew sealed, stop case needs_agent
- hosted registry publish gate passed: `dh0h/renewal-decision@sha-23e7a258c30a`
- published-package dogfood sealed receipt: `runx:receipt:sha256:c430d1034f64321e98aaf568e0091bcee57d9328b65f1daf20efc0b938932e8a`
- receipt verification passed with local-development signature mode

Registry: https://runx.ai/x/dh0h/renewal-decision@sha-23e7a258c30a
Evidence: https://raw.githubusercontent.com/dh0h/runx/codex/renewal-decision-110/skills/renewal-decision/artifacts/evidence.json
