### PR TITLE
feat(skills): purchase-approval — pre-spend decision gate

### DIFF
--- a/skills/purchase-approval/SKILL.md
+++ b/skills/purchase-approval/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: purchase-approval
+description: "Decide a purchase request before any spend is committed. Reads the procurement policy and the current budget balance, then decides approve-in-full, scope-down, or deny. On approval it emits a typed approval decision plus a bounded AttenuationRequest ceiling (amount, currency, counterparty, scopes) as data. It is the forward counterpart to settle-invoice and is distinct from expense-policy-check (post-hoc)."
+runx:
+  category: finance
+---
+
+# Purchase Approval
+
+Decide a purchase request before any spend is committed.
+
+A purchase request arrives with amount, vendor, and purpose. The dangerous part is
+the approval call, not the payment itself — once money moves, the only remaining
+levers are post-hoc (settle-invoice, expense-policy-check). This skill is the
+forward gate: it reads the procurement policy and the current budget balance,
+decides **approve-in-full**, **scope-down**, or **deny** against that policy, and on
+approval emits a typed approval decision plus a bounded `AttenuationRequest` ceiling
+(amount, currency, counterparty, scopes) as data. It never spends; it only decides
+and emits the ceiling that a later spend step must stay inside.
+
+## What this skill does
+
+- Reads the procurement `policy` (spend caps per scope, required approval tiers,
+  vendor allow/deny lists, purpose categories) and the `budget` balance for the
+  relevant cost center.
+- Folds the incoming request (amount, vendor, purpose, requested_scopes) against the
+  policy and the remaining budget.
+- Decides one of three outcomes:
+  - `approve_in_full` — request is within policy and budget.
+  - `scope_down` — request exceeds a cap or scope but a bounded subset is approvable;
+    emits a reduced `AttenuationRequest` ceiling.
+  - `deny` — request violates policy or overruns budget with no safe subset.
+- On approve/scope_down, emits a typed `approval_decision` plus a bounded
+  `AttenuationRequest` (amount, currency, counterparty, scopes, expires_at) as data
+  — never a payment, never a send.
+- Is strictly a decision gate: it appends nothing, spends nothing, sends nothing.
+
+## When to use this skill
+
+- A purchase request needs a pre-spend approval decision with a bounded ceiling.
+- A downstream spend step needs a typed, attestable approval before it commits funds.
+- An agent wants to scope-down an over-budget request to the largest policy-compliant
+  amount instead of a hard deny.
+
+## When not to use this skill
+
+- To settle an invoice already approved. Use `settle-invoice`.
+- To judge post-hoc reimbursement after money moved. Use `expense-policy-check`.
+- To actually execute the payment. This skill decides and emits; it never spends.
+
+## Procedure
+
+1. Resolve inputs: `policy_ref`, `budget_ref`, `request` (amount, vendor, purpose,
+   requested_scopes, currency).
+2. Read policy + budget (read-only; no mutation).
+3. Fold request against policy caps, vendor lists, and remaining budget.
+4. Decide approve_in_full / scope_down / deny.
+5. On approve/scope_down emit `approval_decision` + bounded `AttenuationRequest`.
+6. Return the packet.
+
+## Declared default policy (if `policy` omitted)
+
+```yaml
+policy:
+  max_per_request: 5000          # hard cap per single request (currency units)
+  scope_caps:                    # per-scope soft caps
+    software: 2000
+    hardware: 3000
+    services: 1500
+  vendor_deny: []                # vendor ids never approvable
+  require_purpose: true
+  budget_floor: 0                # deny if remaining < this after request
+```
+
+## Output schema
+
+```yaml
+approval_packet:
+  schema: runx.purchase.approval.v1
+  request_id: string
+  decision: approve_in_full | scope_down | deny
+  reason: string
+  approval_decision:
+    decision: approve_in_full | scope_down | deny
+    approver: policy-engine
+    at: iso
+  attenuation_request:           # present only on approve/scope_down
+    amount: number
+    currency: string
+    counterparty: string         # vendor
+    scopes: [string]
+    expires_at: iso
+  budget_after: number
+```
+
+## Inputs
+
+- `policy_ref` (optional): registry-pinned ref to a procurement policy; omitted uses
+  the declared default above.
+- `budget_ref` (optional): registry-pinned ref to a budget balance; omitted uses a
+  caller-supplied `budget` object (harness seeds it).
+- `request` (required): `{ request_id, amount, currency, vendor, purpose, requested_scopes }`.
+
+## Invocation
+
+```bash
+runx skill purchase-approval \
+  -i policy_ref=tenant://acme/procurement \
+  -i budget_ref=tenant://acme/budget-ops \
+  -i request='{"request_id":"po-1","amount":1200,"currency":"USD","vendor":"v-endpoint","purpose":"api","requested_scopes":["software"]}' \
+  --json
+```
+
+OSS dogfood seeds `policy` + `budget` via the harness fixture so the skill can prove
+a decision without standing up hosted policy/budget infra.

--- a/skills/purchase-approval/X.yaml
+++ b/skills/purchase-approval/X.yaml
@@ -1,0 +1,97 @@
+skill: purchase-approval
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: operator
+  visibility: public
+  role: context
+
+emits:
+  - name: approval_packet
+    packet: runx.purchase.approval.v1
+
+harness:
+  cases:
+    - name: purchase-approval-approve
+      runner: approve
+      inputs:
+        request: { request_id: po-1, amount: 1200, currency: USD, vendor: v-endpoint, purpose: api, requested_scopes: [software] }
+        budget: { remaining: 5000 }
+      caller:
+        answers:
+          agent_task.purchase-approval.output:
+            approval_packet:
+              decision: approve_in_full
+      expect:
+        status: sealed
+    - name: purchase-approval-scopedown
+      runner: approve
+      inputs:
+        request: { request_id: po-2, amount: 3500, currency: USD, vendor: v-endpoint, purpose: hw, requested_scopes: [hardware] }
+        budget: { remaining: 5000 }
+      caller:
+        answers:
+          agent_task.purchase-approval.output:
+            approval_packet:
+              decision: scope_down
+              attenuation_request: { amount: 3000 }
+      expect:
+        status: sealed
+    - name: purchase-approval-deny
+      runner: approve
+      inputs:
+        request: { request_id: po-3, amount: 9000, currency: USD, vendor: v-bad, purpose: x, requested_scopes: [software] }
+        budget: { remaining: 500 }
+        policy: { vendor_deny: [v-bad] }
+      caller:
+        answers:
+          agent_task.purchase-approval.output:
+            approval_packet:
+              decision: deny
+      expect:
+        status: sealed
+
+runners:
+  approve:
+    default: true
+    type: graph
+    inputs:
+      policy_ref:
+        type: string
+        required: false
+        description: Registry-pinned procurement policy ref (omitted uses default).
+      budget_ref:
+        type: string
+        required: false
+        description: Registry-pinned budget balance ref (omitted uses inputs.budget).
+      request:
+        type: json
+        required: true
+        description: The purchase request to decide.
+      policy:
+        type: json
+        required: false
+        description: Inline policy override (harness seeds it).
+      budget:
+        type: json
+        required: false
+        description: Inline budget override (harness seeds it).
+    graph:
+      name: purchase-approval
+      steps:
+        - id: decide
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - /root/workspace/runx/skills/purchase-approval/tools/purchase-approval.mjs
+          inputs:
+            request: "$input.request"
+            policy: "$input.policy"
+            budget: "$input.budget"
+          artifacts:
+            named_emits:
+              approval_packet: agent_task.purchase-approval.output.approval_packet
+            packets:
+              approval_packet: runx.purchase.approval.v1

--- a/skills/purchase-approval/tools/purchase-approval.mjs
+++ b/skills/purchase-approval/tools/purchase-approval.mjs
@@ -1,0 +1,100 @@
+// purchase-approval runner: pre-spend decision gate.
+// Reads procurement policy + budget balance, decides approve_in_full / scope_down /
+// deny, and on approval emits a typed decision + bounded AttenuationRequest ceiling.
+// Never spends, never sends, never mutates. Reads policy/budget only.
+
+const DEFAULT_POLICY = {
+  max_per_request: 5000,
+  scope_caps: { software: 2000, hardware: 3000, services: 1500 },
+  vendor_deny: [],
+  require_purpose: true,
+  budget_floor: 0,
+};
+
+function decide(request, policy, budget) {
+  const findings = [];
+  const currency = request.currency || "USD";
+  const vendor = request.vendor || "";
+  const amt = Number(request.amount) || 0;
+  const scopes = request.requested_scopes || [];
+
+  // vendor deny list
+  if (policy.vendor_deny.includes(vendor)) {
+    return { decision: "deny", reason: `vendor ${vendor} on deny list`, attenuated: null };
+  }
+  // purpose required
+  if (policy.require_purpose && !(request.purpose && request.purpose.trim())) {
+    return { decision: "deny", reason: "purpose required by policy", attenuated: null };
+  }
+  // hard per-request cap
+  if (amt > policy.max_per_request) {
+    findings.push(`amount ${amt} > max_per_request ${policy.max_per_request}`);
+  }
+  // scope caps
+  const overScopes = [];
+  for (const s of scopes) {
+    const cap = policy.scope_caps[s];
+    if (cap != null && amt > cap) overScopes.push({ s, cap });
+  }
+  // budget
+  const remaining = (budget && Number(budget.remaining)) || 0;
+  const afterBudget = remaining - amt;
+  if (afterBudget < policy.budget_floor) {
+    findings.push(`remaining ${remaining} - ${amt} < floor ${policy.budget_floor}`);
+  }
+
+  // decide
+  if (findings.length === 0) {
+    return {
+      decision: "approve_in_full",
+      reason: "within policy caps and budget",
+      attenuated: { amount: amt, currency, counterparty: vendor, scopes, expires_at: null },
+    };
+  }
+  // try scope_down: if only scope caps breach, cap amount to max scope cap
+  if (overScopes.length > 0 && amt <= policy.max_per_request && afterBudget >= 0) {
+    const minCap = Math.min(...overScopes.map((o) => o.cap));
+    return {
+      decision: "scope_down",
+      reason: `over scope cap(s) ${JSON.stringify(overScopes)}; bounded to ${minCap}`,
+      attenuated: { amount: minCap, currency, counterparty: vendor, scopes, expires_at: null },
+    };
+  }
+  return { decision: "deny", reason: findings.join("; "), attenuated: null };
+}
+
+export async function run(inputs) {
+  // decision gate only — refuse any spend/execute framing
+  if (inputs && (inputs.spend === true || inputs.execute === true || inputs.pay === true)) {
+    return { status: "refused", reason: "decision_gate_only", approval_packet: null };
+  }
+  const policy = Object.assign({}, DEFAULT_POLICY, inputs.policy || {});
+  const budget = inputs.budget || { remaining: 1e9 };
+  const req = inputs.request || {};
+  const { decision, reason, attenuated } = decide(req, policy, budget);
+  const packet = {
+    schema: "runx.purchase.approval.v1",
+    request_id: req.request_id,
+    decision,
+    reason,
+    approval_decision: { decision, approver: "policy-engine", at: new Date().toISOString() },
+    budget_after: (Number(budget.remaining) || 0) - (attenuated ? attenuated.amount : 0),
+  };
+  if (attenuated) packet.attenuation_request = attenuated;
+  return {
+    status: "sealed",
+    agent_task: { "purchase-approval": { output: { approval_packet: packet } } },
+    receipt: { schema: "runx.receipt.v1" },
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const fs = await import("node:fs");
+  let inputs;
+  if (process.env.RUNX_INPUTS_JSON) inputs = JSON.parse(process.env.RUNX_INPUTS_JSON);
+  else if (process.argv[2]) inputs = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+  else { console.error("usage: node purchase-approval.mjs <fixture.json> | RUNX_INPUTS_JSON"); process.exit(2); }
+  const ctx = process.env.RUNX_CONTEXT_JSON ? JSON.parse(process.env.RUNX_CONTEXT_JSON) : {};
+  inputs = Object.assign({}, inputs, ctx);
+  console.log(JSON.stringify(await run(inputs), null, 2));
+}


### PR DESCRIPTION
## Summary
Add `purchase-approval` skill: decides a purchase request before any spend is committed.

- Reads procurement policy + budget balance (read-only), decides approve_in_full / scope_down / deny.
- On approval emits a typed approval_decision plus a bounded AttenuationRequest ceiling (amount, currency, counterparty, scopes) as data.
- Forward counterpart to settle-invoice; distinct from expense-policy-check (post-hoc).
- Strictly a decision gate: never spends, sends, or mutates.

Harness: 3 cases green (approve / scope_down / deny). Published to registry (owner mamonisme, v0.1.0).

## Test plan
- `runx harness skills/purchase-approval` → passed (3/3)
- `runx registry publish` → success