### PR TITLE
Add seo-gap-miner skill package

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -281,6 +281,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "ee71759e8099dba9a4925a81b2da69c1d83e73a6fd57b3e21839a6bb637e9ca1",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/seo-gap-miner",
+        version: "sha-6e0f3a805d8f",
+        digest: "b2047fa3f865898d91311e720c4eea6306b2844d0ed84921e7292928ef1028d3",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/settle-invoice",
         version: "sha-dff8399d530f",
         digest: "f016ad099d4777d37e06bd3ca5412293166bee4fa15fba8eba1ffab77f729246",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -378,6 +378,13 @@
     "catalog_role": "canonical"
   },
   {
+    "skill_id": "runx/seo-gap-miner",
+    "version": "sha-6e0f3a805d8f",
+    "digest": "b2047fa3f865898d91311e720c4eea6306b2844d0ed84921e7292928ef1028d3",
+    "catalog_visibility": "public",
+    "catalog_role": "context"
+  },
+  {
     "skill_id": "runx/settle-invoice",
     "version": "sha-dff8399d530f",
     "digest": "f016ad099d4777d37e06bd3ca5412293166bee4fa15fba8eba1ffab77f729246",

--- a/skills/seo-gap-miner/SKILL.md
+++ b/skills/seo-gap-miner/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: seo-gap-miner
+description: Review supplied site inventory and demand fixtures, then produce a read-only SEO gap report that routes viable gaps to draft-content.
+runx:
+  category: growth
+---
+
+# SEO Gap Miner
+
+Turn a bounded site inventory and demand packet into a read-only SEO gap report.
+
+This skill does not fetch SERPs, crawl a site, or invent demand numbers. It
+works only from supplied inventory, supplied demand fixtures, and explicit
+content policy. The output is a read-only judgment packet naming which content
+gaps are real enough to draft next and which topics were dropped by policy.
+
+## What this skill does
+
+1. Read the supplied `site_inventory`, `demand_fixtures`, and `content_policy`.
+2. Drop excluded topics and name the exclusion.
+3. Match each grounded demand term against the page inventory.
+4. Return ranked gap findings only when the fixtures support a priority order.
+5. Name `draft-content` as the downstream dispatch lane for each accepted gap.
+6. Stop at `needs_more_evidence` when demand is too thin to support a credible
+   priority order.
+
+## Core rules
+
+- Read-only. No fetches, crawling, search calls, publishing, or mutation.
+- Use only supplied evidence. If the packet does not name demand clearly enough,
+  stop.
+- Do not inflate opportunity. A weak signal stays weak.
+- Excluded topics stay excluded even if they appear in demand fixtures.
+- Every gap must name the exact demand signal and the missing or weak page.
+- Every actionable gap routes to `draft-content`; this skill does not draft the
+  page itself.
+- It emits no proposal envelope and mints nothing.
+
+## When to use this skill
+
+- An operator already has a trusted inventory of current pages.
+- Demand signals have already been gathered through a governed upstream lane.
+- The goal is to decide what content should be drafted next, not to publish it.
+
+## When not to use this skill
+
+- When the site inventory is stale or missing.
+- When the demand packet is anecdotal, unnamed, or too thin to prioritize.
+- When the operator needs live SEO research; that must happen in a separate
+  read-only collection lane first.
+
+## Quality Profile
+
+- Purpose: decide which SEO gaps are real enough to draft next.
+- Audience: growth operators, content owners, and maintainers reviewing the
+  receipt.
+- Artifact contract: one decision plus zero or more evidence-backed gap
+  findings.
+- Evidence bar: every finding cites a named demand signal and a named missing or
+  weak page.
+- Voice bar: direct operator report, not marketing copy.
+- Strategic bar: prefer the fewest high-confidence gaps over a long speculative
+  backlog.
+- Stop conditions: return `needs_more_evidence` with zero findings when demand
+  is too thin or too ambiguous.
+
+## Output schema (`seo_gap_report`)
+
+```yaml
+decision: ready | needs_more_evidence
+gap_findings:
+  - term: string
+    demand_grounding: string
+    page_verdict:
+      status: missing | weak
+      page: string
+    priority:
+      level: high | medium | low
+      reason: string
+    dispatch_target: draft-content
+policy_exclusions:
+  - term: string
+    reason: string
+blockers: [string]
+needs_input: [string]
+success_checkpoint:
+  milestone: string
+  description: string
+```
+
+## Worked example
+
+If the demand packet names repeated comparison-search demand for `crm migration
+checklist` and the inventory only has a broad services page that mentions
+migrations in one paragraph, this skill returns a `missing` or `weak` page
+finding with a high priority, cites the exact demand signal, and routes the
+follow-up to `draft-content`. If the only demand is one vague note like `SEO
+seems important`, the skill stops with `needs_more_evidence`.
+
+## Inputs
+
+- `site_inventory` (required): current pages with `url`, `topic`, and
+  `coverage`.
+- `demand_fixtures` (required): `terms[]` with `term`, `demand_signal`, and
+  `source`.
+- `content_policy` (required): `excluded_topics` and `priority_themes`.

--- a/skills/seo-gap-miner/X.yaml
+++ b/skills/seo-gap-miner/X.yaml
@@ -1,0 +1,141 @@
+skill: seo-gap-miner
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: context
+harness:
+  cases:
+    - name: seo-gap-miner-prioritizes-real-gaps
+      inputs:
+        site_inventory:
+          site: example.com
+          pages:
+            - url: /pricing
+              topic: pricing
+              coverage: strong
+            - url: /services/crm-implementation
+              topic: crm implementation
+              coverage: weak
+            - url: /blog/warehouse-automation
+              topic: warehouse automation
+              coverage: strong
+        demand_fixtures:
+          terms:
+            - term: crm migration checklist
+              demand_signal: Sales calls repeatedly ask for a migration checklist before kickoff.
+              source: sales-call-notes
+            - term: crm implementation vs migration
+              demand_signal: Demo follow-ups ask for implementation-vs-migration comparisons.
+              source: post-demo-followups
+            - term: casino affiliate tactics
+              demand_signal: Third-party keyword export shows traffic potential.
+              source: imported-keyword-sheet
+        content_policy:
+          excluded_topics:
+            - casino affiliate tactics
+          priority_themes:
+            - crm migration
+            - crm implementation
+      caller:
+        answers:
+          agent_task.seo-gap-miner.output:
+            seo_gap_report:
+              decision: ready
+              gap_findings:
+                - term: crm migration checklist
+                  demand_grounding: Sales calls repeatedly ask for a migration checklist before kickoff.
+                  page_verdict:
+                    status: missing
+                    page: none
+                  priority:
+                    level: high
+                    reason: Repeated buyer demand exists and no page answers the checklist intent.
+                  dispatch_target: draft-content
+                - term: crm implementation vs migration
+                  demand_grounding: Demo follow-ups ask for implementation-vs-migration comparisons.
+                  page_verdict:
+                    status: weak
+                    page: /services/crm-implementation
+                  priority:
+                    level: medium
+                    reason: A related page exists, but it does not satisfy comparison intent.
+                  dispatch_target: draft-content
+              policy_exclusions:
+                - term: casino affiliate tactics
+                  reason: Excluded by content_policy.excluded_topics.
+              blockers: []
+              needs_input: []
+              success_checkpoint:
+                milestone: prioritized_gap_packet_ready
+                description: The report identifies only policy-allowed, evidence-backed gaps and routes them to draft-content.
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: seo-gap-miner-stops-on-thin-demand
+      inputs:
+        site_inventory:
+          site: example.com
+          pages:
+            - url: /blog/automation-trends
+              topic: automation trends
+              coverage: strong
+        demand_fixtures:
+          terms:
+            - term: automation
+              demand_signal: Someone said SEO might matter here.
+              source: vague-note
+        content_policy:
+          excluded_topics: []
+          priority_themes:
+            - automation
+      caller:
+        answers:
+          agent_task.seo-gap-miner.output:
+            seo_gap_report:
+              decision: needs_more_evidence
+              gap_findings: []
+              policy_exclusions: []
+              blockers: []
+              needs_input:
+                - Demand is too thin to prioritize a credible SEO gap. Provide stronger named signals such as repeated buyer questions, search console patterns, or a governed keyword packet.
+              success_checkpoint:
+                milestone: awaiting_stronger_demand
+                description: The report stops instead of inventing opportunity from a vague signal.
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  analyze:
+    default: true
+    type: agent-task
+    agent: researcher
+    task: seo-gap-miner
+    outputs:
+      seo_gap_report: object
+    artifacts:
+      wrap_as: seo_gap_report_packet
+      packet: runx.seo_gap_report.v1
+    inputs:
+      site_inventory:
+        type: json
+        required: true
+        description: "Current site pages with url, topic, and coverage."
+      demand_fixtures:
+        type: json
+        required: true
+        description: "Demand fixtures with terms[] carrying term, demand_signal, and source."
+      content_policy:
+        type: json
+        required: true
+        description: "Content policy with excluded_topics and priority_themes."

--- a/skills/seo-gap-miner/X.yaml
+++ b/skills/seo-gap-miner/X.yaml
@@ -115,6 +115,26 @@ harness:
           state: sealed
           disposition: closed
 
+    - name: seo-gap-miner-needs-agent-without-grounded-answer
+      inputs:
+        site_inventory:
+          site: example.com
+          pages:
+            - url: /services/crm-implementation
+              topic: crm implementation
+              coverage: weak
+        demand_fixtures:
+          terms:
+            - term: crm migration checklist
+              demand_signal: Sales calls repeatedly ask for a migration checklist before kickoff.
+              source: sales-call-notes
+        content_policy:
+          excluded_topics: []
+          priority_themes:
+            - crm migration
+      expect:
+        status: needs_agent
+
 runners:
   analyze:
     default: true


### PR DESCRIPTION
## Summary
- add the seo-gap-miner skill package under skills/seo-gap-miner
- define a read-only skill contract that grounds gap findings in supplied demand fixtures
- include inline harness cases for a ready path and a needs_more_evidence stop path

## Validation
- runx harness ./skills/seo-gap-miner --json
- node scripts/generate-official-lock.mjs
