### PR TITLE
skills: add purchase approval decision skill

### DIFF
--- a/skills/purchase-approval/SKILL.md
+++ b/skills/purchase-approval/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: purchase-approval
+description: Decide whether a proposed purchase is allowed under a procurement policy, refusing budget overages and unapproved vendors instead of guessing.
+runx:
+  category: operations
+---
+
+# Purchase Approval
+
+This skill makes a bounded procurement decision from explicit input. It approves only when the requested vendor, amount, currency, and budget authority are present in the supplied `procurement_policy`.
+
+## What it does
+
+1. Reads `purchase_request.vendor`, `amount`, `currency`, and `purpose`.
+2. Reads `procurement_policy.approved_vendors`, `remaining_budget`, `single_purchase_cap`, and `currency`.
+3. Emits a `purchase_approval` packet with a decision, reason, ceiling amount, policy references, and any human lane required.
+4. Refuses out-of-policy purchases instead of inventing missing vendors, thresholds, or budget authority.
+
+## Approval rules
+
+- Approve only if the vendor is in `approved_vendors`.
+- Approve only if request currency matches the policy currency.
+- Approve only if amount is less than or equal to both `remaining_budget` and `single_purchase_cap`.
+- If the amount reaches or exceeds an approval threshold that requires human review, return `needs_human` with the named lane.
+- If any required policy field is missing, refuse with `missing_policy_authority`.
+
+## Output shape
+
+```yaml
+purchase_approval:
+  decision: approved | refused | needs_human
+  reason: string
+  ceiling_amount: number
+  currency: string
+  vendor: string
+  human_lane: string | null
+  refused_reason: string | null
+  policy_refs: [string]
+```
+
+## Harness cases
+
+- `approved-vendor-under-budget`: sourcey purchase under the available cap is approved.
+- `refused-vendor-over-budget`: unknown vendor and over-budget request is refused and routed to a human review lane.

--- a/skills/purchase-approval/X.yaml
+++ b/skills/purchase-approval/X.yaml
@@ -1,0 +1,110 @@
+skill: purchase-approval
+version: "0.1.0"
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: canonical
+harness:
+  cases:
+    - name: approved-vendor-under-budget
+      inputs:
+        purchase_request:
+          vendor: sourcey
+          amount: 125
+          currency: USD
+          purpose: generate public llms.txt docs for a maintained OSS project
+        procurement_policy:
+          currency: USD
+          remaining_budget: 300
+          single_purchase_cap: 200
+          approved_vendors:
+            - sourcey
+            - runx
+          approval_threshold: 200
+      caller:
+        answers:
+          agent_task.purchase-approval.output:
+            purchase_approval:
+              decision: approved
+              reason: vendor is approved, currency matches policy, and amount is within remaining budget and single-purchase cap
+              ceiling_amount: 125
+              currency: USD
+              vendor: sourcey
+              human_lane: null
+              refused_reason: null
+              policy_refs:
+                - approved_vendors
+                - remaining_budget
+                - single_purchase_cap
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+    - name: refused-vendor-over-budget
+      inputs:
+        purchase_request:
+          vendor: unknown-ai-tool
+          amount: 450
+          currency: USD
+          purpose: buy unreviewed credits
+        procurement_policy:
+          currency: USD
+          remaining_budget: 300
+          single_purchase_cap: 200
+          approved_vendors:
+            - sourcey
+            - runx
+          approval_threshold: 200
+      caller:
+        answers:
+          agent_task.purchase-approval.output:
+            purchase_approval:
+              decision: refused
+              reason: vendor is not approved and amount exceeds both remaining budget and single-purchase cap
+              ceiling_amount: 0
+              currency: USD
+              vendor: unknown-ai-tool
+              human_lane: procurement-review
+              refused_reason: unapproved_vendor_and_budget_overage
+              policy_refs:
+                - approved_vendors
+                - remaining_budget
+                - single_purchase_cap
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+runners:
+  decision:
+    default: true
+    type: agent-task
+    agent: operator
+    task: purchase-approval
+    outputs:
+      purchase_approval: object
+      decision: string
+      reason: string
+      ceiling_amount: number
+      currency: string
+      human_lane: string
+      refused_reason: string
+      policy_refs: array
+    artifacts:
+      wrap_as: purchase_approval_packet
+      packet: runx.ops.purchase_approval.v1
+    runx:
+      category: operations
+    inputs:
+      purchase_request:
+        type: json
+        required: true
+        description: Proposed purchase with vendor, amount, currency, and purpose.
+      procurement_policy:
+        type: json
+        required: true
+        description: Approved vendors, currency, remaining budget, single-purchase cap, and approval thresholds.
+      prior_spend:
+        type: json
+        required: false
+        description: Optional already-committed spend or reserved purchase receipts.


### PR DESCRIPTION
## Purchase approval skill

Adds a bounded `purchase-approval` decision skill for procurement checks.

Why this helps:
- approves only explicit approved-vendor + in-budget purchases;
- refuses unapproved vendors and budget overages rather than guessing;
- includes two inline harness cases: approved vendor under budget and refused vendor over budget.

Verification run:
- `runx skill inspect skills/purchase-approval --json` -> status ok
- `runx harness skills/purchase-approval --json` with demo receipt signer -> status passed, 2 cases, 0 assertion errors
- runx version: runx-cli 0.6.14
