### PR TITLE
feat(skills): add governed open-skill overlay (overlay-open-skill-2)

### DIFF
--- a/skills/overlay-open-skill-2/SKILL.md
+++ b/skills/overlay-open-skill-2/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: overlay-open-skill-2
+description: Govern a public brand-styling skill from the open skill ecosystem under an immutable sha256 pin, read-only filesystem scope, and an explicit allowed-tool set, so the wrapped instructions run under runx authority without being copied or edited.
+runx:
+  category: governance
+---
+
+# Governed brand-styling overlay
+
+This package wraps a public brand-styling skill from the open skill ecosystem
+without copying or editing its instructions. The immutable upstream reference
+and its sha256 pin live in `X.yaml`; the caller resolves those bytes and
+supplies the recomputed digest as `resolved_digest`. The overlay admits the
+wrapped instructions only when the freshly resolved digest still matches the
+reviewed pin.
+
+## What this skill does
+
+1. Admits only the immutable wrapped instructions named in `X.yaml`.
+2. Compares a freshly resolved sha256 digest with the reviewed pin.
+3. Bounds the wrapped instructions to read-only filesystem inspection through
+   one explicit tool.
+4. Emits a machine-readable `ready` decision or a sealed stale-digest refusal.
+
+## When to use this skill
+
+- Before applying wrapped brand-styling guidance to an artifact.
+- When an operator wants the wrapped styling discipline without granting
+  filesystem write, network, or shell authority.
+- When the upstream instructions must remain content-addressed and reviewable.
+
+## When not to use this skill
+
+- To modify, write, commit, push, publish, or otherwise mutate an artifact or
+  repository.
+- To download mutable instructions or trust an unpinned branch URL.
+- To execute a changed upstream skill before its new digest is reviewed.
+
+## Governance boundary
+
+- **Pinned instructions:** only the exact bytes identified by
+  `sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe`
+  are admitted.
+- **Scope bound:** `fs.read` permits read-only inspection of the brand assets
+  and the target artifact already in scope. It does not grant any mutation.
+- **Allowed tools:** `fs.read` is the only tool the wrapped instructions may
+  use, and only for read-only inspection.
+- **Explicit exclusions:** no file writes, commits, pushes, publishing, network
+  access, shell execution, credential access, or secret access.
+
+The most restrictive authority wins. A graph or host may narrow this envelope,
+but the overlay never widens it.
+
+## Procedure
+
+1. Resolve the immutable `wraps.path` declared in `X.yaml`.
+2. Compute sha256 over the exact response bytes without transforming them.
+3. Pass the prefixed value as `resolved_digest` and state the styling intent as
+   `objective`.
+4. Continue only when the result decision is `ready`. A `refused` decision
+   carries `runx.overlay.digest.stale` and admits nothing.
+
+## Diagnostics
+
+- `runx.overlay.digest.required` (warning): no `resolved_digest` was supplied;
+  resolve the wrapped bytes and recompute before running.
+- `runx.overlay.digest.stale` (error): the resolved digest is malformed or no
+  longer matches the pin; the changed upstream is refused unseen.
+
+## Output schema (`runx.skill_overlay.v1`)
+
+```json
+{
+  "schema": "runx.skill_overlay.v1",
+  "objective": "string",
+  "wraps": { "path": "string", "digest": "sha256:<64 hex>" },
+  "resolved_digest": "sha256:<64 hex> | null",
+  "runner": {
+    "type": "agent",
+    "scopes": ["fs.read"],
+    "allowed_tools": ["fs.read"],
+    "denied_capabilities": ["filesystem.write", "network.access", "shell.exec", "repo.commit", "repo.push", "publish", "secrets.read"]
+  },
+  "decision": "ready | refused | needs_input",
+  "diagnostics": []
+}
+```
+
+## Harness cases
+
+- **pinned-digest-seals:** the resolved digest equals the pin, so the overlay
+  admits the wrapped instructions and the receipt seals `closed`.
+- **digest-stale-refuses:** the resolved digest differs from the pin, so the
+  overlay raises `runx.overlay.digest.stale` and the receipt seals `failed`
+  without admitting the changed instructions.
+
+## Installation and usage
+
+```bash
+runx add <owner>/overlay-open-skill-2@<version> --registry https://api.runx.ai
+RUNX_INPUT_RESOLVED_DIGEST=sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe \
+  runx skill <owner>/overlay-open-skill-2@<version> --registry https://api.runx.ai --json -R ./receipts
+runx verify --receipt <receipt.json> --json
+```
+
+## Upstream and license
+
+The wrapped skill is a public, permissively licensed, actively maintained
+brand-styling skill from the open skill ecosystem. Its repository, path, pinned
+commit, license, and sha256 are recorded in `fixtures/evidence/upstream-provenance.json`
+and in the delivery evidence so a reviewer can recompute the digest from the
+immutable source. The upstream file is never copied into or edited by this
+overlay.

--- a/skills/overlay-open-skill-2/X.yaml
+++ b/skills/overlay-open-skill-2/X.yaml
@@ -1,0 +1,61 @@
+skill: overlay-open-skill-2
+version: "0.1.0"
+runx:
+  overlay:
+    wraps:
+      path: https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md
+      version: sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe
+    pinned_digest: sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: context
+harness:
+  cases:
+    - name: pinned-digest-seals
+      runner: default
+      inputs:
+        objective: Confirm the immutable wrapped styling instructions remain current before applying them.
+        resolved_digest: sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: digest-stale-refuses
+      runner: default
+      inputs:
+        objective: Refuse changed wrapped instructions before any styling guidance is applied.
+        resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: failed
+          reason_code: process_failed
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    mutating: false
+    runx:
+      scopes:
+        - fs.read
+      allowed_tools:
+        - fs.read
+    inputs:
+      objective:
+        type: string
+        required: false
+        description: Styling intent recorded in the sealed receipt without granting authority.
+      resolved_digest:
+        type: string
+        required: false
+        description: Recomputed sha256 digest of the immutable wrapped SKILL.md bytes.

--- a/skills/overlay-open-skill-2/evidence/dogfood_output.json
+++ b/skills/overlay-open-skill-2/evidence/dogfood_output.json
@@ -1,0 +1,251 @@
+{
+  "closure": {
+    "closed_at": "2026-07-12T09:20:10.069Z",
+    "disposition": "closed",
+    "reason_code": "process_closed",
+    "summary": "cli-tool default completed"
+  },
+  "execution": {
+    "exit_code": 0,
+    "skill_claim": {
+      "decision": "ready",
+      "diagnostics": [],
+      "objective": "Apply the wrapped brand-styling guidance under read-only authority.",
+      "resolved_digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+      "runner": {
+        "allowed_tools": [
+          "fs.read"
+        ],
+        "denied_capabilities": [
+          "filesystem.write",
+          "network.access",
+          "shell.exec",
+          "repo.commit",
+          "repo.push",
+          "publish",
+          "secrets.read"
+        ],
+        "scopes": [
+          "fs.read"
+        ],
+        "type": "agent"
+      },
+      "schema": "runx.skill_overlay.v1",
+      "wraps": {
+        "digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+        "path": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md"
+      }
+    },
+    "stderr": "",
+    "stdout": "{\"schema\":\"runx.skill_overlay.v1\",\"objective\":\"Apply the wrapped brand-styling guidance under read-only authority.\",\"wraps\":{\"path\":\"https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md\",\"digest\":\"sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe\"},\"resolved_digest\":\"sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe\",\"runner\":{\"type\":\"agent\",\"scopes\":[\"fs.read\"],\"allowed_tools\":[\"fs.read\"],\"denied_capabilities\":[\"filesystem.write\",\"network.access\",\"shell.exec\",\"repo.commit\",\"repo.push\",\"publish\",\"secrets.read\"]},\"decision\":\"ready\",\"diagnostics\":[]}\n",
+    "structured_output": {
+      "decision": "ready",
+      "diagnostics": [],
+      "objective": "Apply the wrapped brand-styling guidance under read-only authority.",
+      "resolved_digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+      "runner": {
+        "allowed_tools": [
+          "fs.read"
+        ],
+        "denied_capabilities": [
+          "filesystem.write",
+          "network.access",
+          "shell.exec",
+          "repo.commit",
+          "repo.push",
+          "publish",
+          "secrets.read"
+        ],
+        "scopes": [
+          "fs.read"
+        ],
+        "type": "agent"
+      },
+      "schema": "runx.skill_overlay.v1",
+      "wraps": {
+        "digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+        "path": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md"
+      }
+    }
+  },
+  "payload": {
+    "decision": "ready",
+    "diagnostics": [],
+    "objective": "Apply the wrapped brand-styling guidance under read-only authority.",
+    "resolved_digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+    "runner": {
+      "allowed_tools": [
+        "fs.read"
+      ],
+      "denied_capabilities": [
+        "filesystem.write",
+        "network.access",
+        "shell.exec",
+        "repo.commit",
+        "repo.push",
+        "publish",
+        "secrets.read"
+      ],
+      "scopes": [
+        "fs.read"
+      ],
+      "type": "agent"
+    },
+    "schema": "runx.skill_overlay.v1",
+    "wraps": {
+      "digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+      "path": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md"
+    }
+  },
+  "receipt": {
+    "acts": [
+      {
+        "artifact_refs": [],
+        "closure": {
+          "closed_at": "2026-07-12T09:20:10.069Z",
+          "disposition": "closed",
+          "reason_code": "process_exit",
+          "summary": "cli-tool exited successfully"
+        },
+        "criterion_bindings": [
+          {
+            "criterion_id": "process_exit",
+            "evidence_refs": [],
+            "status": "verified",
+            "summary": "cli-tool exited successfully",
+            "verification_refs": []
+          }
+        ],
+        "form": "observation",
+        "id": "act_default",
+        "intent": {
+          "constraints": [],
+          "derived_from": [],
+          "legitimacy": "Runtime graph execution was admitted by the local harness",
+          "purpose": "Run graph step default",
+          "success_criteria": [
+            {
+              "criterion_id": "process_exit",
+              "required": true,
+              "statement": "cli-tool exits successfully"
+            }
+          ]
+        },
+        "source_refs": [],
+        "summary": "Executed graph step default",
+        "target_refs": []
+      }
+    ],
+    "authority": {
+      "actor_ref": {
+        "type": "principal",
+        "uri": "runx:principal:local_runtime"
+      },
+      "attenuation": {
+        "parent_authority_ref": null,
+        "subset_proof": null
+      },
+      "authority_proof_refs": [],
+      "enforcement": {
+        "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
+        "redaction_refs": [],
+        "setup_refs": [],
+        "teardown_refs": []
+      },
+      "grant_refs": [],
+      "scope_refs": [],
+      "terms": []
+    },
+    "canonicalization": "runx.receipt.c14n.v1",
+    "created_at": "2026-07-12T09:20:10.069Z",
+    "decisions": [
+      {
+        "artifact_refs": [],
+        "choice": "open",
+        "closure": null,
+        "decision_id": "dec_default",
+        "inputs": {
+          "opportunity_refs": [],
+          "selection_ref": null,
+          "signal_refs": [],
+          "target_ref": null
+        },
+        "justification": {
+          "evidence_refs": [],
+          "summary": "runtime graph planner selected this node"
+        },
+        "proposed_intent": {
+          "constraints": [],
+          "derived_from": [],
+          "legitimacy": "Local graph execution requested this node",
+          "purpose": "Open runtime node default",
+          "success_criteria": []
+        },
+        "selected_act_id": "act_default",
+        "selected_harness_ref": null
+      }
+    ],
+    "digest": "sha256:edbc60da786897e18c35f5fa7ecdb417f95f9d72586645322f260f67c4c7f2eb",
+    "id": "sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+    "idempotency": {
+      "content_hash": "sha256:run_default_88a740c9846b-default-content",
+      "intent_key": "sha256:run_default_88a740c9846b-default-intent",
+      "trigger_fingerprint": "sha256:run_default_88a740c9846b-default-trigger"
+    },
+    "issuer": {
+      "kid": "key1",
+      "public_key_sha256": "sha256:625772519d340670204205d92600ff803eed53849a0c9c7ce623c0a3ac4dcf96",
+      "type": "ci"
+    },
+    "lineage": {
+      "children": [],
+      "sync": []
+    },
+    "schema": "runx.receipt.v1",
+    "seal": {
+      "closed_at": "2026-07-12T09:20:10.069Z",
+      "criteria": [
+        {
+          "criterion_id": "process_exit",
+          "evidence_refs": [],
+          "status": "verified",
+          "summary": "cli-tool exited successfully",
+          "verification_refs": []
+        }
+      ],
+      "disposition": "closed",
+      "last_observed_at": "2026-07-12T09:20:10.069Z",
+      "reason_code": "process_closed",
+      "summary": "cli-tool default completed"
+    },
+    "signals": [],
+    "signature": {
+      "alg": "Ed25519",
+      "value": "base64:VKBryaJiR1eSoFwDjvoQadhZkhUyq1HfKZ1GBzQbOBUqZhevba1m_2wd6GPhyQyD1dkycBTaBkRt49tia5mRDA"
+    },
+    "subject": {
+      "commitments": [],
+      "kind": "skill",
+      "ref": {
+        "type": "harness",
+        "uri": "hrn_run_default_88a740c9846b_default"
+      }
+    }
+  },
+  "receipt_id": "sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+  "registry_provenance": {
+    "digest": "sha256:b4f1ccace4662a2c17cfbb8c215846b50a66aa6f23c357ac1965ce68db06fce8",
+    "profile_digest": "sha256:03d12b64d5bf8c4bfb5527fedd3eff208780e0b81dd2de30a6fe2083f0388eb0",
+    "registry_key_id": "runx-registry-ed25519-v1",
+    "registry_source": "remote https://api.runx.ai",
+    "registry_source_fingerprint": "ba1ac16b631195fd",
+    "skill_id": "codeboost-tr/overlay-open-skill-2",
+    "trust_state": "trusted",
+    "trust_tier": "community",
+    "version": "sha-8e908cfce069"
+  },
+  "run_id": "run_default_88a740c9846b",
+  "schema": "runx.skill_run.v1",
+  "skill_name": "overlay-open-skill-2",
+  "status": "sealed"
+}

--- a/skills/overlay-open-skill-2/evidence/dogfood_receipt.json
+++ b/skills/overlay-open-skill-2/evidence/dogfood_receipt.json
@@ -1,0 +1,135 @@
+{
+  "acts": [
+    {
+      "artifact_refs": [],
+      "closure": {
+        "closed_at": "2026-07-12T09:20:10.069Z",
+        "disposition": "closed",
+        "reason_code": "process_exit",
+        "summary": "cli-tool exited successfully"
+      },
+      "criterion_bindings": [
+        {
+          "criterion_id": "process_exit",
+          "evidence_refs": [],
+          "status": "verified",
+          "summary": "cli-tool exited successfully",
+          "verification_refs": []
+        }
+      ],
+      "form": "observation",
+      "id": "act_default",
+      "intent": {
+        "constraints": [],
+        "derived_from": [],
+        "legitimacy": "Runtime graph execution was admitted by the local harness",
+        "purpose": "Run graph step default",
+        "success_criteria": [
+          {
+            "criterion_id": "process_exit",
+            "required": true,
+            "statement": "cli-tool exits successfully"
+          }
+        ]
+      },
+      "source_refs": [],
+      "summary": "Executed graph step default",
+      "target_refs": []
+    }
+  ],
+  "authority": {
+    "actor_ref": {
+      "type": "principal",
+      "uri": "runx:principal:local_runtime"
+    },
+    "attenuation": {
+      "parent_authority_ref": null,
+      "subset_proof": null
+    },
+    "authority_proof_refs": [],
+    "enforcement": {
+      "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
+      "redaction_refs": [],
+      "setup_refs": [],
+      "teardown_refs": []
+    },
+    "grant_refs": [],
+    "scope_refs": [],
+    "terms": []
+  },
+  "canonicalization": "runx.receipt.c14n.v1",
+  "created_at": "2026-07-12T09:20:10.069Z",
+  "decisions": [
+    {
+      "artifact_refs": [],
+      "choice": "open",
+      "closure": null,
+      "decision_id": "dec_default",
+      "inputs": {
+        "opportunity_refs": [],
+        "selection_ref": null,
+        "signal_refs": [],
+        "target_ref": null
+      },
+      "justification": {
+        "evidence_refs": [],
+        "summary": "runtime graph planner selected this node"
+      },
+      "proposed_intent": {
+        "constraints": [],
+        "derived_from": [],
+        "legitimacy": "Local graph execution requested this node",
+        "purpose": "Open runtime node default",
+        "success_criteria": []
+      },
+      "selected_act_id": "act_default",
+      "selected_harness_ref": null
+    }
+  ],
+  "digest": "sha256:edbc60da786897e18c35f5fa7ecdb417f95f9d72586645322f260f67c4c7f2eb",
+  "id": "sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+  "idempotency": {
+    "content_hash": "sha256:run_default_88a740c9846b-default-content",
+    "intent_key": "sha256:run_default_88a740c9846b-default-intent",
+    "trigger_fingerprint": "sha256:run_default_88a740c9846b-default-trigger"
+  },
+  "issuer": {
+    "kid": "key1",
+    "public_key_sha256": "sha256:625772519d340670204205d92600ff803eed53849a0c9c7ce623c0a3ac4dcf96",
+    "type": "ci"
+  },
+  "lineage": {
+    "children": [],
+    "sync": []
+  },
+  "schema": "runx.receipt.v1",
+  "seal": {
+    "closed_at": "2026-07-12T09:20:10.069Z",
+    "criteria": [
+      {
+        "criterion_id": "process_exit",
+        "evidence_refs": [],
+        "status": "verified",
+        "summary": "cli-tool exited successfully",
+        "verification_refs": []
+      }
+    ],
+    "disposition": "closed",
+    "last_observed_at": "2026-07-12T09:20:10.069Z",
+    "reason_code": "process_closed",
+    "summary": "cli-tool default completed"
+  },
+  "signals": [],
+  "signature": {
+    "alg": "Ed25519",
+    "value": "base64:VKBryaJiR1eSoFwDjvoQadhZkhUyq1HfKZ1GBzQbOBUqZhevba1m_2wd6GPhyQyD1dkycBTaBkRt49tia5mRDA"
+  },
+  "subject": {
+    "commitments": [],
+    "kind": "skill",
+    "ref": {
+      "type": "harness",
+      "uri": "hrn_run_default_88a740c9846b_default"
+    }
+  }
+}

--- a/skills/overlay-open-skill-2/evidence/evidence.json
+++ b/skills/overlay-open-skill-2/evidence/evidence.json
@@ -1,0 +1,219 @@
+{
+  "summary": "Evidence packet for the runx overlay-open-skill-2 skill (codeboost-tr/overlay-open-skill-2@sha-8e908cfce069). A governed overlay wraps the public brand-guidelines SKILL.md (anthropics/skills, Apache-2.0) by REFERENCE under a pinned sha256 (sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe), read-only fs.read scope, and an explicit fs.read allowed-tool set; the upstream is never copied or edited. A real post-publish dogfood run produced a sealed runx.receipt.v1 that passes runx verify with a production signature. The pinned-digest-seals case admits the wrapped instructions and seals; the digest-stale-refuses case raises runx.overlay.digest.stale and refuses. The wrapped upstream is distinct from overlay-open-skill-1 (verification-before-completion, obra/superpowers). All source artifacts pin to a single commit.",
+  "dogfood": {
+    "package": "codeboost-tr/overlay-open-skill-2@sha-8e908cfce069",
+    "input": {
+      "resolved_digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+      "objective": "Apply the wrapped brand-styling guidance under read-only authority."
+    },
+    "command": "runx skill codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai --json -i resolved_digest='sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe' -i objective='Apply the wrapped brand-styling guidance under read-only authority.' -R ./receipts",
+    "receipt_ref": "runx:receipt:sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+    "verify_verdict": "valid",
+    "output": {
+      "decision": "ready",
+      "diagnostics": [],
+      "objective": "Apply the wrapped brand-styling guidance under read-only authority.",
+      "resolved_digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+      "runner": {
+        "allowed_tools": [
+          "fs.read"
+        ],
+        "denied_capabilities": [
+          "filesystem.write",
+          "network.access",
+          "shell.exec",
+          "repo.commit",
+          "repo.push",
+          "publish",
+          "secrets.read"
+        ],
+        "scopes": [
+          "fs.read"
+        ],
+        "type": "agent"
+      },
+      "schema": "runx.skill_overlay.v1",
+      "wraps": {
+        "digest": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+        "path": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md"
+      }
+    },
+    "harness_cases": [
+      {
+        "name": "pinned-digest-seals",
+        "status": "sealed"
+      },
+      {
+        "name": "digest-stale-refuses",
+        "status": "refused"
+      }
+    ]
+  },
+  "observations": [
+    {
+      "type": "runx_version",
+      "value": "runx-cli 0.6.14",
+      "detail": "runx --version used for publish/install/dogfood/verify."
+    },
+    {
+      "type": "publisher_owner",
+      "value": "codeboost-tr",
+      "detail": "Publisher owner (matches the verified claimant)."
+    },
+    {
+      "type": "package_name",
+      "value": "overlay-open-skill-2",
+      "detail": "Exact published package name."
+    },
+    {
+      "type": "version",
+      "value": "sha-8e908cfce069",
+      "detail": "Published package version."
+    },
+    {
+      "type": "registry_ref",
+      "value": "codeboost-tr/overlay-open-skill-2@sha-8e908cfce069",
+      "detail": "Fully qualified registry reference."
+    },
+    {
+      "type": "package_digest",
+      "value": "sha256:b4f1ccace4662a2c17cfbb8c215846b50a66aa6f23c357ac1965ce68db06fce8",
+      "detail": "Published package content digest."
+    },
+    {
+      "type": "public_url",
+      "value": "https://runx.ai/x/codeboost-tr/overlay-open-skill-2@sha-8e908cfce069",
+      "detail": "Live registry listing / canonical adoption page."
+    },
+    {
+      "type": "pr_url",
+      "value": "https://github.com/runxhq/runx/pull/282",
+      "detail": "Public PR against runxhq/runx containing the package."
+    },
+    {
+      "type": "source_url",
+      "value": "https://github.com/codeboost-tr/runx/tree/ef3fd85415948907ff660ecaba695e9eb544e931",
+      "detail": "Public source revision (commit X)."
+    },
+    {
+      "type": "raw_x_yaml",
+      "value": "https://raw.githubusercontent.com/codeboost-tr/runx/ef3fd85415948907ff660ecaba695e9eb544e931/skills/overlay-open-skill-2/X.yaml",
+      "detail": "Raw X.yaml at the source revision."
+    },
+    {
+      "type": "raw_skill_md",
+      "value": "https://raw.githubusercontent.com/codeboost-tr/runx/ef3fd85415948907ff660ecaba695e9eb544e931/skills/overlay-open-skill-2/SKILL.md",
+      "detail": "Raw SKILL.md at the source revision."
+    },
+    {
+      "type": "verification_json",
+      "value": "https://raw.githubusercontent.com/codeboost-tr/runx/ef3fd85415948907ff660ecaba695e9eb544e931/skills/overlay-open-skill-2/evidence/verification.json",
+      "detail": "Raw runx verify verdict."
+    },
+    {
+      "type": "publish_method",
+      "value": "runx login --provider github --for publish, then runx registry publish ./skills/overlay-open-skill-2/SKILL.md --registry https://api.runx.ai",
+      "detail": "Authenticate and publish commands."
+    },
+    {
+      "type": "install_command",
+      "value": "runx add codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai",
+      "detail": "Clean install command (verified: source=remote, signed, status=installed)."
+    },
+    {
+      "type": "harness_cases",
+      "value": "pinned-digest-seals (sealed), digest-stale-refuses (refused)",
+      "detail": "Harness case names with status."
+    },
+    {
+      "type": "hosted_harness_status",
+      "value": "WSL local `runx harness ./skills/overlay-open-skill-2` passed 2/2 with 0 assertion errors (pinned-digest-seals sealed, digest-stale-refuses failed). The published package installs cleanly from the remote registry (runx add: source=remote, signed runx-registry-ed25519-v1, status=installed) and its inline harness.cases are executed by the hosted registry harness at review. Environment: WSL Linux local + remote registry install.",
+      "detail": "Harness status with explicit environment labeling."
+    },
+    {
+      "type": "dogfood_command",
+      "value": "runx skill codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai --json -i resolved_digest='sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe' -i objective='Apply the wrapped brand-styling guidance under read-only authority.' -R ./receipts",
+      "detail": "Exact post-publish dogfood command."
+    },
+    {
+      "type": "receipt_ref",
+      "value": "runx:receipt:sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+      "detail": "Sealed receipt id from the post-publish dogfood run (not a harness fixture seal)."
+    },
+    {
+      "type": "runx_verify_verdict",
+      "value": "valid=True, signature_mode=production, signature_status=valid, digest=valid, content_address=valid",
+      "detail": "runx verify verdict for the dogfood receipt."
+    },
+    {
+      "type": "overlay_wraps_reference",
+      "value": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md",
+      "detail": "The wraps REFERENCE (immutable raw URL); upstream is not copied."
+    },
+    {
+      "type": "overlay_pinned_digest",
+      "value": "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+      "detail": "Pinned sha256 of the wrapped SKILL.md bytes; a reviewer recomputes from wraps reference."
+    },
+    {
+      "type": "overlay_scope_bounds",
+      "value": "fs.read",
+      "detail": "Non-empty scope bounds declared on the overlay runner."
+    },
+    {
+      "type": "overlay_allowed_tools",
+      "value": "fs.read",
+      "detail": "Explicit allowed-tool set (no wildcard); the only tool the wrapped skill may touch."
+    },
+    {
+      "type": "overlay_denied_capabilities",
+      "value": "filesystem.write, network.access, shell.exec, repo.commit, repo.push, publish, secrets.read",
+      "detail": "Capabilities the overlay explicitly denies."
+    },
+    {
+      "type": "upstream_skill",
+      "value": "brand-guidelines",
+      "detail": "Wrapped upstream skill name."
+    },
+    {
+      "type": "upstream_repo",
+      "value": "anthropics/skills",
+      "detail": "Upstream public repository."
+    },
+    {
+      "type": "upstream_commit",
+      "value": "9d2f1ae187231d8199c64b5b762e1bdf2244733d",
+      "detail": "Pinned upstream commit."
+    },
+    {
+      "type": "upstream_license",
+      "value": "Apache-2.0",
+      "detail": "Upstream license (permissive, verified in LICENSE.txt)."
+    },
+    {
+      "type": "upstream_maintenance",
+      "value": "anthropics/skills not archived; stars 160431; pushed_at 2026-07-01T18:11:25Z",
+      "detail": "Active-maintenance signal."
+    },
+    {
+      "type": "distinct_from_companion",
+      "value": "overlay-open-skill-1 (bilbop1) wraps verification-before-completion (obra/superpowers); this overlay wraps brand-guidelines (anthropics/skills) \u2014 different upstream, no target collision.",
+      "detail": "Distinctness from the companion overlay bounty."
+    },
+    {
+      "type": "digest_stale_case",
+      "value": "digest-stale-refuses: resolved_digest != pin -> decision refused, diagnostic runx.overlay.digest.stale, receipt sealed failed; changed instructions not admitted.",
+      "detail": "The digest-stale refusal path."
+    },
+    {
+      "type": "registry_provenance",
+      "value": "{\"digest\": \"sha256:b4f1ccace4662a2c17cfbb8c215846b50a66aa6f23c357ac1965ce68db06fce8\", \"profile_digest\": \"sha256:03d12b64d5bf8c4bfb5527fedd3eff208780e0b81dd2de30a6fe2083f0388eb0\", \"registry_key_id\": \"runx-registry-ed25519-v1\", \"registry_source\": \"remote https://api.runx.ai\", \"registry_source_fingerprint\": \"ba1ac16b631195fd\", \"skill_id\": \"codeboost-tr/overlay-open-skill-2\", \"trust_state\": \"trusted\", \"trust_tier\": \"community\", \"version\": \"sha-8e908cfce069\"}",
+      "detail": "registry_provenance block from the dogfood receipt (same published package version)."
+    },
+    {
+      "type": "how_to_use",
+      "value": "Install: runx add codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai. Run: runx skill codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai --json -i resolved_digest='<sha256 of wrapped SKILL.md>' -i objective='...' -R ./receipts. Verify: runx verify --receipt <receipt.json> --json (expects valid=true, signature_mode=production). Supplying the pinned digest seals a ready decision; any other digest refuses with runx.overlay.digest.stale.",
+      "detail": "End-to-end install/run/verify for a new user without private context."
+    }
+  ]
+}

--- a/skills/overlay-open-skill-2/evidence/report.md
+++ b/skills/overlay-open-skill-2/evidence/report.md
@@ -1,0 +1,52 @@
+# overlay-open-skill-2 - Delivery Report
+
+## Package
+- **Skill** `overlay-open-skill-2` | **Owner** `codeboost-tr` | **Version** `sha-8e908cfce069`
+- **Registry ref** `codeboost-tr/overlay-open-skill-2@sha-8e908cfce069` | **digest** `sha256:b4f1ccace4662a2c17cfbb8c215846b50a66aa6f23c357ac1965ce68db06fce8`
+- **public_url** https://runx.ai/x/codeboost-tr/overlay-open-skill-2@sha-8e908cfce069
+- **pr_url** https://github.com/runxhq/runx/pull/282
+- **source_url** https://github.com/codeboost-tr/runx/tree/ef3fd85415948907ff660ecaba695e9eb544e931
+- **raw X.yaml** https://raw.githubusercontent.com/codeboost-tr/runx/ef3fd85415948907ff660ecaba695e9eb544e931/skills/overlay-open-skill-2/X.yaml
+- **raw SKILL.md** https://raw.githubusercontent.com/codeboost-tr/runx/ef3fd85415948907ff660ecaba695e9eb544e931/skills/overlay-open-skill-2/SKILL.md
+
+## What this is
+A governed **overlay**: it wraps the public `brand-guidelines` SKILL.md by REFERENCE
+(never copying it) under an immutable sha256 pin, a non-empty `fs.read` scope bound, and an
+explicit `fs.read` allowed-tool set. The overlay admits the wrapped instructions only while a
+freshly resolved digest matches the reviewed pin; a changed upstream raises
+`runx.overlay.digest.stale` and is refused unseen.
+
+## Wrapped upstream (named, permissive, maintained)
+- **Skill** brand-guidelines | **Repo** anthropics/skills | **Path** skills/brand-guidelines/SKILL.md
+- **Commit** 9d2f1ae187231d8199c64b5b762e1bdf2244733d | **License** Apache-2.0
+- **Immutable source** https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md
+- **Pinned digest** sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe (byte_count 2235; recompute: `curl -sL https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md | sha256sum`)
+- **Distinct** from overlay-open-skill-1, which wraps `verification-before-completion` (obra/superpowers).
+
+## runx CLI
+`runx --version` -> **runx-cli 0.6.14** (>= 0.6.14). Used for publish, install, dogfood, verify.
+
+## Harness (WSL local)
+`runx harness ./skills/overlay-open-skill-2` -> **2/2 PASSED, 0 assertion errors**.
+Cases: **pinned-digest-seals** (resolved digest == pin -> sealed/closed),
+**digest-stale-refuses** (resolved digest != pin -> runx.overlay.digest.stale -> sealed/failed).
+
+## Install (clean)
+`runx add codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai` -> source=remote, signed (runx-registry-ed25519-v1), status=installed.
+
+## Dogfood (post-publish, real)
+- Command: `runx skill codeboost-tr/overlay-open-skill-2@sha-8e908cfce069 --registry https://api.runx.ai --json -i resolved_digest='sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe' -i objective='Apply the wrapped brand-styling guidance under read-only authority.' -R ./receipts`
+- Output: `decision: ready`, empty diagnostics, resolved_digest == pin, runner scopes=[fs.read] allowed_tools=[fs.read].
+- Receipt: `runx:receipt:sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586`
+- `runx verify --receipt dogfood_receipt.json --json` -> **valid: true, signature_mode: production, signature: valid, digest: valid, content_address: valid**.
+
+## Provenance
+Source artifacts (source_url, X.yaml, SKILL.md, verification.json, dogfood receipt, upstream-provenance)
+pin to commit X `ef3fd85415948907ff660ecaba695e9eb544e931` on `codeboost-tr/runx`. This report and evidence.json are its child commit Y (the PR head).
+The evidence-internal `source_url` observation equals the delivered `source_url` (commit X). The recorded
+receipt_ref is the post-publish dogfood run, not a harness fixture seal.
+
+## What to inspect first
+1. `runx verify --receipt dogfood_receipt.json --json` (valid=true, production).
+2. `curl -sL https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md | sha256sum` == sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe (recompute the pin from the immutable upstream).
+3. evidence.json dogfood.output (decision ready, wraps reference + pinned digest) and the digest-stale case.

--- a/skills/overlay-open-skill-2/evidence/upstream-provenance.json
+++ b/skills/overlay-open-skill-2/evidence/upstream-provenance.json
@@ -1,0 +1,25 @@
+{
+  "upstream_skill": "brand-guidelines",
+  "upstream_repo": "anthropics/skills",
+  "upstream_path": "skills/brand-guidelines/SKILL.md",
+  "upstream_commit": "9d2f1ae187231d8199c64b5b762e1bdf2244733d",
+  "immutable_source_url": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md",
+  "sha256": "1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe",
+  "byte_count": 2235,
+  "license": "Apache-2.0",
+  "license_url": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/LICENSE.txt",
+  "maintenance": {
+    "archived": false,
+    "stars_at_check": 160431,
+    "forks_at_check": 18937,
+    "pushed_at": "2026-07-01T18:11:25Z"
+  },
+  "selection": {
+    "permissive_license_verified": true,
+    "actively_maintained_verified": true,
+    "upstream_content_copied": false,
+    "companion_overlay_target_collision_found": false,
+    "companion_overlay_target": "verification-before-completion (obra/superpowers) wrapped by overlay-open-skill-1"
+  },
+  "checked_at": "2026-07-12T09:15:00Z"
+}

--- a/skills/overlay-open-skill-2/evidence/verification.json
+++ b/skills/overlay-open-skill-2/evidence/verification.json
@@ -1,0 +1,25 @@
+{
+  "schema": "runx.verify_verdict.v1",
+  "receipt_id": "sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+  "valid": true,
+  "digest": {
+    "status": "valid",
+    "expected": "sha256:edbc60da786897e18c35f5fa7ecdb417f95f9d72586645322f260f67c4c7f2eb",
+    "actual": "sha256:edbc60da786897e18c35f5fa7ecdb417f95f9d72586645322f260f67c4c7f2eb"
+  },
+  "content_address": {
+    "status": "valid",
+    "expected": "sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586",
+    "actual": "sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586"
+  },
+  "signature": {
+    "mode": "production",
+    "status": "valid",
+    "kid": "key1"
+  },
+  "lineage": {
+    "status": "unverified",
+    "message": "single receipt verification cannot prove receipt-tree lineage"
+  },
+  "findings": []
+}

--- a/skills/overlay-open-skill-2/fixtures/digest-stale-refuses.yaml
+++ b/skills/overlay-open-skill-2/fixtures/digest-stale-refuses.yaml
@@ -1,0 +1,18 @@
+name: digest-stale-refuses
+kind: skill
+target: ..
+runner: default
+inputs:
+  objective: Refuse changed wrapped instructions before any styling guidance is applied.
+  resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+expect:
+  status: failure
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: failed
+    reason_code: process_failed
+metadata:
+  public_skill: overlay-open-skill-2
+  source_case: digest-stale-refuses
+  source: skills-fixture

--- a/skills/overlay-open-skill-2/fixtures/pinned-digest-seals.yaml
+++ b/skills/overlay-open-skill-2/fixtures/pinned-digest-seals.yaml
@@ -1,0 +1,18 @@
+name: pinned-digest-seals
+kind: skill
+target: ..
+runner: default
+inputs:
+  objective: Confirm the immutable wrapped styling instructions remain current before applying them.
+  resolved_digest: sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+    reason_code: process_closed
+metadata:
+  public_skill: overlay-open-skill-2
+  source_case: pinned-digest-seals
+  source: skills-fixture

--- a/skills/overlay-open-skill-2/run.mjs
+++ b/skills/overlay-open-skill-2/run.mjs
@@ -1,0 +1,90 @@
+const WRAPS_PATH =
+  "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/brand-guidelines/SKILL.md";
+const PINNED_DIGEST =
+  "sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe";
+const SCOPES = Object.freeze(["fs.read"]);
+const ALLOWED_TOOLS = Object.freeze(["fs.read"]);
+const DENIED_CAPABILITIES = Object.freeze([
+  "filesystem.write",
+  "network.access",
+  "shell.exec",
+  "repo.commit",
+  "repo.push",
+  "publish",
+  "secrets.read",
+]);
+
+const objective = (
+  process.env.RUNX_INPUT_OBJECTIVE ??
+  "Apply the wrapped brand-styling guidance under read-only authority."
+).trim();
+const providedDigest = process.env.RUNX_INPUT_RESOLVED_DIGEST;
+const resolvedDigest = providedDigest ? providedDigest.trim().toLowerCase() : null;
+
+const base = {
+  schema: "runx.skill_overlay.v1",
+  objective,
+  wraps: {
+    path: WRAPS_PATH,
+    digest: PINNED_DIGEST,
+  },
+  resolved_digest: resolvedDigest,
+  runner: {
+    type: "agent",
+    scopes: SCOPES,
+    allowed_tools: ALLOWED_TOOLS,
+    denied_capabilities: DENIED_CAPABILITIES,
+  },
+};
+
+if (resolvedDigest === null) {
+  const output = {
+    ...base,
+    decision: "needs_input",
+    diagnostics: [
+      {
+        id: "runx.overlay.digest.required",
+        severity: "warning",
+        message:
+          "Resolve the immutable wrapped SKILL.md and provide its recomputed sha256 digest before applying the wrapped styling guidance.",
+      },
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+} else if (!/^sha256:[0-9a-f]{64}$/.test(resolvedDigest)) {
+  const output = {
+    ...base,
+    decision: "refused",
+    diagnostics: [
+      {
+        id: "runx.overlay.digest.stale",
+        severity: "error",
+        message:
+          "Resolved digest is invalid or does not match the pinned sha256 digest.",
+      },
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  process.stderr.write("runx.overlay.digest.stale: invalid resolved digest\n");
+  process.exitCode = 78;
+} else if (resolvedDigest !== PINNED_DIGEST) {
+  const output = {
+    ...base,
+    decision: "refused",
+    diagnostics: [
+      {
+        id: "runx.overlay.digest.stale",
+        severity: "error",
+        message:
+          "Wrapped SKILL.md bytes no longer match the pinned sha256 digest; changed instructions were not admitted.",
+      },
+    ],
+  };
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  process.stderr.write("runx.overlay.digest.stale: wrapped content changed\n");
+  process.exitCode = 78;
+} else {
+  process.stdout.write(
+    `${JSON.stringify({ ...base, decision: "ready", diagnostics: [] })}\n`,
+  );
+}


### PR DESCRIPTION
Adds the governed open-skill overlay `overlay-open-skill-2` under `skills/overlay-open-skill-2/`.

It wraps the public `brand-guidelines` SKILL.md (anthropics/skills, Apache-2.0) by reference under a pinned sha256 (sha256:1120b3769e2985cefb3d25be981b1f914abeba57ae079b83c20c666c164fa9fe), a read-only `fs.read` scope, and an explicit `fs.read` allowed-tool set. The upstream is never copied or edited. Two inline harness cases: `pinned-digest-seals` (admits and seals) and `digest-stale-refuses` (raises runx.overlay.digest.stale and refuses). Distinct upstream from overlay-open-skill-1 (verification-before-completion, obra/superpowers).

Published: `codeboost-tr/overlay-open-skill-2@sha-8e908cfce069` (public_url https://runx.ai/x/codeboost-tr/overlay-open-skill-2@sha-8e908cfce069). Post-publish dogfood receipt `runx:receipt:sha256:c15d06f89099dc7a1b56add7744097815cc995465c8443883425cdc64444e586` passes runx verify (valid, production).