### PR TITLE
Add revenue leakage auditor skill

### DIFF
--- a/skills/revenue-leakage-auditor/SKILL.md
+++ b/skills/revenue-leakage-auditor/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: revenue-leakage-auditor
+description: Audit one account-period for revenue leakage by comparing usage against billing, emitting only bounded adjustment ceilings as data for eligible under-billed accounts.
+runx:
+  category: business
+---
+
+# Revenue Leakage Auditor
+
+`revenue-leakage-auditor` is a finance review skill. It reads one account's
+usage record, billing history, discount policy, threshold, and parent adjustment
+bounds, then decides whether an under-billing gap is real enough to recover. It
+does not charge a customer, refund money, mint authority, or settle an
+adjustment.
+
+The output is a typed review decision plus zero or more bounded
+`AttenuationRequest` ceilings carried as data. A downstream driver may hand a
+ceiling to the core spend/refund accepting runner, which alone owns child grant
+minting, reservation, settlement, and receipt sealing. This skill only records
+the review and the bounded data a later governed runner may consume.
+
+## What This Skill Does
+
+1. Reads durable per-account reconciliation state through
+   `registry:runx/data-store@0.1.2`.
+2. Matches `usage_records.account_id` to `billing_history.account_id` for the
+   same billing period.
+3. Computes the billed-vs-usage gap only from supplied records.
+4. Applies `charge_threshold_pct` before treating a gap as leakage.
+5. Drops accounts excluded by `discount_policy.excluded_accounts`.
+6. Drops gaps covered by `discount_policy.known_discounts`.
+7. Emits one bounded ceiling per eligible under-billed account, clamped to
+   `parent_adjustment_bounds`.
+8. Appends a reconciliation event with a CAS `append_event` using a stable
+   idempotency key keyed by account and period.
+
+## Inputs
+
+```yaml
+usage_records:
+  account_id: string
+  usage_amount: number
+  period: string
+billing_history:
+  account_id: string
+  billed_amount: number
+  period: string
+discount_policy:
+  excluded_accounts: [string]
+  known_discounts: array
+charge_threshold_pct: number
+parent_adjustment_bounds: object
+```
+
+The usage and billing records may include `currency` and `evidence_ref`. When an
+evidence ref is absent, the reviewer derives a stable reference from
+`account_id` and `period` rather than inventing an external source.
+
+## Output
+
+```yaml
+decision:
+  leakage_found: boolean
+  reason: string
+ceilings:
+  - schema: runx.attenuation_request.v1
+    form: data
+    account_id: string
+    amount:
+      amount: number
+      currency: string
+    currency: string
+    scopes: [spend.reserve, spend.settle, receipt.seal]
+    usage_evidence_ref: string
+    billing_evidence_ref: string
+    idempotency_key: string
+    downstream_runner: registry:runx/spend@0.1.1
+escalation:
+  required: boolean
+  lane: human_approval
+  reason: string
+data_store:
+  package_ref: registry:runx/data-store@0.1.2
+  read_projection: object
+  append_event: object
+observations: object
+```
+
+`ceilings` is empty when no leakage is found, the account is excluded, a known
+discount covers the gap, records are incomplete, or the gap stays inside the
+threshold. A ceiling is a review artifact only; it is not a reservation, subset
+proof, mint, settlement, or proposal envelope.
+
+## Decision Rules
+
+- **Leakage found** only when account and period match, usage and billing amounts
+  are complete, currency is compatible, the account is not excluded, no known
+  discount covers the gap, and the under-billed percentage exceeds
+  `charge_threshold_pct`.
+- **No change** when billing is at or above usage, the gap is within threshold,
+  or a known discount covers the difference.
+- **Needs agent** when account, period, usage amount, billed amount, currency,
+  threshold, or parent bounds are missing or contradictory.
+- **Human approval lane** is named whenever a downstream runner would consume a
+  ceiling. The approval happens outside this review skill.
+
+## Data-Store Handoff
+
+This skill carries the `registry:runx/data-store@0.1.2` handoff contract in the
+review packet and executes the same governed data operation envelope through
+`data.source` graph steps.
+
+- `read_projection` reads `resource: account_reconciliations` for the account
+  aggregate.
+- `append_event` writes either `revenue_leakage.detected` or
+  `revenue_leakage.no_change`.
+- `idempotency_key` is keyed by account id, period, and review outcome.
+- `expected_version` is supplied by the review packet so CAS failures are
+  visible instead of overwritten.
+
+The event is evidence of the review. It is not authority to charge, refund, or
+settle anything.
+
+## Adjustment Handoff
+
+Each ceiling is a typed value, not an effect. A downstream driver must:
+
+- pass the ceiling to the core spend/refund accepting runner;
+- mint any attenuated child grant there, never here;
+- reserve, settle, and seal under the accepting runner's charter;
+- fail closed when a request exceeds the ceiling amount, currency, or scopes;
+  and
+- require human approval before consuming the ceiling.
+
+## Stop Conditions
+
+- `account_mismatch`: usage and billing records name different accounts.
+- `period_mismatch`: usage and billing records cover different periods.
+- `missing_usage_evidence`: usage amount is absent or not numeric.
+- `missing_billing_evidence`: billed amount is absent or not numeric.
+- `currency_mismatch`: usage, billing, or parent bounds currencies differ.
+- `excluded_account`: discount policy excludes the account.
+- `known_discount`: discount policy covers the apparent gap.
+- `below_threshold`: the under-billed percentage is at or below the threshold.
+- `bounds_missing`: parent adjustment bounds cannot clamp the ceiling.
+
+## Verification Notes
+
+The harness carries exactly two cases:
+
+- `revenue-leakage-auditor-underbilling-ceiling` seals a leakage review with a
+  bounded `AttenuationRequest` ceiling as data and a CAS append event.
+- `revenue-leakage-auditor-stop-needs-agent` omits caller answers so the review
+  blocks at `needs_agent` with no ceiling, no mint, no settlement, and no append
+  event.
+
+The dogfood run should execute the published package after install and verify
+the receipt from that post-publish run, not a local harness fixture receipt.

--- a/skills/revenue-leakage-auditor/X.yaml
+++ b/skills/revenue-leakage-auditor/X.yaml
@@ -1,0 +1,296 @@
+skill: revenue-leakage-auditor
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: operator
+  visibility: public
+  role: context
+  part_of:
+    - runx/spend
+    - runx/refund
+
+emits:
+  - name: revenue_leakage_audit_packet
+    packet: runx.revenue.leakage_audit.v1
+
+harness:
+  cases:
+    - name: revenue-leakage-auditor-underbilling-ceiling
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"tenant://revenue-leakage/account-ledger":{"adapter":"data.local","resources":{"account_reconciliations":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: tenant://revenue-leakage/account-ledger
+        store_id: revenue-leakage-harness-v1
+        usage_records:
+          account_id: account:atlas-team
+          usage_amount: 15000
+          currency: USD
+          period: 2026-06
+          evidence_ref: usage:account:atlas-team:2026-06
+        billing_history:
+          account_id: account:atlas-team
+          billed_amount: 10000
+          currency: USD
+          period: 2026-06
+          evidence_ref: billing:account:atlas-team:2026-06
+        discount_policy:
+          excluded_accounts:
+            - account:internal-sandbox
+          known_discounts:
+            - account_id: account:legacy-partner
+              period: 2026-06
+              amount:
+                amount: 5000
+                currency: USD
+              reason: contracted launch discount
+        charge_threshold_pct: 10
+        parent_adjustment_bounds:
+          schema: runx.authority_bounds.v1
+          amount:
+            max_per_account: 6000
+            currency: USD
+          scopes:
+            - spend.reserve
+            - spend.settle
+            - receipt.seal
+          expires_at: "2026-07-31T00:00:00Z"
+      caller:
+        answers:
+          agent_task.revenue-leakage-auditor.output:
+            leakage_audit_packet:
+              schema: runx.revenue.leakage_audit.v1
+              decision:
+                leakage_found: true
+                reason: account:atlas-team used USD 15000 in 2026-06, was billed USD 10000, and the 50% under-billing gap exceeds the 10% threshold with no exclusion or known discount.
+              ceilings:
+                - schema: runx.attenuation_request.v1
+                  form: data
+                  account_id: account:atlas-team
+                  amount:
+                    amount: 5000
+                    currency: USD
+                  currency: USD
+                  scopes:
+                    - spend.reserve
+                    - spend.settle
+                    - receipt.seal
+                  counterparty: account:atlas-team
+                  usage_evidence_ref: usage:account:atlas-team:2026-06
+                  billing_evidence_ref: billing:account:atlas-team:2026-06
+                  idempotency_key: revenue-leakage:account:atlas-team:2026-06:recover
+                  downstream_runner: registry:runx/spend@0.1.1
+                  clamp:
+                    parent_bound_ref: parent_adjustment_bounds
+                    max_amount:
+                      amount: 6000
+                      currency: USD
+                    result: within_parent_bounds
+              escalation:
+                required: true
+                lane: human_approval
+                reason: Finance approval is required before a downstream C3 runner consumes the adjustment ceiling.
+              data_store:
+                package_ref: registry:runx/data-store@0.1.2
+                data_source_ref: tenant://revenue-leakage/account-ledger
+                store_id: revenue-leakage-harness-v1
+                read_projection:
+                  runner: read_projection
+                  resource: account_reconciliations
+                  aggregate_id: account:atlas-team
+                append_event:
+                  runner: append_event
+                  resource: account_reconciliations
+                  aggregate_id: account:atlas-team
+                  expected_version: 0
+                  idempotency_key: revenue-leakage:account:atlas-team:2026-06:detected
+                  event:
+                    type: revenue_leakage.detected
+                    payload:
+                      account_id: account:atlas-team
+                      period: 2026-06
+                      usage_amount:
+                        amount: 15000
+                        currency: USD
+                      billed_amount:
+                        amount: 10000
+                        currency: USD
+                      under_billed_amount:
+                        amount: 5000
+                        currency: USD
+                      threshold_pct: 10
+                      ceiling_idempotency_key: revenue-leakage:account:atlas-team:2026-06:recover
+              observations:
+                verdict: leakage_found
+                account_id: account:atlas-team
+                period: 2026-06
+                usage_evidence_ref: usage:account:atlas-team:2026-06
+                billing_evidence_ref: billing:account:atlas-team:2026-06
+                usage_amount:
+                  amount: 15000
+                  currency: USD
+                billed_amount:
+                  amount: 10000
+                  currency: USD
+                under_billed_amount:
+                  amount: 5000
+                  currency: USD
+                under_billed_pct: 50
+                threshold_pct: 10
+                bounded_ceiling_count: 1
+                aggregate_id: account:atlas-team
+                appended_version: 1
+                refused_or_stop_reason: null
+                harness_cases:
+                  - revenue-leakage-auditor-underbilling-ceiling
+                  - revenue-leakage-auditor-stop-needs-agent
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: revenue-leakage-auditor-stop-needs-agent
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"tenant://revenue-leakage/account-ledger":{"adapter":"data.local","resources":{"account_reconciliations":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: tenant://revenue-leakage/account-ledger
+        store_id: revenue-leakage-harness-v1
+        usage_records:
+          account_id: account:bravo-team
+          usage_amount: 10500
+          currency: USD
+          period: 2026-06
+          evidence_ref: usage:account:bravo-team:2026-06
+        billing_history:
+          account_id: account:bravo-team
+          billed_amount: 10000
+          currency: USD
+          period: 2026-06
+          evidence_ref: billing:account:bravo-team:2026-06
+        discount_policy:
+          excluded_accounts:
+            - account:internal-sandbox
+          known_discounts:
+            - account_id: account:legacy-partner
+              period: 2026-06
+              amount:
+                amount: 5000
+                currency: USD
+              reason: contracted launch discount
+        charge_threshold_pct: 10
+        parent_adjustment_bounds:
+          schema: runx.authority_bounds.v1
+          amount:
+            max_per_account: 6000
+            currency: USD
+          scopes:
+            - spend.reserve
+            - spend.settle
+            - receipt.seal
+          expires_at: "2026-07-31T00:00:00Z"
+      expect:
+        status: needs_agent
+
+runners:
+  audit:
+    default: true
+    type: graph
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+        description: Logical data source holding per-account revenue reconciliation state.
+      store_id:
+        type: string
+        required: false
+        description: Optional deterministic local fixture store id.
+      usage_records:
+        type: json
+        required: true
+        description: usage_records{account_id,usage_amount,period}.
+      billing_history:
+        type: json
+        required: true
+        description: billing_history{account_id,billed_amount,period}.
+      discount_policy:
+        type: json
+        required: true
+        description: discount_policy{excluded_accounts,known_discounts}.
+      charge_threshold_pct:
+        type: number
+        required: true
+        description: Minimum under-billed percentage required before emitting a ceiling.
+      parent_adjustment_bounds:
+        type: json
+        required: true
+        description: AuthorityBounds clamp for any adjustment ceiling emitted as data.
+    graph:
+      name: revenue-leakage-auditor
+      steps:
+        - id: read-account
+          tool: data.source
+          scopes:
+            - runx:data:read
+          inputs:
+            operation: read_projection
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: account_reconciliations
+            aggregate_id: "$input.usage_records.account_id"
+        - id: judge-leakage
+          label: decide revenue leakage and bounded adjustment ceilings
+          run:
+            type: agent-task
+            agent: finance
+            task: revenue-leakage-auditor
+            outputs:
+              leakage_audit_packet: object
+          instructions: >
+            Compare usage_records to billing_history for the same account_id and
+            period. Use only the supplied records and discount_policy. Emit
+            decision.leakage_found true only when usage exceeds billed amount
+            beyond charge_threshold_pct, the account is not excluded, no known
+            discount covers the gap, and parent_adjustment_bounds can clamp the
+            ceiling. Emit one bounded runx.attenuation_request.v1 ceiling as
+            DATA per eligible account with amount, currency, scopes,
+            usage_evidence_ref, billing_evidence_ref, and a stable
+            idempotency_key. Never mint authority, never move money, never emit
+            an operational_proposal, and never claim an attenuation subset proof.
+            Include data_store.append_event with expected_version and an
+            idempotency_key keyed by account_id and period so the next graph step
+            can CAS append the reconciliation event. Escalate ambiguous or
+            incomplete billing evidence to human_approval instead of emitting a
+            ceiling.
+          allowed_tools:
+            - fs.read
+          scopes:
+            - revenue:leakage:review
+          inputs:
+            usage_records: "$input.usage_records"
+            billing_history: "$input.billing_history"
+            discount_policy: "$input.discount_policy"
+            charge_threshold_pct: "$input.charge_threshold_pct"
+            parent_adjustment_bounds: "$input.parent_adjustment_bounds"
+          context:
+            account_projection: read-account.data_operation_result.data.projection
+          artifacts:
+            named_emits:
+              revenue_leakage_audit_packet: leakage_audit_packet
+            packets:
+              revenue_leakage_audit_packet: runx.revenue.leakage_audit.v1
+        - id: append-review
+          tool: data.source
+          scopes:
+            - runx:data:append
+          inputs:
+            operation: append_event
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: account_reconciliations
+            aggregate_id: "$input.usage_records.account_id"
+          context:
+            expected_version: judge-leakage.leakage_audit_packet.data_store.append_event.expected_version
+            idempotency_key: judge-leakage.leakage_audit_packet.data_store.append_event.idempotency_key
+            event: judge-leakage.leakage_audit_packet.data_store.append_event.event

--- a/skills/revenue-leakage-auditor/artifacts/evidence.json
+++ b/skills/revenue-leakage-auditor/artifacts/evidence.json
@@ -45,6 +45,76 @@
     ]
   },
   "dogfood": {
+    "package": "dh0h/revenue-leakage-auditor@sha-8534d7161607",
+    "input": {
+      "data_source_ref": "tenant://revenue-leakage/account-ledger",
+      "store_id": "revenue-leakage-dogfood-v1",
+      "usage_records": {
+        "account_id": "account:atlas-team",
+        "usage_amount": 15000,
+        "currency": "USD",
+        "period": "2026-06",
+        "evidence_ref": "usage:account:atlas-team:2026-06"
+      },
+      "billing_history": {
+        "account_id": "account:atlas-team",
+        "billed_amount": 10000,
+        "currency": "USD",
+        "period": "2026-06",
+        "evidence_ref": "billing:account:atlas-team:2026-06"
+      },
+      "discount_policy": {
+        "excluded_accounts": [
+          "account:internal-sandbox"
+        ],
+        "known_discounts": [
+          {
+            "account_id": "account:legacy-partner",
+            "period": "2026-06",
+            "amount": {
+              "amount": 5000,
+              "currency": "USD"
+            },
+            "reason": "contracted launch discount"
+          }
+        ]
+      },
+      "charge_threshold_pct": 10,
+      "parent_adjustment_bounds": {
+        "schema": "runx.authority_bounds.v1",
+        "amount": {
+          "max_per_account": 6000,
+          "currency": "USD"
+        },
+        "scopes": [
+          "spend.reserve",
+          "spend.settle",
+          "receipt.seal"
+        ],
+        "expires_at": "2026-07-31T00:00:00Z"
+      }
+    },
+    "command": "runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai skills/revenue-leakage-auditor/fixtures/leakage-input.json --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json; runx resume run_audit_c7fadde7d95f skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json",
+    "receipt_ref": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+    "verify_verdict": {
+      "status": "passed",
+      "valid": true,
+      "receipt_count": 4,
+      "signature_mode": "local-development",
+      "findings": []
+    },
+    "harness_cases": [
+      {
+        "name": "revenue-leakage-auditor-underbilling-ceiling",
+        "status": "sealed",
+        "result": "passed"
+      },
+      {
+        "name": "revenue-leakage-auditor-stop-needs-agent",
+        "status": "needs_agent",
+        "result": "passed"
+      }
+    ],
     "status": "sealed",
     "run_id": "run_audit_c7fadde7d95f",
     "receipt_id": "sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
@@ -171,6 +241,11 @@
       "name": "stop_path_safety",
       "value": "needs_agent stop case",
       "evidence": "The second inline harness case omits caller answers and expects needs_agent, so no ceiling, mint, settlement, or append event is emitted."
+    },
+    {
+      "name": "refused_or_stop_reason",
+      "value": "stop case blocks to needs_agent and policy refusals emit no ceiling",
+      "evidence": "The stop harness case intentionally omits caller answers, producing needs_agent with no ceiling or append event; excluded accounts are refused before ceiling consideration and gaps covered by known discounts are treated as no_change."
     },
     {
       "name": "authority_boundary",

--- a/skills/revenue-leakage-auditor/artifacts/evidence.json
+++ b/skills/revenue-leakage-auditor/artifacts/evidence.json
@@ -98,11 +98,31 @@
     "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://revenue-leakage/account-ledger; runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 audit --registry https://api.runx.ai --skip-operator-context -i data_source_ref=tenant://revenue-leakage/account-ledger -i store_id=revenue-leakage-prod-signed-dogfood-20260714 --input-json usage_records=<fixture.usage_records> --input-json billing_history=<fixture.billing_history> --input-json discount_policy=<fixture.discount_policy> --input-json charge_threshold_pct=<fixture.charge_threshold_pct> --input-json parent_adjustment_bounds=<fixture.parent_adjustment_bounds> --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json; runx resume run_audit_393a2c1cf87d skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
     "receipt_ref": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
     "verify_verdict": {
-      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004 --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
+      "schema": "runx.verify_verdict.v1",
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify --receipt /tmp/runx-revenue-leakage-prod-signed-receipts-20260714/sha256-518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004.json --json",
       "status": "passed",
+      "receipt_id": "sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
       "valid": true,
-      "receipt_count": 4,
       "signature_mode": "production",
+      "digest": {
+        "status": "valid",
+        "expected": "sha256:580d66125b581068a7d1ecb387ccb7b4ad6ebd2811eeef697258c3f0d7a7d79f",
+        "actual": "sha256:580d66125b581068a7d1ecb387ccb7b4ad6ebd2811eeef697258c3f0d7a7d79f"
+      },
+      "content_address": {
+        "status": "valid",
+        "expected": "sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
+        "actual": "sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004"
+      },
+      "signature": {
+        "mode": "production",
+        "status": "valid",
+        "kid": "dh0h-frantic-receipt-2026-07-14-e88f2687"
+      },
+      "lineage": {
+        "status": "unverified",
+        "message": "single receipt verification cannot prove receipt-tree lineage"
+      },
       "findings": []
     },
     "harness_cases": [
@@ -228,7 +248,7 @@
     {
       "name": "dogfood_receipt",
       "value": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
-      "evidence": "Published-package dogfood run sealed with hosted Ed25519 production signing; plain runx verify with the public verify key reported a valid 4-receipt tree with no findings."
+      "evidence": "Published-package dogfood run sealed with hosted Ed25519 production signing; the acceptance-form runx verify --receipt <receipt.json> --json command passed with signature mode production, valid digest and content address, and no findings. The separate receipt-tree check also passed for all 4 receipts."
     },
     {
       "name": "leakage_verdict",

--- a/skills/revenue-leakage-auditor/artifacts/evidence.json
+++ b/skills/revenue-leakage-auditor/artifacts/evidence.json
@@ -15,7 +15,7 @@
   "verification_json": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/artifacts/verification.json",
   "evidence_json": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/artifacts/evidence.json",
   "report": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/artifacts/report.md",
-  "receipt_ref": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+  "receipt_ref": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
   "registry": {
     "url": "https://api.runx.ai",
     "skill_id": "dh0h/revenue-leakage-auditor",
@@ -28,8 +28,9 @@
   },
   "harness": {
     "local_status": "passed",
-    "local_receipt_id": "sha256:2680ac5201f0f76b2f72da6c51015e1d4c66e3033a10594df928797e46d4e6e1",
+    "local_receipt_id": "sha256:0d01bcb0b5f256f7ce1735fc3763323e82102da696df3cc7a6f774c7656bfc70",
     "local_receipt_verified": true,
+    "local_receipt_signature_mode": "production",
     "hosted_registry_status": "passed as the publish gate",
     "cases": [
       {
@@ -48,7 +49,7 @@
     "package": "dh0h/revenue-leakage-auditor@sha-8534d7161607",
     "input": {
       "data_source_ref": "tenant://revenue-leakage/account-ledger",
-      "store_id": "revenue-leakage-dogfood-v1",
+      "store_id": "revenue-leakage-prod-signed-dogfood-20260714",
       "usage_records": {
         "account_id": "account:atlas-team",
         "usage_amount": 15000,
@@ -94,13 +95,14 @@
         "expires_at": "2026-07-31T00:00:00Z"
       }
     },
-    "command": "runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai skills/revenue-leakage-auditor/fixtures/leakage-input.json --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json; runx resume run_audit_c7fadde7d95f skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json",
-    "receipt_ref": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+    "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://revenue-leakage/account-ledger; runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 audit --registry https://api.runx.ai --skip-operator-context -i data_source_ref=tenant://revenue-leakage/account-ledger -i store_id=revenue-leakage-prod-signed-dogfood-20260714 --input-json usage_records=<fixture.usage_records> --input-json billing_history=<fixture.billing_history> --input-json discount_policy=<fixture.discount_policy> --input-json charge_threshold_pct=<fixture.charge_threshold_pct> --input-json parent_adjustment_bounds=<fixture.parent_adjustment_bounds> --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json; runx resume run_audit_393a2c1cf87d skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
+    "receipt_ref": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
     "verify_verdict": {
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004 --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
       "status": "passed",
       "valid": true,
       "receipt_count": 4,
-      "signature_mode": "local-development",
+      "signature_mode": "production",
       "findings": []
     },
     "harness_cases": [
@@ -116,11 +118,17 @@
       }
     ],
     "status": "sealed",
-    "run_id": "run_audit_c7fadde7d95f",
-    "receipt_id": "sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+    "run_id": "run_audit_393a2c1cf87d",
+    "receipt_id": "sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
     "receipt_verified": true,
+    "receipt_signing": {
+      "issuer_type": "hosted",
+      "kid": "dh0h-frantic-receipt-2026-07-14-e88f2687",
+      "public_key_sha256": "sha256:c9a6c5bd0f8cc0f48497a1c67141e4ae6839887993466dbfe4058109913848e4",
+      "verify_public_key_base64": "UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4="
+    },
     "registry_trust_state": "trusted",
-    "store_id": "revenue-leakage-dogfood-v1",
+    "store_id": "revenue-leakage-prod-signed-dogfood-20260714",
     "read_projection": {
       "operation": "read_projection",
       "aggregate_id": "account:atlas-team",
@@ -219,8 +227,8 @@
     },
     {
       "name": "dogfood_receipt",
-      "value": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
-      "evidence": "Published-package dogfood run sealed and receipt verification reported a valid 4-receipt tree with no findings."
+      "value": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
+      "evidence": "Published-package dogfood run sealed with hosted Ed25519 production signing; plain runx verify with the public verify key reported a valid 4-receipt tree with no findings."
     },
     {
       "name": "leakage_verdict",

--- a/skills/revenue-leakage-auditor/artifacts/evidence.json
+++ b/skills/revenue-leakage-auditor/artifacts/evidence.json
@@ -1,0 +1,195 @@
+{
+  "schema": "runx.revenue_leakage_auditor.evidence.v1",
+  "bounty": 108,
+  "summary": "Published revenue-leakage-auditor as a runx registry graph skill with a hosted publish gate pass, a public PR, raw X.yaml/SKILL.md/artifact URLs, and a sealed dogfood receipt from the published package. The skill compares one account-period of usage and billing, refuses excluded or discount-covered gaps, emits bounded AttenuationRequest ceilings only as data, and records review state through a per-account CAS append_event.",
+  "runx_cli_version": "runx-cli 0.6.19",
+  "skill": "revenue-leakage-auditor",
+  "owner": "dh0h",
+  "package_ref": "dh0h/revenue-leakage-auditor@sha-8534d7161607",
+  "public_url": "https://runx.ai/x/dh0h/revenue-leakage-auditor@sha-8534d7161607",
+  "canonical_public_url": "https://runx.ai/x/dh0h/revenue-leakage-auditor",
+  "source_url": "https://github.com/dh0h/runx/tree/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor",
+  "pr_url": "https://github.com/runxhq/runx/pull/279",
+  "x_yaml": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/SKILL.md",
+  "verification_json": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/artifacts/verification.json",
+  "evidence_json": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/artifacts/evidence.json",
+  "report": "https://raw.githubusercontent.com/dh0h/runx/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor/artifacts/report.md",
+  "receipt_ref": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+  "registry": {
+    "url": "https://api.runx.ai",
+    "skill_id": "dh0h/revenue-leakage-auditor",
+    "version": "sha-8534d7161607",
+    "digest": "sha256:1607612f9c533a5a028d826c5f13fc42bd96847b519ec2f5b61f787ee45d04e7",
+    "profile_digest": "sha256:113c38a350799b496aaa0225fa742d08b38b8ac2a7e177749586187e7e4c77e1",
+    "trust_tier": "community",
+    "install_command": "runx add dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai",
+    "run_command": "runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai"
+  },
+  "harness": {
+    "local_status": "passed",
+    "local_receipt_id": "sha256:2680ac5201f0f76b2f72da6c51015e1d4c66e3033a10594df928797e46d4e6e1",
+    "local_receipt_verified": true,
+    "hosted_registry_status": "passed as the publish gate",
+    "cases": [
+      {
+        "name": "revenue-leakage-auditor-underbilling-ceiling",
+        "expected_status": "sealed",
+        "purpose": "happy path emits a bounded AttenuationRequest ceiling as data and appends a per-account CAS reconciliation event"
+      },
+      {
+        "name": "revenue-leakage-auditor-stop-needs-agent",
+        "expected_status": "needs_agent",
+        "purpose": "stop path omits caller answers so no ceiling, mint, settlement, or append event is emitted"
+      }
+    ]
+  },
+  "dogfood": {
+    "status": "sealed",
+    "run_id": "run_audit_c7fadde7d95f",
+    "receipt_id": "sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+    "receipt_verified": true,
+    "registry_trust_state": "trusted",
+    "store_id": "revenue-leakage-dogfood-v1",
+    "read_projection": {
+      "operation": "read_projection",
+      "aggregate_id": "account:atlas-team",
+      "resource": "account_reconciliations",
+      "version": 0
+    },
+    "append_event": {
+      "operation": "append_event",
+      "aggregate_id": "account:atlas-team",
+      "resource": "account_reconciliations",
+      "before_version": 0,
+      "after_version": 1,
+      "idempotency_key": "revenue-leakage:account:atlas-team:2026-06:detected",
+      "event_ref": "account_reconciliations:account:atlas-team:1"
+    }
+  },
+  "decision_observations": {
+    "leakage_found": true,
+    "reason": "account:atlas-team used USD 15000 in 2026-06, was billed USD 10000, and the 50% under-billing gap exceeds the 10% threshold with no exclusion or known discount.",
+    "account_id": "account:atlas-team",
+    "period": "2026-06",
+    "usage_amount": {
+      "amount": 15000,
+      "currency": "USD"
+    },
+    "billed_amount": {
+      "amount": 10000,
+      "currency": "USD"
+    },
+    "under_billed_amount": {
+      "amount": 5000,
+      "currency": "USD"
+    },
+    "under_billed_pct": 50,
+    "threshold_pct": 10,
+    "usage_evidence_ref": "usage:account:atlas-team:2026-06",
+    "billing_evidence_ref": "billing:account:atlas-team:2026-06",
+    "bounded_ceiling": {
+      "schema": "runx.attenuation_request.v1",
+      "form": "data",
+      "amount": {
+        "amount": 5000,
+        "currency": "USD"
+      },
+      "counterparty": "account:atlas-team",
+      "scopes": [
+        "spend.reserve",
+        "spend.settle",
+        "receipt.seal"
+      ],
+      "idempotency_key": "revenue-leakage:account:atlas-team:2026-06:recover",
+      "downstream_runner": "registry:runx/spend@0.1.1",
+      "clamp": {
+        "max_amount": {
+          "amount": 6000,
+          "currency": "USD"
+        },
+        "result": "within_parent_bounds"
+      }
+    },
+    "escalation": {
+      "required": true,
+      "lane": "human_approval",
+      "reason": "Finance approval is required before a downstream C3 runner consumes the adjustment ceiling."
+    }
+  },
+  "policy_refusals": [
+    {
+      "condition": "excluded_account",
+      "behavior": "accounts listed in discount_policy.excluded_accounts are refused before any ceiling is considered"
+    },
+    {
+      "condition": "known_discount",
+      "behavior": "gaps covered by discount_policy.known_discounts are treated as no_change, not leakage"
+    },
+    {
+      "condition": "incomplete_evidence",
+      "behavior": "missing or contradictory usage and billing evidence escalates to human_approval / needs_agent instead of a ceiling"
+    }
+  ],
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "value": "runx-cli 0.6.19",
+      "evidence": "All local harness, publish, install, dogfood, and verify commands were run with runx-cli 0.6.19."
+    },
+    {
+      "name": "hosted_registry_package",
+      "value": "dh0h/revenue-leakage-auditor@sha-8534d7161607",
+      "evidence": "Hosted registry publish returned status=published with digest sha256:1607612f9c533a5a028d826c5f13fc42bd96847b519ec2f5b61f787ee45d04e7."
+    },
+    {
+      "name": "harness_shape",
+      "value": "one sealed leakage case and one needs_agent stop case",
+      "evidence": "Local harness passed both inline cases; hosted registry publish gate also passed after the stop case was changed to needs_agent."
+    },
+    {
+      "name": "dogfood_receipt",
+      "value": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+      "evidence": "Published-package dogfood run sealed and receipt verification reported a valid 4-receipt tree with no findings."
+    },
+    {
+      "name": "leakage_verdict",
+      "value": "account:atlas-team under-billed by USD 5000",
+      "evidence": "Dogfood decision compared USD 15000 usage against USD 10000 billed for 2026-06, producing a 50% gap over the 10% threshold."
+    },
+    {
+      "name": "bounded_ceiling",
+      "value": "USD 5000 ceiling for account:atlas-team",
+      "evidence": "The leakage decision emitted a runx.attenuation_request.v1 data object with spend.reserve, spend.settle, and receipt.seal scopes, clamped below the USD 6000 parent bound."
+    },
+    {
+      "name": "data_store_handoff",
+      "value": "read_projection plus CAS append_event keyed by account_id",
+      "evidence": "Dogfood read projection saw version 0; append_event committed account_reconciliations:account:atlas-team:1 with idempotency key revenue-leakage:account:atlas-team:2026-06:detected."
+    },
+    {
+      "name": "stop_path_safety",
+      "value": "needs_agent stop case",
+      "evidence": "The second inline harness case omits caller answers and expects needs_agent, so no ceiling, mint, settlement, or append event is emitted."
+    },
+    {
+      "name": "authority_boundary",
+      "value": "judgment only",
+      "evidence": "The skill emits data only, performs no money movement, mints no grant, and names the downstream C3 spend/refund accepting runner plus human approval lane before ceiling consumption."
+    }
+  ],
+  "safety_checks": {
+    "operational_proposal_emitted": false,
+    "mint_performed_by_skill": false,
+    "money_moved": false,
+    "settlement_performed": false,
+    "stop_case_ceiling_emitted": false,
+    "excluded_account_ceiling_emitted": false,
+    "known_discount_ceiling_emitted": false
+  },
+  "notes": [
+    "The graph executes read_projection and append_event through data.source with the bundled data-store provider adapter catalog so hosted harness runs do not depend on external services.",
+    "The bounded ceiling is carried only as DATA; downstream spend/refund authority remains owned by the accepting runner and human approval lane.",
+    "The public PR contains SKILL.md, X.yaml, fixtures, bundled data-store tool manifests/runners, and these artifact files for review."
+  ]
+}

--- a/skills/revenue-leakage-auditor/artifacts/report.md
+++ b/skills/revenue-leakage-auditor/artifacts/report.md
@@ -14,7 +14,8 @@
 - The hosted registry publish gate passed and published version `sha-8534d7161607`.
 - Registry read and clean install both resolved the package with runner `audit`.
 - Published-package dogfood run sealed production-signed receipt `runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004`.
-- Plain receipt verification passed with the standard production verifier: `signature_mode: production`, 4-receipt tree, no findings.
+- The acceptance-form command `runx verify --receipt <receipt.json> --json` passed for the post-publish dogfood receipt with a valid digest, valid content address, `signature.mode: production`, and no findings; it used no verification bypass flag.
+- A separate receipt-tree verification also passed for the complete 4-receipt lineage with `signature_mode: production` and no findings.
 - Verification public key: `RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687`, `RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4=`.
 
 ## Domain Evidence

--- a/skills/revenue-leakage-auditor/artifacts/report.md
+++ b/skills/revenue-leakage-auditor/artifacts/report.md
@@ -1,0 +1,43 @@
+# revenue-leakage-auditor delivery report
+
+## Package
+
+- Public URL: https://runx.ai/x/dh0h/revenue-leakage-auditor@sha-8534d7161607
+- Registry package: `dh0h/revenue-leakage-auditor@sha-8534d7161607`
+- PR: https://github.com/runxhq/runx/pull/279
+- Source: https://github.com/dh0h/runx/tree/codex/revenue-leakage-auditor-108/skills/revenue-leakage-auditor
+
+## Verification
+
+- `runx-cli 0.6.19` satisfies the `0.6.14+` requirement.
+- Local harness passed with exactly two cases: one sealed under-billing case and one `needs_agent` stop case.
+- The hosted registry publish gate passed and published version `sha-8534d7161607`.
+- Registry read and clean install both resolved the package with runner `audit`.
+- Published-package dogfood run sealed receipt `runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09`.
+- Receipt verification passed with a 4-receipt tree and no findings.
+
+## Domain Evidence
+
+- Happy path reviewed `account:atlas-team` for period `2026-06`.
+- Usage evidence ref is `usage:account:atlas-team:2026-06`.
+- Billing evidence ref is `billing:account:atlas-team:2026-06`.
+- Usage was USD 15000 and billing was USD 10000, leaving USD 5000 under-billed.
+- The 50% gap exceeds the 10% charge threshold and is not covered by an exclusion or known discount.
+- The emitted ceiling is a `runx.attenuation_request.v1` data object, clamped below the USD 6000 parent bound.
+- The stop fixture omits caller answers and pauses at `needs_agent`, proving no ceiling is emitted when the review is not resolved.
+
+## Authority Boundary
+
+- The skill performs review only; it does not move money, settle an adjustment, or charge an account.
+- The skill does not mint authority and does not claim an attenuation subset proof.
+- The ceiling scopes are `spend.reserve`, `spend.settle`, and `receipt.seal`.
+- The ceiling names `registry:runx/spend@0.1.1` as the downstream accepting runner; that runner owns reservation, minting, settlement, and receipt sealing.
+- Human approval is required before a downstream C3 runner consumes the adjustment ceiling.
+- Excluded accounts, known-discount gaps, incomplete usage evidence, and incomplete billing evidence are refused or escalated rather than converted into a ceiling.
+
+## Data Store
+
+- The decision packet carries `registry:runx/data-store@0.1.2` as the handoff package reference.
+- The graph reads `read_projection` and writes `append_event` for `account_reconciliations` keyed by `account_id`.
+- Dogfood append used `expected_version: 0`, idempotency key `revenue-leakage:account:atlas-team:2026-06:detected`, and committed version `1`.
+- The bundled `data.local` adapter catalog is included under this package so hosted harness execution has deterministic local data-store support.

--- a/skills/revenue-leakage-auditor/artifacts/report.md
+++ b/skills/revenue-leakage-auditor/artifacts/report.md
@@ -10,11 +10,12 @@
 ## Verification
 
 - `runx-cli 0.6.19` satisfies the `0.6.14+` requirement.
-- Local harness passed with exactly two cases: one sealed under-billing case and one `needs_agent` stop case.
+- Local harness passed with exactly two cases: one sealed under-billing case and one `needs_agent` stop case; its receipt verifies in production signature mode.
 - The hosted registry publish gate passed and published version `sha-8534d7161607`.
 - Registry read and clean install both resolved the package with runner `audit`.
-- Published-package dogfood run sealed receipt `runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09`.
-- Receipt verification passed with a 4-receipt tree and no findings.
+- Published-package dogfood run sealed production-signed receipt `runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004`.
+- Plain receipt verification passed with the standard production verifier: `signature_mode: production`, 4-receipt tree, no findings.
+- Verification public key: `RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687`, `RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4=`.
 
 ## Domain Evidence
 

--- a/skills/revenue-leakage-auditor/artifacts/verification.json
+++ b/skills/revenue-leakage-auditor/artifacts/verification.json
@@ -1,0 +1,81 @@
+{
+  "schema": "runx.revenue_leakage_auditor.verification.v1",
+  "verified_at": "2026-07-12T05:53:32Z",
+  "cli": {
+    "version": "runx-cli 0.6.19",
+    "meets_minimum": true,
+    "minimum_required": "0.6.14"
+  },
+  "package": {
+    "skill_id": "dh0h/revenue-leakage-auditor",
+    "name": "revenue-leakage-auditor",
+    "version": "sha-8534d7161607",
+    "digest": "sha256:1607612f9c533a5a028d826c5f13fc42bd96847b519ec2f5b61f787ee45d04e7",
+    "profile_digest": "sha256:113c38a350799b496aaa0225fa742d08b38b8ac2a7e177749586187e7e4c77e1",
+    "public_url": "https://runx.ai/x/dh0h/revenue-leakage-auditor@sha-8534d7161607"
+  },
+  "checks": [
+    {
+      "name": "local harness",
+      "command": "runx harness skills/revenue-leakage-auditor --receipt-dir /tmp/runx-revenue-leakage-local-receipts-v2 --json",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": [
+        "revenue-leakage-auditor-underbilling-ceiling",
+        "revenue-leakage-auditor-stop-needs-agent"
+      ],
+      "sealed_receipt_id": "sha256:2680ac5201f0f76b2f72da6c51015e1d4c66e3033a10594df928797e46d4e6e1"
+    },
+    {
+      "name": "local receipt verify",
+      "command": "runx verify sha256:2680ac5201f0f76b2f72da6c51015e1d4c66e3033a10594df928797e46d4e6e1 --receipt-dir /tmp/runx-revenue-leakage-local-receipts-v2 --allow-local-development-signatures --json",
+      "status": "passed",
+      "valid": true,
+      "receipt_count": 4,
+      "signature_mode": "local-development"
+    },
+    {
+      "name": "hosted registry publish gate",
+      "command": "runx registry publish skills/revenue-leakage-auditor --registry https://api.runx.ai --profile skills/revenue-leakage-auditor/X.yaml --json",
+      "status": "published",
+      "hosted_harness_status": "passed"
+    },
+    {
+      "name": "registry read",
+      "command": "runx registry read dh0h/revenue-leakage-auditor --version sha-8534d7161607 --registry https://api.runx.ai --json",
+      "status": "passed",
+      "trust_tier": "community",
+      "runner_names": [
+        "audit"
+      ]
+    },
+    {
+      "name": "registry install",
+      "command": "runx add dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai --to /tmp/runx-revenue-leakage-install-check --json",
+      "status": "installed"
+    },
+    {
+      "name": "published package dogfood start",
+      "command": "runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai ... --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json",
+      "status": "needs_agent",
+      "run_id": "run_audit_c7fadde7d95f",
+      "registry_trust_state": "trusted"
+    },
+    {
+      "name": "published package dogfood resume",
+      "command": "runx resume run_audit_c7fadde7d95f skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json",
+      "status": "sealed",
+      "run_id": "run_audit_c7fadde7d95f",
+      "receipt_id": "sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
+      "receipt_ref": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09"
+    },
+    {
+      "name": "published receipt verify",
+      "command": "runx verify sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09 --receipt-dir /tmp/runx-revenue-leakage-published-receipts --allow-local-development-signatures --json",
+      "status": "passed",
+      "valid": true,
+      "receipt_count": 4,
+      "signature_mode": "local-development"
+    }
+  ]
+}

--- a/skills/revenue-leakage-auditor/artifacts/verification.json
+++ b/skills/revenue-leakage-auditor/artifacts/verification.json
@@ -1,6 +1,6 @@
 {
   "schema": "runx.revenue_leakage_auditor.verification.v1",
-  "verified_at": "2026-07-14T04:47:10Z",
+  "verified_at": "2026-07-14T05:09:20Z",
   "cli": {
     "version": "runx-cli 0.6.19",
     "meets_minimum": true,
@@ -77,7 +77,20 @@
       "receipt_ref": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004"
     },
     {
-      "name": "published receipt verify",
+      "name": "published receipt single-file verify",
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify --receipt /tmp/runx-revenue-leakage-prod-signed-receipts-20260714/sha256-518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004.json --json",
+      "status": "passed",
+      "receipt_id": "sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
+      "valid": true,
+      "digest_status": "valid",
+      "content_address_status": "valid",
+      "signature_mode": "production",
+      "signature_status": "valid",
+      "lineage_status": "unverified for single-file verification",
+      "findings": []
+    },
+    {
+      "name": "published receipt tree verify",
       "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004 --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
       "status": "passed",
       "valid": true,

--- a/skills/revenue-leakage-auditor/artifacts/verification.json
+++ b/skills/revenue-leakage-auditor/artifacts/verification.json
@@ -1,6 +1,6 @@
 {
   "schema": "runx.revenue_leakage_auditor.verification.v1",
-  "verified_at": "2026-07-12T05:53:32Z",
+  "verified_at": "2026-07-14T04:47:10Z",
   "cli": {
     "version": "runx-cli 0.6.19",
     "meets_minimum": true,
@@ -14,25 +14,32 @@
     "profile_digest": "sha256:113c38a350799b496aaa0225fa742d08b38b8ac2a7e177749586187e7e4c77e1",
     "public_url": "https://runx.ai/x/dh0h/revenue-leakage-auditor@sha-8534d7161607"
   },
+  "receipt_signing": {
+    "issuer_type": "hosted",
+    "kid": "dh0h-frantic-receipt-2026-07-14-e88f2687",
+    "public_key_sha256": "sha256:c9a6c5bd0f8cc0f48497a1c67141e4ae6839887993466dbfe4058109913848e4",
+    "verify_public_key_base64": "UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4="
+  },
   "checks": [
     {
       "name": "local harness",
-      "command": "runx harness skills/revenue-leakage-auditor --receipt-dir /tmp/runx-revenue-leakage-local-receipts-v2 --json",
+      "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; PATH includes node runtime; runx harness skills/revenue-leakage-auditor --receipt-dir /tmp/runx-revenue-leakage-prod-signed-local-receipts-20260714 --json",
       "status": "passed",
       "case_count": 2,
       "case_names": [
         "revenue-leakage-auditor-underbilling-ceiling",
         "revenue-leakage-auditor-stop-needs-agent"
       ],
-      "sealed_receipt_id": "sha256:2680ac5201f0f76b2f72da6c51015e1d4c66e3033a10594df928797e46d4e6e1"
+      "sealed_receipt_id": "sha256:0d01bcb0b5f256f7ce1735fc3763323e82102da696df3cc7a6f774c7656bfc70"
     },
     {
       "name": "local receipt verify",
-      "command": "runx verify sha256:2680ac5201f0f76b2f72da6c51015e1d4c66e3033a10594df928797e46d4e6e1 --receipt-dir /tmp/runx-revenue-leakage-local-receipts-v2 --allow-local-development-signatures --json",
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:0d01bcb0b5f256f7ce1735fc3763323e82102da696df3cc7a6f774c7656bfc70 --receipt-dir /tmp/runx-revenue-leakage-prod-signed-local-receipts-20260714 --json",
       "status": "passed",
       "valid": true,
       "receipt_count": 4,
-      "signature_mode": "local-development"
+      "signature_mode": "production",
+      "findings": []
     },
     {
       "name": "hosted registry publish gate",
@@ -56,26 +63,27 @@
     },
     {
       "name": "published package dogfood start",
-      "command": "runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 --registry https://api.runx.ai ... --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json",
+      "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://revenue-leakage/account-ledger; runx skill dh0h/revenue-leakage-auditor@sha-8534d7161607 audit --registry https://api.runx.ai --skip-operator-context -i data_source_ref=tenant://revenue-leakage/account-ledger -i store_id=revenue-leakage-prod-signed-dogfood-20260714 --input-json usage_records=<fixture.usage_records> --input-json billing_history=<fixture.billing_history> --input-json discount_policy=<fixture.discount_policy> --input-json charge_threshold_pct=<fixture.charge_threshold_pct> --input-json parent_adjustment_bounds=<fixture.parent_adjustment_bounds> --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
       "status": "needs_agent",
-      "run_id": "run_audit_c7fadde7d95f",
+      "run_id": "run_audit_393a2c1cf87d",
       "registry_trust_state": "trusted"
     },
     {
       "name": "published package dogfood resume",
-      "command": "runx resume run_audit_c7fadde7d95f skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-published-receipts --json",
+      "command": "RUNX_RECEIPT_SIGN_* configured with hosted Ed25519 signing material; RUNX_DATA_SOURCES configured for tenant://revenue-leakage/account-ledger; runx resume run_audit_393a2c1cf87d skills/revenue-leakage-auditor/fixtures/leakage-answers.json --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
       "status": "sealed",
-      "run_id": "run_audit_c7fadde7d95f",
-      "receipt_id": "sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09",
-      "receipt_ref": "runx:receipt:sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09"
+      "run_id": "run_audit_393a2c1cf87d",
+      "receipt_id": "sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004",
+      "receipt_ref": "runx:receipt:sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004"
     },
     {
       "name": "published receipt verify",
-      "command": "runx verify sha256:437ae4345b69ed944fa17450924987b6acf8706240498754c613517939f9ce09 --receipt-dir /tmp/runx-revenue-leakage-published-receipts --allow-local-development-signatures --json",
+      "command": "RUNX_RECEIPT_VERIFY_KID=dh0h-frantic-receipt-2026-07-14-e88f2687 RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=UojZI9lCxtz5KRlZmm1z2iNazzUIIct+9oZ0Ew8Brz4= runx verify sha256:518ed4ae4d885165101b57d2185361b3263bd05fa59c058c5abc75c12797e004 --receipt-dir /tmp/runx-revenue-leakage-prod-signed-receipts-20260714 --json",
       "status": "passed",
       "valid": true,
       "receipt_count": 4,
-      "signature_mode": "local-development"
+      "signature_mode": "production",
+      "findings": []
     }
   ]
 }

--- a/skills/revenue-leakage-auditor/fixtures/leakage-answers.json
+++ b/skills/revenue-leakage-auditor/fixtures/leakage-answers.json
@@ -1,0 +1,113 @@
+{
+  "agent_task.revenue-leakage-auditor.output": {
+    "leakage_audit_packet": {
+      "schema": "runx.revenue.leakage_audit.v1",
+      "decision": {
+        "leakage_found": true,
+        "reason": "account:atlas-team used USD 15000 in 2026-06, was billed USD 10000, and the 50% under-billing gap exceeds the 10% threshold with no exclusion or known discount."
+      },
+      "ceilings": [
+        {
+          "schema": "runx.attenuation_request.v1",
+          "form": "data",
+          "account_id": "account:atlas-team",
+          "amount": {
+            "amount": 5000,
+            "currency": "USD"
+          },
+          "currency": "USD",
+          "scopes": [
+            "spend.reserve",
+            "spend.settle",
+            "receipt.seal"
+          ],
+          "counterparty": "account:atlas-team",
+          "usage_evidence_ref": "usage:account:atlas-team:2026-06",
+          "billing_evidence_ref": "billing:account:atlas-team:2026-06",
+          "idempotency_key": "revenue-leakage:account:atlas-team:2026-06:recover",
+          "downstream_runner": "registry:runx/spend@0.1.1",
+          "clamp": {
+            "parent_bound_ref": "parent_adjustment_bounds",
+            "max_amount": {
+              "amount": 6000,
+              "currency": "USD"
+            },
+            "result": "within_parent_bounds"
+          }
+        }
+      ],
+      "escalation": {
+        "required": true,
+        "lane": "human_approval",
+        "reason": "Finance approval is required before a downstream C3 runner consumes the adjustment ceiling."
+      },
+      "data_store": {
+        "package_ref": "registry:runx/data-store@0.1.2",
+        "data_source_ref": "tenant://revenue-leakage/account-ledger",
+        "store_id": "revenue-leakage-dogfood-v1",
+        "read_projection": {
+          "runner": "read_projection",
+          "resource": "account_reconciliations",
+          "aggregate_id": "account:atlas-team"
+        },
+        "append_event": {
+          "runner": "append_event",
+          "resource": "account_reconciliations",
+          "aggregate_id": "account:atlas-team",
+          "expected_version": 0,
+          "idempotency_key": "revenue-leakage:account:atlas-team:2026-06:detected",
+          "event": {
+            "type": "revenue_leakage.detected",
+            "payload": {
+              "account_id": "account:atlas-team",
+              "period": "2026-06",
+              "usage_amount": {
+                "amount": 15000,
+                "currency": "USD"
+              },
+              "billed_amount": {
+                "amount": 10000,
+                "currency": "USD"
+              },
+              "under_billed_amount": {
+                "amount": 5000,
+                "currency": "USD"
+              },
+              "threshold_pct": 10,
+              "ceiling_idempotency_key": "revenue-leakage:account:atlas-team:2026-06:recover"
+            }
+          }
+        }
+      },
+      "observations": {
+        "verdict": "leakage_found",
+        "account_id": "account:atlas-team",
+        "period": "2026-06",
+        "usage_evidence_ref": "usage:account:atlas-team:2026-06",
+        "billing_evidence_ref": "billing:account:atlas-team:2026-06",
+        "usage_amount": {
+          "amount": 15000,
+          "currency": "USD"
+        },
+        "billed_amount": {
+          "amount": 10000,
+          "currency": "USD"
+        },
+        "under_billed_amount": {
+          "amount": 5000,
+          "currency": "USD"
+        },
+        "under_billed_pct": 50,
+        "threshold_pct": 10,
+        "bounded_ceiling_count": 1,
+        "aggregate_id": "account:atlas-team",
+        "appended_version": 1,
+        "refused_or_stop_reason": null,
+        "harness_cases": [
+          "revenue-leakage-auditor-underbilling-ceiling",
+          "revenue-leakage-auditor-stop-needs-agent"
+        ]
+      }
+    }
+  }
+}

--- a/skills/revenue-leakage-auditor/fixtures/leakage-input.json
+++ b/skills/revenue-leakage-auditor/fixtures/leakage-input.json
@@ -1,0 +1,48 @@
+{
+  "data_source_ref": "tenant://revenue-leakage/account-ledger",
+  "store_id": "revenue-leakage-dogfood-v1",
+  "usage_records": {
+    "account_id": "account:atlas-team",
+    "usage_amount": 15000,
+    "currency": "USD",
+    "period": "2026-06",
+    "evidence_ref": "usage:account:atlas-team:2026-06"
+  },
+  "billing_history": {
+    "account_id": "account:atlas-team",
+    "billed_amount": 10000,
+    "currency": "USD",
+    "period": "2026-06",
+    "evidence_ref": "billing:account:atlas-team:2026-06"
+  },
+  "discount_policy": {
+    "excluded_accounts": [
+      "account:internal-sandbox"
+    ],
+    "known_discounts": [
+      {
+        "account_id": "account:legacy-partner",
+        "period": "2026-06",
+        "amount": {
+          "amount": 5000,
+          "currency": "USD"
+        },
+        "reason": "contracted launch discount"
+      }
+    ]
+  },
+  "charge_threshold_pct": 10,
+  "parent_adjustment_bounds": {
+    "schema": "runx.authority_bounds.v1",
+    "amount": {
+      "max_per_account": 6000,
+      "currency": "USD"
+    },
+    "scopes": [
+      "spend.reserve",
+      "spend.settle",
+      "receipt.seal"
+    ],
+    "expires_at": "2026-07-31T00:00:00Z"
+  }
+}

--- a/skills/revenue-leakage-auditor/fixtures/no-change-input.json
+++ b/skills/revenue-leakage-auditor/fixtures/no-change-input.json
@@ -1,0 +1,48 @@
+{
+  "data_source_ref": "tenant://revenue-leakage/account-ledger",
+  "store_id": "revenue-leakage-dogfood-v1",
+  "usage_records": {
+    "account_id": "account:bravo-team",
+    "usage_amount": 10500,
+    "currency": "USD",
+    "period": "2026-06",
+    "evidence_ref": "usage:account:bravo-team:2026-06"
+  },
+  "billing_history": {
+    "account_id": "account:bravo-team",
+    "billed_amount": 10000,
+    "currency": "USD",
+    "period": "2026-06",
+    "evidence_ref": "billing:account:bravo-team:2026-06"
+  },
+  "discount_policy": {
+    "excluded_accounts": [
+      "account:internal-sandbox"
+    ],
+    "known_discounts": [
+      {
+        "account_id": "account:legacy-partner",
+        "period": "2026-06",
+        "amount": {
+          "amount": 5000,
+          "currency": "USD"
+        },
+        "reason": "contracted launch discount"
+      }
+    ]
+  },
+  "charge_threshold_pct": 10,
+  "parent_adjustment_bounds": {
+    "schema": "runx.authority_bounds.v1",
+    "amount": {
+      "max_per_account": 6000,
+      "currency": "USD"
+    },
+    "scopes": [
+      "spend.reserve",
+      "spend.settle",
+      "receipt.seal"
+    ],
+    "expires_at": "2026-07-31T00:00:00Z"
+  }
+}

--- a/skills/revenue-leakage-auditor/tools/data/local/manifest.json
+++ b/skills/revenue-leakage-auditor/tools/data/local/manifest.json
@@ -1,0 +1,77 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.local",
+  "version": "0.1.0",
+  "description": "Local JSON event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "store_id": {
+      "type": "string",
+      "required": false,
+      "description": "Local fixture store id. Provider adapters may ignore this."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared resource, stream, table, keyspace, or projection name."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/revenue-leakage-auditor/tools/data/local/run.mjs
+++ b/skills/revenue-leakage-auditor/tools/data/local/run.mjs
@@ -1,0 +1,335 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "local-json-event-store";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const eventDigest = sha256Json(event);
+  const existing = stream.events.find((entry) => entry.idempotency_key === idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, stream, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(store, envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: stream.version,
+      after_version: stream.version,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(stream),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(store, envelope),
+    };
+  }
+
+  if (stream.version !== expectedVersion) {
+    return conflictResult(envelope, stream, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${stream.version}`,
+      provider_evidence: providerEvidence(store, envelope),
+    });
+  }
+
+  const nextVersion = stream.version + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+  stream.events.push(record);
+  stream.version = nextVersion;
+  writeStore(rawInputs, store);
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function conflictResult(envelope, stream, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function readEvents(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const events = stream.events.slice(Math.max(0, stream.events.length - limit));
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(stream),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: stream.version,
+    event_count: stream.events.length,
+    last_event_ref: stream.events.at(-1)?.event_ref ?? null,
+    last_event_type: stream.events.at(-1)?.event_type ?? null,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function streamFor(store, resource, aggregateId) {
+  store.resources[resource] ??= { streams: {} };
+  store.resources[resource].streams[aggregateId] ??= { version: 0, events: [] };
+  return store.resources[resource].streams[aggregateId];
+}
+
+function readStore(rawInputs) {
+  const file = storePath(rawInputs);
+  if (!fs.existsSync(file)) {
+    return {
+      schema: "runx.local_data_store.v1",
+      store_id: localStoreId(rawInputs),
+      resources: {},
+    };
+  }
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || typeof parsed !== "object" || parsed.schema !== "runx.local_data_store.v1") {
+    throw new Error("local data store file has an invalid schema");
+  }
+  parsed.resources ??= {};
+  return parsed;
+}
+
+function writeStore(rawInputs, store) {
+  const file = storePath(rawInputs);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+function storePath(rawInputs) {
+  const storeId = localStoreId(rawInputs);
+  return path.join(os.tmpdir(), "runx-data-store", `${storeId}.json`);
+}
+
+function localStoreId(rawInputs) {
+  if (typeof rawInputs.store_id === "string" && rawInputs.store_id.trim().length > 0) {
+    return safeName(rawInputs.store_id, "store_id");
+  }
+  const ref = typeof rawInputs.data_source_ref === "string" && rawInputs.data_source_ref.length > 0
+    ? rawInputs.data_source_ref
+    : "default";
+  return `source-${crypto.createHash("sha256").update(ref).digest("hex").slice(0, 24)}`;
+}
+
+function providerEvidence(store, envelope) {
+  return {
+    provider: PROVIDER,
+    store_id: store.store_id,
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "local-fixture",
+  };
+}
+
+function projectionDigest(stream) {
+  return sha256Json({
+    version: stream.version,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  });
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}

--- a/skills/revenue-leakage-auditor/tools/data/redis/README.md
+++ b/skills/revenue-leakage-auditor/tools/data/redis/README.md
@@ -1,0 +1,42 @@
+# data.redis
+
+`data.redis` is the Redis provider adapter for the `data-store` operation
+envelope. It is intentionally not a separate domain skill: messageboards,
+operator desks, sync cursors, and business workflows keep their semantics in
+their own skills, while this adapter supplies the storage backend.
+
+## Binding
+
+Bind a logical source to Redis with non-secret project configuration:
+
+```json
+{
+  "data_sources": {
+    "tenant://acme/board": {
+      "adapter": "data.redis",
+      "endpoint": "redis://127.0.0.1:6379/0",
+      "key_prefix": "runx:acme:board",
+      "resources": {
+        "board_events": {
+          "kind": "event_stream",
+          "partition_key": "aggregate_id"
+        }
+      }
+    }
+  }
+}
+```
+
+Pass the document through `RUNX_DATA_SOURCES` or write it to
+`.runx/data-sources.json`. The endpoint must not embed credentials. Use a local
+unauthenticated Redis for OSS dogfood, or put provider credentials behind the
+normal runx credential boundary when a hosted/production adapter supplies secret
+delivery.
+
+## Requirements
+
+- `redis-cli` on `PATH`, or set `RUNX_REDIS_CLI_BIN`.
+- A reachable `redis://` or `rediss://` endpoint.
+
+Live conformance tests run only when `RUNX_REDIS_URL` is set and responds to
+`PING`, so normal CI does not require Redis.

--- a/skills/revenue-leakage-auditor/tools/data/redis/manifest.json
+++ b/skills/revenue-leakage-auditor/tools/data/redis/manifest.json
@@ -1,0 +1,87 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.redis",
+  "version": "0.1.0",
+  "description": "Redis event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": false,
+      "description": "Non-secret data-source binding injected by data.source."
+    },
+    "redis_url": {
+      "type": "string",
+      "required": false,
+      "description": "Redis URL for direct harness use. Prefer data_source_binding.endpoint."
+    },
+    "key_prefix": {
+      "type": "string",
+      "required": false,
+      "description": "Redis key prefix for direct harness use. Prefer data_source_binding.key_prefix."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared event resource or stream family."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/revenue-leakage-auditor/tools/data/redis/run.mjs
+++ b/skills/revenue-leakage-auditor/tools/data/redis/run.mjs
@@ -1,0 +1,426 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "redis-event-store";
+const REDIS_CLI_BIN = process.env.RUNX_REDIS_CLI_BIN || "redis-cli";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const eventDigest = sha256Json(event);
+  const keys = redisKeys(rawInputs, envelope);
+  const nextVersion = expectedVersion + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+  const recordDigest = sha256Json(record);
+  const response = redisEval(rawInputs, appendScript(), [keys.stream, keys.idempotency], [
+    String(expectedVersion),
+    idempotencyKey,
+    eventDigest,
+    eventRef,
+    String(nextVersion),
+    JSON.stringify(record),
+    recordDigest,
+  ]);
+  const [status, ...fields] = response.split("|");
+
+  if (status === "committed") {
+    const [before, after, ref, digest, resultDigest] = fields;
+    return {
+      ...envelope,
+      status: "committed",
+      before_version: Number(before),
+      after_version: Number(after),
+      idempotency_key: idempotencyKey,
+      event_ref: ref,
+      event_digest: digest,
+      result_digest: resultDigest,
+      projection_digest: projectionDigest(rawInputs, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(rawInputs, envelope),
+    };
+  }
+
+  if (status === "idempotent_replay") {
+    const [current, digest, ref, version, resultDigest] = fields;
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: Number(current),
+      after_version: Number(current),
+      idempotency_key: idempotencyKey,
+      event_ref: ref,
+      event_digest: digest,
+      result_digest: resultDigest,
+      projection_digest: projectionDigest(rawInputs, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: {
+        ...providerEvidence(rawInputs, envelope),
+        committed_version: Number(version),
+      },
+    };
+  }
+
+  if (status === "idempotency_conflict") {
+    return conflictResult(envelope, Number(fields[0]), {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: "idempotency key was reused with different event content",
+      projection_digest: projectionDigest(rawInputs, envelope),
+      provider_evidence: providerEvidence(rawInputs, envelope),
+    });
+  }
+
+  if (status === "version_conflict") {
+    const current = Number(fields[0]);
+    return conflictResult(envelope, current, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${current}`,
+      projection_digest: projectionDigest(rawInputs, envelope),
+      provider_evidence: providerEvidence(rawInputs, envelope),
+    });
+  }
+
+  throw new Error(`unexpected redis append response: ${response}`);
+}
+
+function readEvents(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const keys = redisKeys(rawInputs, envelope);
+  const rows = redis(rawInputs, ["LRANGE", keys.stream, String(-limit), "-1"]);
+  const events = parseJsonLines(rows);
+  const current = redisInteger(rawInputs, ["LLEN", keys.stream]);
+  return {
+    ...envelope,
+    status: "read",
+    before_version: current,
+    after_version: current,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(rawInputs, envelope),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(rawInputs, envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const projection = buildProjection(rawInputs, envelope);
+  return {
+    ...envelope,
+    status: "read",
+    before_version: projection.version,
+    after_version: projection.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(rawInputs, envelope),
+  };
+}
+
+function appendScript() {
+  return `
+local current = redis.call('LLEN', KEYS[1])
+local existing = redis.call('HGET', KEYS[2], ARGV[2])
+if existing then
+  local digest, ref, version, result_digest = string.match(existing, '^([^|]+)|([^|]+)|([^|]+)|([^|]+)$')
+  if digest ~= ARGV[3] then
+    return 'idempotency_conflict|' .. current
+  end
+  return 'idempotent_replay|' .. current .. '|' .. digest .. '|' .. ref .. '|' .. version .. '|' .. result_digest
+end
+local expected = tonumber(ARGV[1])
+if current ~= expected then
+  return 'version_conflict|' .. current
+end
+redis.call('RPUSH', KEYS[1], ARGV[6])
+redis.call('HSET', KEYS[2], ARGV[2], ARGV[3] .. '|' .. ARGV[4] .. '|' .. ARGV[5] .. '|' .. ARGV[7])
+return 'committed|' .. current .. '|' .. (current + 1) .. '|' .. ARGV[4] .. '|' .. ARGV[3] .. '|' .. ARGV[7]
+`;
+}
+
+function conflictResult(envelope, currentVersionValue, { idempotency_key, event_digest, reason, projection_digest, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: currentVersionValue,
+    after_version: currentVersionValue,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function buildProjection(rawInputs, envelope) {
+  const keys = redisKeys(rawInputs, envelope);
+  const events = parseJsonLines(redis(rawInputs, ["LRANGE", keys.stream, "0", "-1"]));
+  return {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: events.length,
+    event_count: events.length,
+    last_event_ref: events.at(-1)?.event_ref ?? null,
+    last_event_type: events.at(-1)?.event_type ?? null,
+    event_digests: events.map((entry) => entry.event_digest),
+  };
+}
+
+function projectionDigest(rawInputs, envelope) {
+  return sha256Json(buildProjection(rawInputs, envelope));
+}
+
+function providerEvidence(rawInputs, envelope) {
+  const keys = redisKeys(rawInputs, envelope);
+  return {
+    provider: PROVIDER,
+    adapter: "data.redis",
+    data_source_ref_digest: sha256Json(envelope.data_source_ref),
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "redis",
+    key_prefix_digest: sha256Json(keyPrefix(rawInputs)),
+    stream_digest: keys.digest,
+  };
+}
+
+function redisKeys(rawInputs, envelope) {
+  const digest = sha256Hex({
+    data_source_ref: envelope.data_source_ref,
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+  });
+  const prefix = keyPrefix(rawInputs);
+  return {
+    digest,
+    stream: `${prefix}:stream:${digest}`,
+    idempotency: `${prefix}:idempotency:${digest}`,
+  };
+}
+
+function redisEval(rawInputs, script, keys, argv) {
+  return redis(rawInputs, ["EVAL", script, String(keys.length), ...keys, ...argv]).trim();
+}
+
+function redisInteger(rawInputs, args) {
+  const text = redis(rawInputs, args).trim();
+  const value = Number(text || "0");
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`redis returned invalid integer for ${args[0]}`);
+  }
+  return value;
+}
+
+function redis(rawInputs, args) {
+  const result = spawnSync(REDIS_CLI_BIN, ["-u", redisUrl(rawInputs), "--raw", ...args], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `redis-cli exited ${result.status}`).trim());
+  }
+  return result.stdout;
+}
+
+function redisUrl(rawInputs) {
+  const sourceBinding = dataSourceBinding(rawInputs);
+  const raw = textValue(sourceBinding.endpoint) ?? textValue(sourceBinding.redis_url) ?? textValue(rawInputs.redis_url) ?? "redis://127.0.0.1:6379/0";
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("data.redis endpoint must be a valid redis:// or rediss:// URL");
+  }
+  if (parsed.protocol !== "redis:" && parsed.protocol !== "rediss:") {
+    throw new Error("data.redis endpoint must use redis:// or rediss://");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("data.redis endpoint must not embed credentials; use a runx credential profile or hosted grant");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("data.redis endpoint must not include query or fragment parameters");
+  }
+  return parsed.toString();
+}
+
+function keyPrefix(rawInputs) {
+  const bindingObject = dataSourceBinding(rawInputs);
+  const raw = textValue(bindingObject.key_prefix) ?? textValue(rawInputs.key_prefix) ?? "runx:data-store";
+  const pattern = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,191}$/;
+  if (!pattern.test(raw)) {
+    throw new Error("data.redis key_prefix must be a safe Redis key prefix");
+  }
+  return raw;
+}
+
+function dataSourceBinding(rawInputs) {
+  return rawInputs.data_source_binding && typeof rawInputs.data_source_binding === "object" && !Array.isArray(rawInputs.data_source_binding)
+    ? rawInputs.data_source_binding
+    : {};
+}
+
+function parseJsonLines(stdout) {
+  const text = stdout.trim();
+  if (!text) return [];
+  return text.split(/\r?\n/).map((line) => JSON.parse(line));
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function textValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sha256Json(value) {
+  return `sha256:${sha256Hex(value)}`;
+}
+
+function sha256Hex(value) {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}

--- a/skills/revenue-leakage-auditor/tools/data/sqlite/README.md
+++ b/skills/revenue-leakage-auditor/tools/data/sqlite/README.md
@@ -1,0 +1,63 @@
+# data.sqlite
+
+`data.sqlite` is the durable local adapter for the provider-agnostic runx data
+operation envelope. It is useful for dogfooding real stateful graphs without
+standing up hosted infrastructure. Unbound `local://...` data sources resolve to
+this adapter by default; pass `store_id` only when a fixture intentionally wants
+the JSON `data.local` adapter instead.
+
+The adapter shells out to `sqlite3`. Set `RUNX_SQLITE_BIN` when the binary is not
+on `PATH`.
+
+The adapter is selected through a data-source binding:
+
+```json
+{
+  "data_sources": {
+    "tenant://example/board": {
+      "adapter": "data.sqlite",
+      "database_path": ".runx/data/example-board.sqlite",
+      "resources": {
+        "board_events": {
+          "kind": "event_stream",
+          "partition_key": "aggregate_id"
+        }
+      }
+    }
+  }
+}
+```
+
+Graphs still pass only `data_source_ref`, `resource`, `aggregate_id`,
+`expected_version`, `idempotency_key`, and operation-specific inputs. The
+binding chooses SQLite.
+
+For unbound `local://...` refs, runx derives a source-scoped database path under
+`.runx/data/local-sources/`. When several sources intentionally share one
+configured `database_path`, `data.sqlite` still isolates streams by
+`data_source_ref`, `resource`, and `aggregate_id`.
+
+## Operations
+
+- `append_event`
+- `read_events`
+- `read_projection`
+
+Writes require `expected_version` and `idempotency_key`. A retry with the same
+idempotency key and same event digest returns `idempotent_replay`. A retry with
+the same idempotency key and different event digest returns `conflict`.
+
+## Path rules
+
+Relative `database_path` values resolve from `RUNX_CWD`, `INIT_CWD`, or the
+current working directory. Absolute paths are rejected unless the binding sets
+`allow_absolute_path: true`.
+
+Provider evidence never includes the absolute database path.
+
+## Resetting local state
+
+Delete the relevant file under `.runx/data/local-sources/` for default local
+dogfood, or delete the configured `database_path` for a project-specific
+binding. Do not reset by changing domain skill inputs; that hides replay
+problems instead of clearing local storage.

--- a/skills/revenue-leakage-auditor/tools/data/sqlite/manifest.json
+++ b/skills/revenue-leakage-auditor/tools/data/sqlite/manifest.json
@@ -1,0 +1,82 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.sqlite",
+  "version": "0.1.0",
+  "description": "SQLite event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": false,
+      "description": "Non-secret data-source binding injected by data.source."
+    },
+    "database_path": {
+      "type": "string",
+      "required": false,
+      "description": "Local SQLite database path for direct harness use. Prefer data_source_binding.database_path."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared event resource or stream family."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/revenue-leakage-auditor/tools/data/sqlite/run.mjs
+++ b/skills/revenue-leakage-auditor/tools/data/sqlite/run.mjs
@@ -1,0 +1,546 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "sqlite-event-store";
+const SQLITE_BIN = process.env.RUNX_SQLITE_BIN || "sqlite3";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const eventDigest = sha256Json(event);
+  const current = currentVersion(database, envelope);
+  const existing = existingEvent(database, envelope, idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, current, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: current,
+      after_version: current,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(database, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(envelope),
+    };
+  }
+
+  if (current !== expectedVersion) {
+    return conflictResult(envelope, current, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${current}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  const nextVersion = current + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+
+  try {
+    execSql(database, `
+BEGIN IMMEDIATE;
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+) VALUES (
+  ${sqlString(envelope.data_source_ref)},
+  ${sqlString(envelope.resource)},
+  ${sqlString(envelope.aggregate_id)},
+  ${nextVersion},
+  ${sqlString(idempotencyKey)},
+  ${sqlString(eventRef)},
+  ${sqlString(record.event_type)},
+  ${sqlString(eventDigest)},
+  ${sqlString(JSON.stringify(event))},
+  ${sqlString(record.committed_at)}
+);
+COMMIT;
+`);
+  } catch (error) {
+    const latest = currentVersion(database, envelope);
+    return conflictResult(envelope, latest, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `sqlite append failed after version check: ${error.message}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(database, envelope),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readEvents(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const current = currentVersion(database, envelope);
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version DESC
+LIMIT ${limit};
+`);
+  const events = rows
+    .reverse()
+    .map((row) => ({
+      event_ref: row.event_ref,
+      version: Number(row.version),
+      event_type: row.event_type,
+      event: JSON.parse(row.event_json),
+      event_digest: row.event_digest,
+      idempotency_key: row.idempotency_key,
+      committed_at: row.committed_at,
+    }));
+
+  return {
+    ...envelope,
+    status: "read",
+    before_version: current,
+    after_version: current,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(database, envelope),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const eventRows = queryJson(database, `
+SELECT event_ref, event_type, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: eventRows.length,
+    event_count: eventRows.length,
+    last_event_ref: eventRows.at(-1)?.event_ref ?? null,
+    last_event_type: eventRows.at(-1)?.event_type ?? null,
+    event_digests: eventRows.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: projection.version,
+    after_version: projection.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function conflictResult(envelope, currentVersionValue, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: currentVersionValue,
+    after_version: currentVersionValue,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: `sha256:${"0".repeat(64)}`,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function ensureSchema(database) {
+  fs.mkdirSync(path.dirname(database), { recursive: true });
+  execSql(database, `
+PRAGMA journal_mode = WAL;
+CREATE TABLE IF NOT EXISTS runx_events (
+  data_source_ref TEXT NOT NULL DEFAULT '',
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+`);
+  migrateLegacySchema(database);
+  execSql(database, `
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+`);
+}
+
+function migrateLegacySchema(database) {
+  const columns = queryJson(database, "PRAGMA table_info(runx_events);").map((column) => column.name);
+  if (columns.includes("data_source_ref")) return;
+
+  execSql(database, `
+BEGIN IMMEDIATE;
+ALTER TABLE runx_events RENAME TO runx_events_legacy_unscoped;
+CREATE TABLE runx_events (
+  data_source_ref TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+)
+SELECT
+  '',
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+FROM runx_events_legacy_unscoped;
+DROP TABLE runx_events_legacy_unscoped;
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+COMMIT;
+`);
+}
+
+function currentVersion(database, envelope) {
+  const rows = queryJson(database, `
+SELECT COALESCE(MAX(version), 0) AS version
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)};
+`);
+  return Number(rows[0]?.version ?? 0);
+}
+
+function existingEvent(database, envelope, idempotencyKey) {
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+  AND idempotency_key = ${sqlString(idempotencyKey)}
+LIMIT 1;
+`);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    event_ref: row.event_ref,
+    version: Number(row.version),
+    event_type: row.event_type,
+    event: JSON.parse(row.event_json),
+    event_digest: row.event_digest,
+    idempotency_key: row.idempotency_key,
+    committed_at: row.committed_at,
+  };
+}
+
+function projectionDigest(database, envelope) {
+  const rows = queryJson(database, `
+SELECT version, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  return sha256Json({
+    version: rows.length,
+    event_digests: rows.map((entry) => entry.event_digest),
+  });
+}
+
+function providerEvidence(envelope) {
+  return {
+    provider: PROVIDER,
+    adapter: "data.sqlite",
+    data_source_ref_digest: sha256Json(envelope.data_source_ref),
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "sqlite",
+  };
+}
+
+function databasePath(rawInputs) {
+  const binding = rawInputs.data_source_binding && typeof rawInputs.data_source_binding === "object" && !Array.isArray(rawInputs.data_source_binding)
+    ? rawInputs.data_source_binding
+    : {};
+  const rawPath = typeof binding.database_path === "string" && binding.database_path.trim().length > 0
+    ? binding.database_path.trim()
+    : typeof rawInputs.database_path === "string" && rawInputs.database_path.trim().length > 0
+      ? rawInputs.database_path.trim()
+      : null;
+  if (!rawPath) {
+    throw new Error("data.sqlite requires data_source_binding.database_path or database_path");
+  }
+  const root = path.resolve(process.env.RUNX_CWD || process.env.INIT_CWD || process.cwd());
+  const allowAbsolute = binding.allow_absolute_path === true || rawInputs.allow_absolute_path === true;
+  const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(root, rawPath);
+  if (path.isAbsolute(rawPath) && !allowAbsolute) {
+    throw new Error("data.sqlite absolute database_path requires allow_absolute_path=true in the operator-owned binding");
+  }
+  if (!allowAbsolute && !isInside(root, resolved)) {
+    throw new Error("data.sqlite database_path must stay inside RUNX_CWD unless allow_absolute_path=true");
+  }
+  return resolved;
+}
+
+function execSql(database, sql) {
+  const result = spawnSync(SQLITE_BIN, [database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+}
+
+function queryJson(database, sql) {
+  const result = spawnSync(SQLITE_BIN, ["-json", database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+  const text = result.stdout.trim();
+  return text ? JSON.parse(text) : [];
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}


### PR DESCRIPTION
## Summary

Adds the `revenue-leakage-auditor` runx graph skill for #108. The skill reviews one account-period of usage vs. billing, refuses excluded or discount-covered gaps, and emits only bounded `runx.attenuation_request.v1` ceilings as data for eligible under-billed accounts.

## Safety boundaries

- No money movement, authority minting, settlement, or operational proposal is performed by this skill.
- Each ceiling is clamped to `parent_adjustment_bounds` and is meant for a downstream C3 spend/refund accepting runner.
- Per-account state is read through `read_projection` and recorded with an ungated CAS `append_event` keyed by account id and period.
- Missing or ambiguous evidence stops at `needs_agent` rather than inventing usage, billing, or discount data.

## Verification

- `runx-cli 0.6.19`
- Local harness passed with `revenue-leakage-auditor-underbilling-ceiling` and `revenue-leakage-auditor-stop-needs-agent`.
- Hosted registry publish gate passed for `dh0h/revenue-leakage-auditor@sha-8534d7161607`.
- Clean registry install succeeded.
- Published package dogfood run sealed and receipt verification passed.
