### PR TITLE
feat(skills): add purchase approval gate

### DIFF
--- a/skills/purchase-approval/SKILL.md
+++ b/skills/purchase-approval/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: purchase-approval
+description: Evaluate one bounded purchase request against explicit policy and emit a downstream ceiling only after policy and human approval pass.
+runx:
+  category: payments
+---
+
+# Purchase Approval
+
+`purchase-approval` evaluates one proposed purchase without paying for it. It
+checks a vendor allowlist, typed purchase limits, approval threshold, current
+budget, currency, and a proposed downstream `AttenuationRequest`. The graph
+then stops at the resumable `purchase-approval-review` human review task.
+
+Only a request that passes deterministic policy and has a positive human
+decision emits one bounded downstream `AttenuationRequest` as data. The output
+is a proposal for a downstream payment runner to validate independently; it is
+not a grant, payment, reservation, or settlement instruction.
+
+The skill never mints authority, reserves funds, moves money, calls a payment
+rail, or emits an operational proposal. A downstream payment runner must
+independently validate authority, reservation, and settlement before any funds
+can move.
+
+## Decision Flow
+
+1. **Evaluate policy.** The deterministic evaluator rejects missing data,
+   currency mismatches, unapproved vendors, over-limit or over-budget requests,
+   and malformed authority requests. It records the exact reason.
+2. **Ask for approval.** The graph gives the policy review to the resumable
+   `purchase-approval-review` task. With no decision, the run returns
+   `needs_agent`; no ceiling is emitted.
+3. **Emit or refuse.** Two graph guards require both `policy_review.allowed`
+   and `approval_decision.approved`. The finalizer then emits exactly one
+   bounded `AttenuationRequest`. A human cannot override a failed policy review.
+
+## Inputs
+
+- `purchase_request`: `{amount, currency, vendor, purpose}`. `amount` is a
+  positive number in the stated policy unit.
+- `procurement_policy`: `{approved_vendors, max_single_purchase,
+  requires_approval_above}`. Both limits are typed money objects:
+  `{amount, currency}`.
+- `current_budget_balance`: `{amount, currency}` for available budget.
+- `requested_budget_bounded_scope`: `{ceiling, counterparty, scopes,
+  allow_scope_down, attenuation_request}`. `ceiling` is `{amount, currency}`
+  and `attenuation_request` is the exact bounded downstream request.
+
+`allow_scope_down` is explicit consent. When true, a request over a monetary
+limit may emit the strictly lower minimum of the single-purchase limit and
+current budget, but only after both gates pass. Without it, the request is
+denied or escalated; the skill never silently reduces a requested purchase.
+
+## Output
+
+The evaluator emits a `policy_review_packet`:
+
+```yaml
+kind: purchase_approval_policy_review
+allowed: boolean
+decision_mode: approve_in_full | scope_down | deny
+approval_reason: string
+violations: [string]
+ceiling:
+  amount: number
+  currency: string
+```
+
+The final step emits a `purchase_approval_packet`:
+
+```yaml
+kind: purchase_approval_result
+decision:
+  approved: boolean
+  mode: approve_in_full | scope_down | deny
+  reason: string
+attenuation_request: object | null
+ceiling:
+  amount: number
+  currency: string
+  counterparty: string
+  scopes: [string]
+escalation: object | null
+```
+
+`ceiling` and `attenuation_request` are present only after both the deterministic
+policy review and human review pass. They are bounded data for a downstream
+runner, not a payment authorization.
+
+## Stop Conditions
+
+- Vendor absent from `approved_vendors`.
+- Request exceeds the typed purchase cap or available budget without explicit
+  scope-down consent.
+- Currency mismatch across request, policy, budget, or proposed scope.
+- Missing amount, purpose, scopes, or a complete `AttenuationRequest`.
+- Scope counterparty, ceiling, or effect limits differ from the approved result.
+- Human review withheld or unavailable.
+
+Every stop condition returns no ceiling. A pending human review returns
+`needs_agent`; a declined or failed policy review is sealed without authority
+output.

--- a/skills/purchase-approval/X.yaml
+++ b/skills/purchase-approval/X.yaml
@@ -1,0 +1,233 @@
+skill: purchase-approval
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: purchase-approval-in-policy-sealed
+      runner: purchase-approval
+      inputs:
+        purchase_request:
+          amount: 84
+          currency: USD
+          vendor: merchant:acme-cloud
+          purpose: Renew the production observability subscription for one month.
+        procurement_policy:
+          approved_vendors:
+            - merchant:acme-cloud
+          max_single_purchase:
+            amount: 100
+            currency: USD
+          requires_approval_above:
+            amount: 250
+            currency: USD
+        current_budget_balance:
+          amount: 500
+          currency: USD
+        requested_budget_bounded_scope:
+          ceiling:
+            amount: 84
+            currency: USD
+          counterparty: merchant:acme-cloud
+          scopes:
+            - payment:prepare
+            - payment:commit
+          allow_scope_down: false
+          attenuation_request:
+            principal_ref:
+              type: principal
+              uri: runx:principal:purchase-requester
+            resource_ref:
+              type: surface
+              uri: merchant:acme-cloud
+            resource_family: effect
+            verbs:
+              - prepare
+              - commit
+            capabilities:
+              - effect_single_use_capability
+            bounds:
+              effect_limits:
+                - family: payment
+                  unit: USD
+                  max_per_call_units: 84
+                  max_per_run_units: 84
+                  channels:
+                    - approved-rail
+                  peer: merchant:acme-cloud
+                  operation: procurement.purchase
+                  approval_threshold_units: 250
+                  authorization_form: single_use_capability
+                  preflight_required: true
+                  commitment_required: true
+                  idempotency_required: true
+                  recovery_required: true
+                  receipt_before_success: true
+                  single_use_capability: true
+            expires_at: 2026-12-31T00:00:00Z
+      caller:
+        answers:
+          agent_task.purchase-approval-review.output:
+            approval_decision:
+              approved: true
+              reason: The reviewer approves this one bounded Acme Cloud renewal.
+            closure:
+              disposition: closed
+              reason_code: human_review_approved
+              summary: The human reviewer approved the bounded purchase ceiling.
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+        steps:
+          - evaluate-policy
+          - human-review
+          - emit-ceiling
+
+    - name: purchase-approval-out-of-policy-needs-agent
+      runner: purchase-approval
+      inputs:
+        purchase_request:
+          amount: 180
+          currency: USD
+          vendor: merchant:unapproved-vendor
+          purpose: Attempt an unapproved premium support purchase.
+        procurement_policy:
+          approved_vendors:
+            - merchant:acme-cloud
+          max_single_purchase:
+            amount: 100
+            currency: USD
+          requires_approval_above:
+            amount: 150
+            currency: USD
+        current_budget_balance:
+          amount: 120
+          currency: USD
+        requested_budget_bounded_scope:
+          ceiling:
+            amount: 180
+            currency: USD
+          counterparty: merchant:unapproved-vendor
+          scopes:
+            - payment:commit
+          allow_scope_down: false
+          attenuation_request:
+            principal_ref:
+              type: principal
+              uri: runx:principal:purchase-requester
+            resource_ref:
+              type: surface
+              uri: merchant:unapproved-vendor
+            resource_family: effect
+            verbs:
+              - commit
+            capabilities:
+              - effect_single_use_capability
+            bounds:
+              effect_limits:
+                - family: payment
+                  unit: USD
+                  max_per_call_units: 180
+                  max_per_run_units: 180
+                  channels:
+                    - approved-rail
+                  peer: merchant:unapproved-vendor
+                  operation: procurement.purchase
+                  approval_threshold_units: 150
+                  authorization_form: single_use_capability
+                  preflight_required: true
+                  commitment_required: true
+                  idempotency_required: true
+                  recovery_required: true
+                  receipt_before_success: true
+                  single_use_capability: true
+            expires_at: 2026-12-31T00:00:00Z
+      # No caller answer: the resumable human-review task must pause.
+      expect:
+        status: needs_agent
+
+runners:
+  purchase-approval:
+    default: true
+    type: graph
+    inputs:
+      purchase_request:
+        type: json
+        required: true
+        description: Purchase request with amount, currency, vendor, and purpose.
+      procurement_policy:
+        type: json
+        required: true
+        description: Approved vendors plus typed purchase and approval limits.
+      current_budget_balance:
+        type: json
+        required: true
+        description: Current available budget as a typed amount and currency.
+      requested_budget_bounded_scope:
+        type: json
+        required: true
+        description: Proposed bounded downstream authority and explicit scope-down consent.
+    graph:
+      name: purchase-approval
+      steps:
+        - id: evaluate-policy
+          label: verify policy and budget bounds
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - run.mjs
+              - evaluate
+          artifacts:
+            named_emits:
+              policy_review_packet: policy_review
+        - id: human-review
+          label: human purchase approval
+          run:
+            type: agent-task
+            agent: human-reviewer
+            task: purchase-approval-review
+            outputs:
+              approval_decision: object
+          instructions: >
+            Review the deterministic policy_review and decide whether this one
+            bounded purchase ceiling may be handed to a downstream payment runner.
+            Emit approval_decision with approved=true or false and a concrete
+            reason. Do not mint authority, reserve funds, perform a payment, or
+            broaden the proposed attenuation request. If the review is not
+            complete, leave the task unresolved so the graph returns needs_agent.
+          context:
+            policy_review: evaluate-policy.policy_review_packet.data
+          artifacts:
+            named_emits:
+              approval_decision: approval_decision
+            packets:
+              approval_decision: runx.approval.decision.v1
+        - id: emit-ceiling
+          label: emit bounded authority request as data
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - run.mjs
+              - finalize
+          context:
+            policy_review: evaluate-policy.policy_review_packet.data
+            approval_decision: human-review.approval_decision.data
+          artifacts:
+            named_emits:
+              purchase_approval_packet: purchase_approval
+      policy:
+        guards:
+          - step: emit-ceiling
+            field: evaluate-policy.policy_review_packet.data.allowed
+            equals: true
+          - step: emit-ceiling
+            field: human-review.approval_decision.data.approved
+            equals: true

--- a/skills/purchase-approval/fixtures/harness-evidence.json
+++ b/skills/purchase-approval/fixtures/harness-evidence.json
@@ -1,0 +1,33 @@
+{
+  "schema": "purchase_approval_harness_evidence.v1",
+  "generated_at": "2026-07-12T19:21:19Z",
+  "runx_cli": "runx-cli 0.7.0",
+  "checks": [
+    {
+      "name": "inline_harness",
+      "command": "npx -y @runxhq/cli@0.7.0 harness ./skills/purchase-approval --json",
+      "status": "passed",
+      "case_count": 2,
+      "case_names": [
+        "purchase-approval-in-policy-sealed",
+        "purchase-approval-out-of-policy-needs-agent"
+      ],
+      "assertion_error_count": 0,
+      "receipt_id": "sha256:2d874021ddb948ba5264255762c5dfeefff5832236256d768dc981d438815f1c"
+    },
+    {
+      "name": "profile_doctor",
+      "command": "npx -y @runxhq/cli@0.7.0 doctor ./skills/purchase-approval --json",
+      "status": "success",
+      "errors": 0,
+      "warnings": 0
+    },
+    {
+      "name": "scope_down_consent",
+      "command": "node skills/purchase-approval/run.mjs evaluate",
+      "status": "passed",
+      "assertion": "A 180 USD request with allow_scope_down=true emitted a 100 USD scope_down ceiling; the deterministic evaluator did not silently reduce the request."
+    }
+  ],
+  "boundary": "The harness exercises only policy and review data. It does not mint authority, reserve funds, move money, or call a payment rail."
+}

--- a/skills/purchase-approval/fixtures/in-policy-purchase.yaml
+++ b/skills/purchase-approval/fixtures/in-policy-purchase.yaml
@@ -1,0 +1,84 @@
+name: purchase-approval-in-policy-sealed
+kind: skill
+target: ..
+runner: purchase-approval
+inputs:
+  purchase_request:
+    amount: 84
+    currency: USD
+    vendor: merchant:acme-cloud
+    purpose: Renew the production observability subscription for one month.
+  procurement_policy:
+    approved_vendors:
+      - merchant:acme-cloud
+    max_single_purchase:
+      amount: 100
+      currency: USD
+    requires_approval_above:
+      amount: 250
+      currency: USD
+  current_budget_balance:
+    amount: 500
+    currency: USD
+  requested_budget_bounded_scope:
+    ceiling:
+      amount: 84
+      currency: USD
+    counterparty: merchant:acme-cloud
+    scopes:
+      - payment:prepare
+      - payment:commit
+    allow_scope_down: false
+    attenuation_request:
+      principal_ref:
+        type: principal
+        uri: runx:principal:purchase-requester
+      resource_ref:
+        type: surface
+        uri: merchant:acme-cloud
+      resource_family: effect
+      verbs:
+        - prepare
+        - commit
+      capabilities:
+        - effect_single_use_capability
+      bounds:
+        effect_limits:
+          - family: payment
+            unit: USD
+            max_per_call_units: 84
+            max_per_run_units: 84
+            channels:
+              - approved-rail
+            peer: merchant:acme-cloud
+            operation: procurement.purchase
+            approval_threshold_units: 250
+            authorization_form: single_use_capability
+            preflight_required: true
+            commitment_required: true
+            idempotency_required: true
+            recovery_required: true
+            receipt_before_success: true
+            single_use_capability: true
+      expires_at: 2026-12-31T00:00:00Z
+caller:
+  answers:
+    agent_task.purchase-approval-review.output:
+      approval_decision:
+        approved: true
+        reason: The reviewer approves this one bounded Acme Cloud renewal.
+      closure:
+        disposition: closed
+        reason_code: human_review_approved
+        summary: The human reviewer approved the bounded purchase ceiling.
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+  steps:
+    - evaluate-policy
+    - human-review
+    - emit-ceiling
+metadata:
+  public_skill: purchase-approval
+  source_case: in-policy-purchase

--- a/skills/purchase-approval/fixtures/over-limit-needs-agent.yaml
+++ b/skills/purchase-approval/fixtures/over-limit-needs-agent.yaml
@@ -1,0 +1,67 @@
+name: purchase-approval-out-of-policy-needs-agent
+kind: skill
+target: ..
+runner: purchase-approval
+inputs:
+  purchase_request:
+    amount: 180
+    currency: USD
+    vendor: merchant:unapproved-vendor
+    purpose: Attempt an unapproved premium support purchase.
+  procurement_policy:
+    approved_vendors:
+      - merchant:acme-cloud
+    max_single_purchase:
+      amount: 100
+      currency: USD
+    requires_approval_above:
+      amount: 150
+      currency: USD
+  current_budget_balance:
+    amount: 120
+    currency: USD
+  requested_budget_bounded_scope:
+    ceiling:
+      amount: 180
+      currency: USD
+    counterparty: merchant:unapproved-vendor
+    scopes:
+      - payment:commit
+    allow_scope_down: false
+    attenuation_request:
+      principal_ref:
+        type: principal
+        uri: runx:principal:purchase-requester
+      resource_ref:
+        type: surface
+        uri: merchant:unapproved-vendor
+      resource_family: effect
+      verbs:
+        - commit
+      capabilities:
+        - effect_single_use_capability
+      bounds:
+        effect_limits:
+          - family: payment
+            unit: USD
+            max_per_call_units: 180
+            max_per_run_units: 180
+            channels:
+              - approved-rail
+            peer: merchant:unapproved-vendor
+            operation: procurement.purchase
+            approval_threshold_units: 150
+            authorization_form: single_use_capability
+            preflight_required: true
+            commitment_required: true
+            idempotency_required: true
+            recovery_required: true
+            receipt_before_success: true
+            single_use_capability: true
+      expires_at: 2026-12-31T00:00:00Z
+# No caller answers or approvals: the native approval gate must pause.
+expect:
+  status: needs_agent
+metadata:
+  public_skill: purchase-approval
+  source_case: out-of-policy-human-approval

--- a/skills/purchase-approval/run.mjs
+++ b/skills/purchase-approval/run.mjs
@@ -1,0 +1,237 @@
+import fs from "node:fs";
+
+const mode = process.argv[2];
+const inputs = readInputs();
+
+if (mode === "evaluate") {
+  process.stdout.write(JSON.stringify({ policy_review_packet: evaluate(inputs) }));
+} else if (mode === "finalize") {
+  process.stdout.write(JSON.stringify({ purchase_approval_packet: finalize(inputs) }));
+} else {
+  process.stderr.write("usage: node run.mjs <evaluate|finalize>\\n");
+  process.exit(64);
+}
+
+function evaluate(inputs) {
+  const request = objectValue(inputs.purchase_request);
+  const policy = objectValue(inputs.procurement_policy);
+  const budget = moneyValue(inputs.current_budget_balance);
+  const scope = objectValue(inputs.requested_budget_bounded_scope);
+  const requested = moneyValue({ amount: request.amount, currency: request.currency });
+  const maxSingle = moneyValue(policy.max_single_purchase);
+  const approvalThreshold = moneyValue(policy.requires_approval_above);
+  const requestedCeiling = moneyValue(scope.ceiling);
+  const vendor = text(request.vendor);
+  const purpose = text(request.purpose);
+  const counterparty = text(scope.counterparty);
+  const scopes = strings(scope.scopes);
+  const allowScopeDown = scope.allow_scope_down === true;
+  const approvedVendors = strings(policy.approved_vendors);
+  const violations = [];
+
+  if (!requested || !vendor || !purpose) {
+    violations.push("purchase_request must include a positive amount, currency, vendor, and purpose");
+  }
+  if (!maxSingle || !approvalThreshold || !budget) {
+    violations.push("procurement_policy limits and current_budget_balance must be typed money objects");
+  }
+  if (requested && maxSingle && requested.currency !== maxSingle.currency) {
+    violations.push(`currency mismatch: request is ${requested.currency} while max_single_purchase is ${maxSingle.currency}`);
+  }
+  if (requested && approvalThreshold && requested.currency !== approvalThreshold.currency) {
+    violations.push(`currency mismatch: request is ${requested.currency} while requires_approval_above is ${approvalThreshold.currency}`);
+  }
+  if (requested && budget && requested.currency !== budget.currency) {
+    violations.push(`currency mismatch: request is ${requested.currency} while budget is ${budget.currency}`);
+  }
+  if (vendor && !approvedVendors.includes(vendor)) {
+    violations.push(`vendor ${vendor} is absent from procurement_policy.approved_vendors`);
+  }
+
+  const permittedAmount = requested && maxSingle && budget
+    && requested.currency === maxSingle.currency
+    && requested.currency === budget.currency
+    ? Math.min(maxSingle.amount, budget.amount)
+    : null;
+  const needsScopeDown = requested && permittedAmount !== null && requested.amount > permittedAmount;
+  const scopeDownAllowed = needsScopeDown && allowScopeDown;
+
+  if (needsScopeDown && !allowScopeDown) {
+    violations.push(`requested ${requested.amount} ${requested.currency} exceeds the permitted ${permittedAmount} ${requested.currency}; allow_scope_down must be true to propose a lower ceiling`);
+  }
+  if (requested && requestedCeiling && requested.currency !== requestedCeiling.currency) {
+    violations.push(`currency mismatch: requested ceiling is ${requestedCeiling.currency} while request is ${requested.currency}`);
+  }
+  const expectedAmount = scopeDownAllowed ? permittedAmount : requested?.amount ?? null;
+  if (!requestedCeiling || expectedAmount === null || requestedCeiling.amount !== expectedAmount || requestedCeiling.currency !== requested?.currency || counterparty !== vendor || scopes.length === 0) {
+    violations.push("requested_budget_bounded_scope must match the approved ceiling, request currency, vendor, and include scopes");
+  }
+  if (!isCompleteAttenuationRequest(scope.attenuation_request, requestedCeiling, vendor, approvalThreshold, scopes)) {
+    violations.push("requested_budget_bounded_scope.attenuation_request is incomplete or exceeds the proposed ceiling");
+  }
+
+  const allowed = violations.length === 0;
+  const decisionMode = allowed ? (scopeDownAllowed ? "scope_down" : "approve_in_full") : "deny";
+  const thresholdReached = requested && approvalThreshold && requested.amount > approvalThreshold.amount;
+  const approvalReason = allowed
+    ? `${decisionMode === "scope_down" ? "Scope down" : "Approve"} ${requestedCeiling.amount} ${requestedCeiling.currency} for ${vendor}. ${thresholdReached ? "The request exceeds the configured approval threshold." : "The graph requires human review before emitting the ceiling."}`
+    : violations.join("; ");
+
+  return {
+    kind: "purchase_approval_policy_review",
+    allowed,
+    decision_mode: decisionMode,
+    approval_required: true,
+    approval_reason: approvalReason,
+    violations,
+    requested_amount: requested?.amount ?? null,
+    requested_currency: requested?.currency ?? null,
+    permitted_amount: allowed ? requestedCeiling.amount : null,
+    ceiling: allowed ? requestedCeiling : null,
+    vendor,
+    approval_threshold: approvalThreshold,
+    budget_balance: budget,
+    scope_down_consent: allowScopeDown,
+  };
+}
+
+function finalize(inputs) {
+  const review = objectValue(inputs.policy_review);
+  const approval = objectValue(inputs.approval_decision);
+  const scope = objectValue(inputs.requested_budget_bounded_scope);
+  const ceiling = moneyValue(review.ceiling);
+  const vendor = text(review.vendor);
+  const scopes = strings(scope.scopes);
+  const approved = review.allowed === true
+    && approval.approved === true
+    && (review.decision_mode === "approve_in_full" || review.decision_mode === "scope_down")
+    && Boolean(ceiling)
+    && text(scope.counterparty) === vendor
+    && isCompleteAttenuationRequest(
+      scope.attenuation_request,
+      ceiling,
+      vendor,
+      moneyValue(review.approval_threshold),
+      scopes,
+    );
+
+  if (!approved) {
+    const reason = review.allowed === true
+      ? "Human approval was not granted, so no downstream ceiling can be emitted."
+      : text(review.approval_reason) || "The deterministic purchase policy review failed.";
+    return {
+      kind: "purchase_approval_result",
+      decision: { approved: false, mode: "deny", reason },
+      attenuation_request: null,
+      ceiling: null,
+      escalation: {
+        lane: "purchase_approval.review",
+        reason,
+        policy_violations: Array.isArray(review.violations) ? review.violations : [],
+      },
+    };
+  }
+
+  return {
+    kind: "purchase_approval_result",
+    decision: {
+      approved: true,
+      mode: review.decision_mode,
+      reason: "The request passed deterministic purchase policy and the named human review task.",
+    },
+    attenuation_request: scope.attenuation_request,
+    ceiling: {
+      amount: ceiling.amount,
+      currency: ceiling.currency,
+      counterparty: vendor,
+      scopes,
+    },
+    escalation: null,
+  };
+}
+
+function isCompleteAttenuationRequest(value, ceiling, vendor, approvalThreshold, scopes) {
+  if (!value || typeof value !== "object" || !ceiling || !vendor) return false;
+  const keys = Object.keys(value).sort();
+  const expectedKeys = ["bounds", "capabilities", "expires_at", "principal_ref", "resource_family", "resource_ref", "verbs"];
+  if (keys.length !== expectedKeys.length || keys.some((key, index) => key !== expectedKeys[index])) return false;
+  const bounds = objectValue(value.bounds);
+  if (Object.keys(bounds).length !== 1 || !Object.hasOwn(bounds, "effect_limits")) return false;
+  const limits = bounds.effect_limits;
+  if (!Array.isArray(limits) || limits.length !== 1) return false;
+  const limit = objectValue(limits[0]);
+  const requestedVerbs = scopeVerbs(scopes);
+  return referenceIs(value.principal_ref, "principal")
+    && referenceIs(value.resource_ref, "surface", vendor)
+    && value.resource_family === "effect"
+    && requestedVerbs.length > 0
+    && sameStrings(strings(value.verbs), requestedVerbs)
+    && strings(value.capabilities).includes("effect_single_use_capability")
+    && text(value.expires_at) !== null
+    && limit.family === "payment"
+    && limit.unit === ceiling.currency
+    && limit.max_per_call_units === ceiling.amount
+    && limit.max_per_run_units === ceiling.amount
+    && strings(limit.channels).length > 0
+    && text(limit.peer) === vendor
+    && text(limit.operation) === "procurement.purchase"
+    && approvalThreshold !== null
+    && limit.approval_threshold_units === approvalThreshold.amount
+    && limit.authorization_form === "single_use_capability"
+    && limit.preflight_required === true
+    && limit.commitment_required === true
+    && limit.idempotency_required === true
+    && limit.recovery_required === true
+    && limit.receipt_before_success === true
+    && limit.single_use_capability === true;
+}
+
+function referenceIs(value, type, uri) {
+  const reference = objectValue(value);
+  return reference.type === type && text(reference.uri) !== null && (!uri || reference.uri === uri);
+}
+
+function scopeVerbs(scopes) {
+  const verbs = strings(scopes).map((scope) => {
+    const match = /^payment:(prepare|commit)$/.exec(scope);
+    return match?.[1] ?? null;
+  });
+  return verbs.some((verb) => verb === null) ? [] : verbs;
+}
+
+function sameStrings(left, right) {
+  return left.length === right.length
+    && new Set(left).size === left.length
+    && left.every((value) => right.includes(value));
+}
+
+function moneyValue(value) {
+  const money = objectValue(value);
+  const amount = positiveNumber(money.amount);
+  const currency = text(money.currency);
+  return amount === null || !currency ? null : { amount, currency };
+}
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function strings(value) {
+  return Array.isArray(value) ? value.map(text).filter(Boolean) : [];
+}
+
+function text(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function positiveNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}


### PR DESCRIPTION
## Summary
- adds a deterministic purchase-policy evaluator, resumable human review, and bounded ceiling handoff
- includes approved and needs-agent inline harness cases plus standalone fixtures
- keeps the package data-only: no authority minting, reservation, payment, or settlement

## Verification
- `npx -y @runxhq/cli@0.7.0 harness ./skills/purchase-approval --json`
- `npx -y @runxhq/cli@0.7.0 doctor ./skills/purchase-approval --json`
- local pause/resume dogfood and receipt verification