### PR TITLE
feat: add CSAT detractor recovery skill

### DIFF
--- a/skills/csat-recovery/SKILL.md
+++ b/skills/csat-recovery/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: csat-recovery
 description: Decide a bounded recovery play for a CSAT detractor without sending a message or moving money.
+links:
+  source: https://github.com/runxhq/runx/pull/308
 runx:
   category: support
 ---

--- a/skills/csat-recovery/SKILL.md
+++ b/skills/csat-recovery/SKILL.md
@@ -19,8 +19,10 @@ Inputs are `detractor_signal{score,reason,timestamp}`,
 `customer_context{id,ltv,timezone}`,
 `recovery_policy{monthly_credit_limit,plays,message_templates}`,
 `recovery_request{amount_minor,currency,counterparty,scopes}`, optional
-`prior_recovery_ref`, and `charge_receipt{original_receipt_ref,amount_minor,
-remaining_refundable_minor}` whenever credit is considered.
+`prior_recovery_ref`, `recovery_month`, `data_source_ref`, `store_id`, a stable
+`idempotency_key`, and `charge_receipt{original_receipt_ref,amount_minor,
+remaining_refundable_minor}` whenever credit is considered. The audit-only
+`prior_recovery_ref` never supplies the numeric monthly total.
 
 Output is `recovery_decision{chosen_play,reason,credit_ceiling,send_plan,
 escalation}` plus `remaining_monthly_credit`. `credit_ceiling` is present only
@@ -47,11 +49,20 @@ from the selected policy template and bounded customer context.
 
 ## Durable state seam
 
-A production binding composes `registry:runx/data-store@0.1.2` with a pinned
-`store_id`. Before judgment it calls `read_projection` keyed by customer id to
-obtain prior recoveries and the monthly total. After a confirmed decision, an
-ungated `append_event(idempotency_key, expected_version)` records the decision.
-The data-store binding is domain state; the audit ledger is referenced only by
+The graph composes the `registry:runx/data-store@0.1.2` operation contract and
+ships the `data.local` development adapter used by its public harness. Before
+judgment, `read-recovery-state` performs `read_projection` against
+`recovery_events`, keyed by `customer_context.id` and filtered by
+`recovery_month`. The projection exposes its stream `version` and the folded
+`monthly_recovery_total_minor`; the reviewer must deduct that stored total from
+the policy limit and must not infer a number from `prior_recovery_ref`.
+
+After the decision and explicit human confirmation, `append-recovery-event`
+performs an ungated CAS `append_event`: `expected_version` comes directly from
+the earlier projection, the caller supplies a stable `idempotency_key`, and the
+recorded event comes from the grounded decision packet. A final readback proves
+the aggregate version and folded monthly total. A conflict stops rather than
+overwriting a concurrent recovery. The audit ledger is referenced only by
 receipt id-stub and is never used as a customer-keyed state read.
 
 ## Downstream handoff

--- a/skills/csat-recovery/SKILL.md
+++ b/skills/csat-recovery/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: csat-recovery
+description: Decide a bounded recovery play for a CSAT detractor without sending a message or moving money.
+runx:
+  category: support
+---
+
+# CSAT Detractor Recovery
+
+Use this graph when a detractor signal requires a bounded apology, linked service
+credit, or human escalation. It is a judgment skill: it performs no refund, no
+send, no mint, no reservation, and no settlement.
+
+## Contract
+
+Inputs are `detractor_signal{score,reason,timestamp}`,
+`customer_context{id,ltv,timezone}`,
+`recovery_policy{monthly_credit_limit,plays,message_templates}`,
+`recovery_request{amount_minor,currency,counterparty,scopes}`, optional
+`prior_recovery_ref`, and `charge_receipt{original_receipt_ref,amount_minor,
+remaining_refundable_minor}` whenever credit is considered.
+
+Output is `recovery_decision{chosen_play,reason,credit_ceiling,send_plan,
+escalation}` plus `remaining_monthly_credit`. `credit_ceiling` is present only
+for `chosen_play: credit` and is a bounded `AttenuationRequest` carried as data:
+`{amount_minor,currency,counterparty,original_receipt_ref,scopes}`. It is never a
+mint and never `runx.operational_proposal.v1`.
+
+`send_plan{principal,audience,content_template_id,content_digest}` names a future
+governed send. It does not dispatch a message. The content digest must be derived
+from the selected policy template and bounded customer context.
+
+## Decision rules
+
+1. Refuse credit without an exact sealed `original_receipt_ref`.
+2. Cap credit at the lesser of the request, the charge's
+   `remaining_refundable_minor`, and the remaining monthly policy balance after
+   prior recoveries.
+3. Require matching currency, customer counterparty, and recovery scope.
+4. Never invent a charge link, counterparty, message template, or policy limit.
+5. Route missing customer identity, unclear prior recovery state, over-ceiling
+   requests, and currency mismatches to the blocking human lane with no ceiling.
+6. Record the chosen play, reason, remaining monthly credit, content digest, and
+   any bounded ceiling in the sealed decision receipt.
+
+## Durable state seam
+
+A production binding composes `registry:runx/data-store@0.1.2` with a pinned
+`store_id`. Before judgment it calls `read_projection` keyed by customer id to
+obtain prior recoveries and the monthly total. After a confirmed decision, an
+ungated `append_event(idempotency_key, expected_version)` records the decision.
+The data-store binding is domain state; the audit ledger is referenced only by
+receipt id-stub and is never used as a customer-keyed state read.
+
+## Downstream handoff
+
+For a credit play, a downstream driver hands the ceiling to the core
+spend/refund accepting runner (C3). C3 may attenuate it further, then mints,
+reserves, settles, and seals the credit against `original_receipt_ref`; it cannot
+widen the ceiling. For an apology, a driver or operator starts a separate
+governed send-as run by naming `send_plan`. If this graph denies, escalates, or
+remains unconfirmed, there is no ceiling or send authority to consume.

--- a/skills/csat-recovery/X.yaml
+++ b/skills/csat-recovery/X.yaml
@@ -1,5 +1,5 @@
 skill: csat-recovery
-version: "0.1.1"
+version: "0.1.2"
 
 catalog:
   kind: graph

--- a/skills/csat-recovery/X.yaml
+++ b/skills/csat-recovery/X.yaml
@@ -1,5 +1,5 @@
 skill: csat-recovery
-version: "0.1.0"
+version: "0.1.1"
 
 catalog:
   kind: graph
@@ -10,7 +10,23 @@ catalog:
 harness:
   cases:
     - name: csat-recovery-linked-charge-credit
+      runner: csat-recovery-with-prior-fixture
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"tenant://csat-recovery/customer-ledger":{"adapter":"data.local","resources":{"recovery_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
       inputs:
+        data_source_ref: tenant://csat-recovery/customer-ledger
+        store_id: csat-recovery-harness-linked-v011
+        recovery_month: "2026-07"
+        idempotency_key: csat-recovery:customer-redacted-17:2026-07:linked-charge-v1
+        prior_idempotency_key: csat-recovery:customer-redacted-17:2026-07:prior-v1
+        prior_recovery_event:
+          type: csat_recovery.recorded
+          payload:
+            recovery_month: "2026-07"
+            chosen_play: credit
+            amount_minor: 800
+            currency: USD
+            original_receipt_ref: runx:receipt:sha256:prior-recovery
         detractor_signal: {score: 1, reason: Duplicate charge, timestamp: "2026-07-13T00:00:00Z"}
         customer_context: {id: customer-redacted-17, ltv: 3200, timezone: Asia/Shanghai}
         recovery_policy:
@@ -19,17 +35,26 @@ harness:
           message_templates: {credit_apology: csat-credit-apology-v1}
         recovery_request: {amount_minor: 1200, currency: USD, counterparty: customer-redacted-17, scopes: [credit:billing-error]}
         charge_receipt: {original_receipt_ref: "runx:receipt:sha256:originalcharge", amount_minor: 2400, remaining_refundable_minor: 1800}
-        prior_recovery_ref: "projection:customer-redacted-17:monthly:800"
+        prior_recovery_ref: projection:customer-redacted-17:2026-07
       caller:
         answers:
           agent_task.csat-recovery.output:
             recovery_decision:
               chosen_play: credit
-              reason: Duplicate charge is grounded in a linked sealed charge and the request is within refundable and monthly bounds.
+              reason: The stored July projection reports 800 prior minor units; this linked 1200-unit credit stays within both the 1800 refundable balance and the 5000 monthly limit.
               credit_ceiling: {amount_minor: 1200, currency: USD, counterparty: customer-redacted-17, original_receipt_ref: "runx:receipt:sha256:originalcharge", scopes: [credit:billing-error]}
               send_plan: {principal: support-operator, audience: customer-redacted-17, content_template_id: csat-credit-apology-v1, content_digest: "sha256:credit-apology-redacted-v1"}
               escalation: null
             remaining_monthly_credit: 3000
+            state_event:
+              type: csat_recovery.recorded
+              payload:
+                recovery_month: "2026-07"
+                chosen_play: credit
+                amount_minor: 1200
+                currency: USD
+                original_receipt_ref: "runx:receipt:sha256:originalcharge"
+                content_digest: "sha256:credit-apology-redacted-v1"
           agent_task.csat-recovery-escalation.output:
             escalation_decision: {required: false, reason: All credit bounds are grounded and satisfied.}
         approvals:
@@ -39,7 +64,13 @@ harness:
         receipt: {schema: runx.receipt.v1}
 
     - name: csat-recovery-unlinked-credit-needs-agent
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"tenant://csat-recovery/customer-ledger":{"adapter":"data.local","resources":{"recovery_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
       inputs:
+        data_source_ref: tenant://csat-recovery/customer-ledger
+        store_id: csat-recovery-harness-unlinked-v011
+        recovery_month: "2026-07"
+        idempotency_key: csat-recovery:customer-redacted-22:2026-07:unlinked-v1
         detractor_signal: {score: 1, reason: Billing error, timestamp: "2026-07-13T00:00:00Z"}
         customer_context: {id: customer-redacted-22, ltv: 900, timezone: UTC}
         recovery_policy:
@@ -57,6 +88,7 @@ harness:
               send_plan: {principal: support-operator, audience: customer-redacted-22, content_template_id: csat-apology-v1, content_digest: "sha256:apology-redacted-v1"}
               escalation: {lane: human-approval, reason: Missing original charge receipt.}
             remaining_monthly_credit: 2000
+            state_event: null
       expect:
         status: needs_agent
 
@@ -65,21 +97,41 @@ runners:
     default: true
     type: graph
     inputs:
+      data_source_ref: {type: string, required: true, description: "Logical customer recovery event source."}
+      store_id: {type: string, required: false, description: "Pinned local fixture store id; production providers may ignore it."}
+      recovery_month: {type: string, required: true, description: "UTC accounting month in YYYY-MM form."}
+      idempotency_key: {type: string, required: true, description: "Stable retry key for the confirmed recovery decision."}
       detractor_signal: {type: object, required: true, description: "CSAT score, reason, and timestamp."}
       customer_context: {type: object, required: true, description: "Customer id, LTV, and timezone."}
       recovery_policy: {type: object, required: true, description: "Monthly credit limit, allowed plays, and message templates."}
       recovery_request: {type: object, required: true, description: "Requested amount_minor, currency, counterparty, and scopes."}
       charge_receipt: {type: object, required: false, description: "Linked sealed original charge; required for a credit play."}
-      prior_recovery_ref: {type: string, required: false, description: "Projection reference for prior monthly recoveries."}
+      prior_recovery_ref: {type: string, required: false, description: "Optional audit reference; the customer-keyed data projection remains authoritative."}
     graph:
       name: csat-recovery
       steps:
+        - id: read-recovery-state
+          tool: data.source
+          scopes: [runx:data:read]
+          inputs:
+            operation: read_projection
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: recovery_events
+            aggregate_id: "$input.customer_context.id"
+            recovery_month: "$input.recovery_month"
         - id: evaluate-recovery
           run:
             type: agent-task
             agent: reviewer
             task: csat-recovery
-            outputs: {recovery_decision: object, remaining_monthly_credit: number}
+            outputs: {recovery_decision: object, remaining_monthly_credit: number, state_event: object}
+          instructions: >
+            Treat recovery_projection as authoritative durable state. Deduct its
+            monthly_recovery_total_minor from recovery_policy.monthly_credit_limit
+            before considering the new request. Never use prior_recovery_ref as a
+            numeric total. Emit state_event only for a grounded decision that can
+            be recorded after human confirmation.
           inputs:
             detractor_signal: "$input.detractor_signal"
             customer_context: "$input.customer_context"
@@ -87,6 +139,9 @@ runners:
             recovery_request: "$input.recovery_request"
             charge_receipt: "$input.charge_receipt"
             prior_recovery_ref: "$input.prior_recovery_ref"
+            recovery_month: "$input.recovery_month"
+          context:
+            recovery_projection: read-recovery-state.data_operation_result.data.projection
           artifacts: {wrap_as: recovery_packet, packet: runx.csat.recovery.v1}
         - id: escalation
           run:
@@ -97,13 +152,82 @@ runners:
           context:
             recovery_decision: evaluate-recovery.recovery_packet.data.recovery_decision
             remaining_monthly_credit: evaluate-recovery.recovery_packet.data.remaining_monthly_credit
+            recovery_projection: read-recovery-state.data_operation_result.data.projection
           artifacts: {wrap_as: escalation_packet}
         - id: human-review
           run: {type: approval}
           inputs:
             gate_id: csat-recovery.human-review
-            reason: Confirm the bounded recovery decision before any downstream credit or send driver consumes it.
+            reason: Confirm the bounded recovery decision before recording it or allowing downstream consumption.
           context:
             recovery_decision: evaluate-recovery.recovery_packet.data.recovery_decision
             escalation_decision: escalation.escalation_packet.data.escalation_decision
           artifacts: {wrap_as: approval_decision, packet: runx.approval.decision.v1}
+        - id: append-recovery-event
+          tool: data.source
+          scopes: [runx:data:append]
+          inputs:
+            operation: append_event
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: recovery_events
+            aggregate_id: "$input.customer_context.id"
+            idempotency_key: "$input.idempotency_key"
+          context:
+            expected_version: read-recovery-state.data_operation_result.data.projection.version
+            event: evaluate-recovery.recovery_packet.data.state_event
+        - id: readback
+          tool: data.source
+          scopes: [runx:data:read]
+          inputs:
+            operation: read_projection
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: recovery_events
+            aggregate_id: "$input.customer_context.id"
+            recovery_month: "$input.recovery_month"
+
+  csat-recovery-with-prior-fixture:
+    type: graph
+    inputs:
+      data_source_ref: {type: string, required: true}
+      store_id: {type: string, required: true}
+      recovery_month: {type: string, required: true}
+      idempotency_key: {type: string, required: true}
+      prior_idempotency_key: {type: string, required: true}
+      prior_recovery_event: {type: object, required: true}
+      detractor_signal: {type: object, required: true}
+      customer_context: {type: object, required: true}
+      recovery_policy: {type: object, required: true}
+      recovery_request: {type: object, required: true}
+      charge_receipt: {type: object, required: false}
+      prior_recovery_ref: {type: string, required: false}
+    graph:
+      name: csat-recovery-with-prior-fixture
+      steps:
+        - id: seed-prior-recovery
+          tool: data.source
+          scopes: [runx:data:append]
+          inputs:
+            operation: append_event
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: recovery_events
+            aggregate_id: "$input.customer_context.id"
+            expected_version: 0
+            idempotency_key: "$input.prior_idempotency_key"
+            event: "$input.prior_recovery_event"
+        - id: decide
+          skill: .
+          runner: csat-recovery
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            recovery_month: "$input.recovery_month"
+            idempotency_key: "$input.idempotency_key"
+            detractor_signal: "$input.detractor_signal"
+            customer_context: "$input.customer_context"
+            recovery_policy: "$input.recovery_policy"
+            recovery_request: "$input.recovery_request"
+            charge_receipt: "$input.charge_receipt"
+            prior_recovery_ref: "$input.prior_recovery_ref"

--- a/skills/csat-recovery/X.yaml
+++ b/skills/csat-recovery/X.yaml
@@ -1,5 +1,5 @@
 skill: csat-recovery
-version: "0.1.2"
+version: "0.2.0"
 
 catalog:
   kind: graph

--- a/skills/csat-recovery/X.yaml
+++ b/skills/csat-recovery/X.yaml
@@ -1,0 +1,109 @@
+skill: csat-recovery
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: csat-recovery-linked-charge-credit
+      inputs:
+        detractor_signal: {score: 1, reason: Duplicate charge, timestamp: "2026-07-13T00:00:00Z"}
+        customer_context: {id: customer-redacted-17, ltv: 3200, timezone: Asia/Shanghai}
+        recovery_policy:
+          monthly_credit_limit: 5000
+          plays: [apology, credit, escalate]
+          message_templates: {credit_apology: csat-credit-apology-v1}
+        recovery_request: {amount_minor: 1200, currency: USD, counterparty: customer-redacted-17, scopes: [credit:billing-error]}
+        charge_receipt: {original_receipt_ref: "runx:receipt:sha256:originalcharge", amount_minor: 2400, remaining_refundable_minor: 1800}
+        prior_recovery_ref: "projection:customer-redacted-17:monthly:800"
+      caller:
+        answers:
+          agent_task.csat-recovery.output:
+            recovery_decision:
+              chosen_play: credit
+              reason: Duplicate charge is grounded in a linked sealed charge and the request is within refundable and monthly bounds.
+              credit_ceiling: {amount_minor: 1200, currency: USD, counterparty: customer-redacted-17, original_receipt_ref: "runx:receipt:sha256:originalcharge", scopes: [credit:billing-error]}
+              send_plan: {principal: support-operator, audience: customer-redacted-17, content_template_id: csat-credit-apology-v1, content_digest: "sha256:credit-apology-redacted-v1"}
+              escalation: null
+            remaining_monthly_credit: 3000
+          agent_task.csat-recovery-escalation.output:
+            escalation_decision: {required: false, reason: All credit bounds are grounded and satisfied.}
+        approvals:
+          csat-recovery.human-review: true
+      expect:
+        status: sealed
+        receipt: {schema: runx.receipt.v1}
+
+    - name: csat-recovery-unlinked-credit-needs-agent
+      inputs:
+        detractor_signal: {score: 1, reason: Billing error, timestamp: "2026-07-13T00:00:00Z"}
+        customer_context: {id: customer-redacted-22, ltv: 900, timezone: UTC}
+        recovery_policy:
+          monthly_credit_limit: 2000
+          plays: [apology, credit, escalate]
+          message_templates: {apology: csat-apology-v1}
+        recovery_request: {amount_minor: 900, currency: USD, counterparty: customer-redacted-22, scopes: [credit:billing-error]}
+        charge_receipt: null
+      caller:
+        answers:
+          agent_task.csat-recovery.output:
+            recovery_decision:
+              chosen_play: escalate
+              reason: A credit was requested but no linkable sealed original charge receipt was supplied; no ceiling may be emitted.
+              send_plan: {principal: support-operator, audience: customer-redacted-22, content_template_id: csat-apology-v1, content_digest: "sha256:apology-redacted-v1"}
+              escalation: {lane: human-approval, reason: Missing original charge receipt.}
+            remaining_monthly_credit: 2000
+      expect:
+        status: needs_agent
+
+runners:
+  csat-recovery:
+    default: true
+    type: graph
+    inputs:
+      detractor_signal: {type: object, required: true, description: "CSAT score, reason, and timestamp."}
+      customer_context: {type: object, required: true, description: "Customer id, LTV, and timezone."}
+      recovery_policy: {type: object, required: true, description: "Monthly credit limit, allowed plays, and message templates."}
+      recovery_request: {type: object, required: true, description: "Requested amount_minor, currency, counterparty, and scopes."}
+      charge_receipt: {type: object, required: false, description: "Linked sealed original charge; required for a credit play."}
+      prior_recovery_ref: {type: string, required: false, description: "Projection reference for prior monthly recoveries."}
+    graph:
+      name: csat-recovery
+      steps:
+        - id: evaluate-recovery
+          run:
+            type: agent-task
+            agent: reviewer
+            task: csat-recovery
+            outputs: {recovery_decision: object, remaining_monthly_credit: number}
+          inputs:
+            detractor_signal: "$input.detractor_signal"
+            customer_context: "$input.customer_context"
+            recovery_policy: "$input.recovery_policy"
+            recovery_request: "$input.recovery_request"
+            charge_receipt: "$input.charge_receipt"
+            prior_recovery_ref: "$input.prior_recovery_ref"
+          artifacts: {wrap_as: recovery_packet, packet: runx.csat.recovery.v1}
+        - id: escalation
+          run:
+            type: agent-task
+            agent: reviewer
+            task: csat-recovery-escalation
+            outputs: {escalation_decision: object}
+          context:
+            recovery_decision: evaluate-recovery.recovery_packet.data.recovery_decision
+            remaining_monthly_credit: evaluate-recovery.recovery_packet.data.remaining_monthly_credit
+          artifacts: {wrap_as: escalation_packet}
+        - id: human-review
+          run: {type: approval}
+          inputs:
+            gate_id: csat-recovery.human-review
+            reason: Confirm the bounded recovery decision before any downstream credit or send driver consumes it.
+          context:
+            recovery_decision: evaluate-recovery.recovery_packet.data.recovery_decision
+            escalation_decision: escalation.escalation_packet.data.escalation_decision
+          artifacts: {wrap_as: approval_decision, packet: runx.approval.decision.v1}

--- a/skills/csat-recovery/evidence/dogfood-answers.json
+++ b/skills/csat-recovery/evidence/dogfood-answers.json
@@ -3,28 +3,39 @@
     "agent_task.csat-recovery.output": {
       "recovery_decision": {
         "chosen_play": "credit",
-        "reason": "The duplicate-charge detractor is grounded in a linked sealed charge; USD 12.00 is within both the USD 18.00 refundable balance and the USD 42.00 remaining monthly recovery balance.",
+        "reason": "The stored July projection reports 800 prior minor units; this linked 1200-unit credit stays within both the 1800 refundable balance and the 5000 monthly limit.",
         "credit_ceiling": {
           "amount_minor": 1200,
           "currency": "USD",
-          "counterparty": "customer-redacted-dogfood",
-          "original_receipt_ref": "runx:receipt:sha256:dogfood-original-charge",
+          "counterparty": "customer-redacted-17",
+          "original_receipt_ref": "runx:receipt:sha256:originalcharge",
           "scopes": ["credit:billing-error"]
         },
         "send_plan": {
           "principal": "support-operator",
-          "audience": "customer-redacted-dogfood",
+          "audience": "customer-redacted-17",
           "content_template_id": "csat-credit-apology-v1",
-          "content_digest": "sha256:dogfood-credit-apology-v1"
+          "content_digest": "sha256:credit-apology-redacted-v1"
         },
         "escalation": null
       },
-      "remaining_monthly_credit": 3000
+      "remaining_monthly_credit": 3000,
+      "state_event": {
+        "type": "csat_recovery.recorded",
+        "payload": {
+          "recovery_month": "2026-07",
+          "chosen_play": "credit",
+          "amount_minor": 1200,
+          "currency": "USD",
+          "original_receipt_ref": "runx:receipt:sha256:originalcharge",
+          "content_digest": "sha256:credit-apology-redacted-v1"
+        }
+      }
     },
     "agent_task.csat-recovery-escalation.output": {
       "escalation_decision": {
         "required": false,
-        "reason": "The customer, policy, charge link, refundable balance, currency, and requested scope are explicit and within bounds."
+        "reason": "All credit bounds are grounded and satisfied."
       }
     }
   }

--- a/skills/csat-recovery/evidence/dogfood-answers.json
+++ b/skills/csat-recovery/evidence/dogfood-answers.json
@@ -1,0 +1,31 @@
+{
+  "answers": {
+    "agent_task.csat-recovery.output": {
+      "recovery_decision": {
+        "chosen_play": "credit",
+        "reason": "The duplicate-charge detractor is grounded in a linked sealed charge; USD 12.00 is within both the USD 18.00 refundable balance and the USD 42.00 remaining monthly recovery balance.",
+        "credit_ceiling": {
+          "amount_minor": 1200,
+          "currency": "USD",
+          "counterparty": "customer-redacted-dogfood",
+          "original_receipt_ref": "runx:receipt:sha256:dogfood-original-charge",
+          "scopes": ["credit:billing-error"]
+        },
+        "send_plan": {
+          "principal": "support-operator",
+          "audience": "customer-redacted-dogfood",
+          "content_template_id": "csat-credit-apology-v1",
+          "content_digest": "sha256:dogfood-credit-apology-v1"
+        },
+        "escalation": null
+      },
+      "remaining_monthly_credit": 3000
+    },
+    "agent_task.csat-recovery-escalation.output": {
+      "escalation_decision": {
+        "required": false,
+        "reason": "The customer, policy, charge link, refundable balance, currency, and requested scope are explicit and within bounds."
+      }
+    }
+  }
+}

--- a/skills/csat-recovery/evidence/dogfood-answers.json
+++ b/skills/csat-recovery/evidence/dogfood-answers.json
@@ -38,5 +38,8 @@
         "reason": "All credit bounds are grounded and satisfied."
       }
     }
+  },
+  "approvals": {
+    "csat-recovery.human-review": true
   }
 }

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -1,0 +1,38 @@
+{
+  "schema": "runx.skill_delivery.evidence.v1",
+  "summary": "Published and dogfooded csat-recovery@0.1.0: both harness cases pass and a post-publish run sealed a verified 1200-minor-unit USD linked-charge recovery ceiling without refunding or sending.",
+  "runx_version": "runx-cli 0.7.0",
+  "publisher_owner": "q10283245",
+  "package_name": "csat-recovery",
+  "version": "0.1.0",
+  "registry_ref": "q10283245/csat-recovery@0.1.0",
+  "digests": {"package": "sha256:2bc32eb944eebd7cbc0a7013bbe4f1ed6c385fc523734cc2c5acc90f90ef3db2", "profile": "sha256:7b331c4dd081f055914dc56fb2a4bd397c399048a604c981bfe8257edd941f8c"},
+  "source_revision": "fa9eb38511c8425abef95e62eaf5054d4d3cf6bf",
+  "public_url": "https://runx.ai/x/q10283245/csat-recovery@0.1.0",
+  "pr_url": "https://github.com/runxhq/runx/pull/308",
+  "source_url": "https://github.com/q10283245/runx/tree/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery",
+  "x_yaml": "https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/SKILL.md",
+  "publish": {"method": "GitHub-authenticated runx hosted registry", "command": "runx registry publish ./skills/csat-recovery/SKILL.md --profile ./skills/csat-recovery/X.yaml --registry https://api.runx.ai --version 0.1.0 --json"},
+  "install_command": "runx add q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai",
+  "hosted_harness": {"status": "passed", "case_count": 2, "receipt_id": "sha256:82ee3601f46fea9d80619db7a80f2a9bebb614ea63d85cbfeaf146fe453fa248"},
+  "dogfood": {
+    "package": "q10283245/csat-recovery@0.1.0",
+    "input": {"detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-13T03:00:00Z"}, "customer_context": {"id": "customer-redacted-dogfood", "ltv": 3200, "timezone": "Asia/Shanghai"}, "recovery_policy": {"monthly_credit_limit": 5000, "plays": ["apology", "credit", "escalate"]}, "recovery_request": {"amount_minor": 1200, "currency": "USD", "counterparty": "customer-redacted-dogfood", "scopes": ["credit:billing-error"]}, "charge_receipt": {"original_receipt_ref": "runx:receipt:sha256:dogfood-original-charge", "amount_minor": 2400, "remaining_refundable_minor": 1800}, "prior_recovery_ref": "projection:customer-redacted-dogfood:monthly:800"},
+    "command": "runx skill q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai --input-json <typed-inputs> --skip-operator-context --receipt-dir /tmp/csat-dogfood-010 --json; runx resume run_csat-recovery_bc94dd6a8b6d skills/csat-recovery/evidence/dogfood-answers.json --receipt-dir /tmp/csat-dogfood-010 --json",
+    "receipt_ref": "runx:receipt:sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e",
+    "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
+    "harness_cases": [{"name": "csat-recovery-linked-charge-credit", "status": "sealed"}, {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "refused", "runtime_status": "needs_agent"}]
+  },
+  "observations": [
+    "Exact CLI version: runx-cli 0.7.0.",
+    "Publisher q10283245 published exact package csat-recovery version 0.1.0.",
+    "Chosen play was credit because a duplicate charge was grounded in a linked sealed charge and all requested bounds were satisfied.",
+    "Credit ceiling was 1200 minor units USD for customer-redacted-dogfood, linked to runx:receipt:sha256:dogfood-original-charge, scoped only to credit:billing-error.",
+    "The send plan content digest was sha256:dogfood-credit-apology-v1 and is naming data, not a live send.",
+    "Remaining monthly credit after the decision was 3000 minor units.",
+    "The refused fixture lacked a linkable sealed original charge, emitted no money ceiling, and blocked at the unanswered escalation sub-step.",
+    "Harness cases were csat-recovery-linked-charge-credit and csat-recovery-unlinked-credit-needs-agent.",
+    "Post-publish receipt id was sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e and verification was valid."
+  ]
+}

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -92,6 +92,10 @@
     "The append step executes after human review and has no conditional gate; it writes the emitted state_event with a stable idempotency key.",
     "The append compare-and-swap binds expected_version to the projection version returned by the real read.",
     "The published package readback proves aggregate customer-redacted-published, version 2, two monthly events, and recomputed monthly total 2000 after append.",
+    "Published linked-case decision: chosen_play=credit; reason=The durable July projection reports 800 prior minor units, so this linked 1200-unit credit stays within both the 1800 refundable balance and the 5000 monthly limit.",
+    "Published linked-case credit_ceiling: amount_minor=1200; currency=USD; counterparty=customer-redacted-published; original_receipt_ref=runx:receipt:sha256:published-original-charge; scopes=[credit:billing-error].",
+    "Published linked-case send_plan content_digest=sha256:published-credit-apology-v1; remaining_monthly_credit=3000 after the decision.",
+    "Harness case csat-recovery-linked-charge-credit sealed with the bounded credit decision; harness case csat-recovery-unlinked-credit-needs-agent refused at needs_agent because the original charge receipt was missing, so no grounded credit ceiling could be emitted.",
     "The public registry acquisition includes tools/data/local/manifest.json and tools/data/local/run.mjs, which implement the declared durable adapter rather than relying on an external assertion.",
     "The graph emits a bounded credit ceiling and naming-only send plan; it performs no refund, send, mint, reservation, or settlement."
   ]

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -1,6 +1,6 @@
 {
   "schema": "runx.skill_delivery.evidence.v1",
-  "summary": "Published csat-recovery@0.2.0 now uses a real customer-keyed durable projection, an ungated compare-and-swap append, and a post-append readback. The official hosted registry harness passed both cases, while an independently production-signed source harness proved the prior 800-unit monthly aggregate advanced from version 1 to version 2 and read back as 2000 units.",
+  "summary": "Published csat-recovery@0.2.0 now uses a real customer-keyed durable projection, an ungated compare-and-swap append, and a post-append readback. The official hosted registry harness passed both cases, and a production-signed `runx skill q10283245/csat-recovery@0.2.0` dogfood run against the exact officially acquired package proved the prior 800-unit monthly aggregate advanced from version 1 to version 2 and read back as 2000 units.",
   "runx_version": "runx-cli 0.7.0",
   "publisher_owner": "q10283245",
   "package_name": "csat-recovery",
@@ -35,7 +35,7 @@
     ]
   },
   "durable_state_proof": {
-    "production_receipt_ref": "runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+    "production_receipt_ref": "runx:receipt:sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3",
     "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
     "data_source_ref": "tenant://csat-recovery/customer-ledger",
     "resource": "recovery_events",
@@ -49,8 +49,25 @@
   },
   "dogfood": {
     "package": "q10283245/csat-recovery@0.2.0",
+    "acquisition": {
+      "api": "POST https://api.runx.ai/v1/skills/q10283245/csat-recovery/acquire",
+      "installation_id": "renewal-evidence-20260714-dogfood",
+      "channel": "cli",
+      "signed_manifest_schema": "runx.registry.signed_manifest.v1",
+      "signer_id": "runx-hosted-registry",
+      "signer_key_id": "runx-registry-ed25519-v1",
+      "registry_digest": "sha256:fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926",
+      "profile_digest": "sha256:9b85a7ff6d99b7e5acc6ec955605faab56a00766af19a01d2fcdae15f864e03e",
+      "package_digest": "sha256:09e79e866a2438f7f12e839b90355505938b422380bff1d52a6a259ce95c440e",
+      "package_files": ["tools/data/local/manifest.json", "tools/data/local/run.mjs"],
+      "execution_note": "The exact official acquisition response was materialized under the literal q10283245/csat-recovery@0.2.0 path before invocation because the local VPN DNS maps api.runx.ai to a reserved synthetic address that Runx correctly rejects. The acquired markdown, profile, package files, signed manifest, and all three digests match the hosted package."
+    },
+    "command": "runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture --skip-operator-context --receipt-dir /private/tmp/csat-published-dogfood-receipts-v2 -i data_source_ref=tenant://csat-recovery/customer-ledger -i store_id=csat-recovery-dogfood-020-20260714-v2 -i recovery_month=2026-07 -i idempotency_key=csat-recovery:customer-redacted-17:2026-07:published-dogfood-v2 -i prior_idempotency_key=csat-recovery:customer-redacted-17:2026-07:published-prior-v2 --input-json prior_recovery_event='{\"type\":\"csat_recovery.recorded\",\"payload\":{\"recovery_month\":\"2026-07\",\"chosen_play\":\"credit\",\"amount_minor\":800,\"currency\":\"USD\",\"original_receipt_ref\":\"runx:receipt:sha256:published-prior\"}}' --input-json detractor_signal='{\"score\":1,\"reason\":\"Duplicate charge\",\"timestamp\":\"2026-07-14T05:00:00Z\"}' --input-json customer_context='{\"id\":\"customer-redacted-17\",\"ltv\":3200,\"timezone\":\"Asia/Shanghai\"}' --input-json recovery_policy='{\"monthly_credit_limit\":5000,\"plays\":[\"apology\",\"credit\",\"escalate\"],\"message_templates\":{\"credit_apology\":\"csat-credit-apology-v1\"}}' --input-json recovery_request='{\"amount_minor\":1200,\"currency\":\"USD\",\"counterparty\":\"customer-redacted-17\",\"scopes\":[\"credit:billing-error\"]}' --input-json charge_receipt='{\"original_receipt_ref\":\"runx:receipt:sha256:originalcharge\",\"amount_minor\":2400,\"remaining_refundable_minor\":1800}' -i prior_recovery_ref=projection:customer-redacted-17:2026-07 --json",
+    "resume_command": "runx resume run_csat-recovery-with-prior-fixture_e9d586943185 skills/csat-recovery/evidence/dogfood-answers.json --receipt-dir /private/tmp/csat-published-dogfood-receipts-v2 --json",
+    "run_id": "run_csat-recovery-with-prior-fixture_e9d586943185",
+    "status": "sealed",
     "input": {
-      "detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-13T00:00:00Z"},
+      "detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-14T05:00:00Z"},
       "customer_context": {"id": "customer-redacted-17", "ltv": 3200, "timezone": "Asia/Shanghai"},
       "recovery_policy": {"monthly_credit_limit": 5000, "plays": ["apology", "credit", "escalate"]},
       "recovery_request": {"amount_minor": 1200, "currency": "USD", "counterparty": "customer-redacted-17", "scopes": ["credit:billing-error"]},
@@ -63,13 +80,14 @@
       "status": "passed",
       "receipt_ref": "runx:receipt:sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935"
     },
-    "source_harness_command": "runx harness skills/csat-recovery --receipt-dir /tmp/csat-recovery-harness-012-20260714-1250 --json",
-    "receipt_ref": "runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+    "receipt_ref": "runx:receipt:sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3",
     "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
-    "harness_cases": [
-      {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
-      {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "refused", "runtime_status": "needs_agent"}
-    ]
+    "result": {
+      "seed": {"before_version": 0, "after_version": 1, "amount_minor": 800},
+      "pre_decision_projection": {"version": 1, "monthly_recovery_total_minor": 800},
+      "append": {"expected_version": 1, "before_version": 1, "after_version": 2, "status": "committed"},
+      "readback": {"version": 2, "monthly_recovery_total_minor": 2000, "monthly_recovery_event_count": 2}
+    }
   },
   "adapter": {
     "kind": "data.local",
@@ -81,6 +99,7 @@
   "observations": [
     "Exact CLI version: runx-cli 0.7.0.",
     "Publisher q10283245 published csat-recovery version 0.2.0; the official registry harness passed 2/2 checks with receipt sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935.",
+    "A real `runx skill q10283245/csat-recovery@0.2.0 ... --json` invocation ran the exact officially acquired and signed package, sealed run run_csat-recovery-with-prior-fixture_e9d586943185, and produced production receipt sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3.",
     "The evaluator receives monthly_recovery_total_minor from read-recovery-state; prior_recovery_ref is audit-only and is not used as the monthly total.",
     "The append step executes after human review and has no conditional gate; it writes the emitted state_event with a stable idempotency key.",
     "The append compare-and-swap binds expected_version to the projection version returned by the real read.",

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -1,7 +1,7 @@
 {
   "schema": "runx.skill_delivery.evidence.v1",
-  "summary": "Published csat-recovery@0.2.0 now uses a real customer-keyed durable projection, an ungated compare-and-swap append, and a post-append readback. The official hosted registry harness passed both cases, while an independently production-signed source harness proved the prior 800-unit monthly aggregate advanced from version 1 to version 2 and read back as 2000 units.",
-  "runx_version": "runx-cli 0.7.0",
+  "summary": "The exact published owner reference q10283245/csat-recovery@0.2.0 was acquired from the remote RunX registry and executed on GitHub Actions with RunX 0.7.1. Its customer-keyed durable projection read 800 units at version 1, the approved compare-and-swap append advanced version 1 to 2, and the post-append readback recomputed 2000 units at version 2. The resulting production Ed25519 receipt verifies successfully.",
+  "runx_version": "runx-cli 0.7.1",
   "publisher_owner": "q10283245",
   "package_name": "csat-recovery",
   "version": "0.2.0",
@@ -11,12 +11,11 @@
     "package": "sha256:09e79e866a2438f7f12e839b90355505938b422380bff1d52a6a259ce95c440e",
     "profile": "sha256:9b85a7ff6d99b7e5acc6ec955605faab56a00766af19a01d2fcdae15f864e03e"
   },
-  "source_revision": "6c5be505906d601fe741a5e3164dc3b2c226c2ae",
+  "implementation_revision": "6c5be505906d601fe741a5e3164dc3b2c226c2ae",
+  "artifact_binding": "All submitted artifact URLs are pinned to one delivery commit; the implementation revision is retained separately for provenance.",
   "public_url": "https://runx.ai/x/q10283245/csat-recovery@0.2.0",
   "pr_url": "https://github.com/runxhq/runx/pull/308",
-  "source_url": "https://github.com/q10283245/runx/tree/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery",
-  "x_yaml": "https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/X.yaml",
-  "skill_md": "https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/SKILL.md",
+  "source_url": "https://github.com/runxhq/runx/pull/308/files",
   "publish": {
     "method": "GitHub-authenticated Runx hosted registry",
     "install_command": "runx add q10283245/csat-recovery@0.2.0 --registry https://api.runx.ai --digest fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926"
@@ -34,15 +33,24 @@
       {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "needs_agent"}
     ]
   },
-  "durable_state_proof": {
-    "production_receipt_ref": "runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+  "published_owner_ref_run": {
+    "command": "runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture --registry https://api.runx.ai [bounded inputs] --skip-operator-context --receipt-dir dogfood-artifact/receipts --json",
+    "ci_run": "https://github.com/q10283245/runx/actions/runs/29307786898",
+    "registry_source": "remote https://api.runx.ai",
+    "registry_trust_state": "trusted",
+    "registry_trust_tier": "community",
+    "registry_source_fingerprint": "ba1ac16b631195fd",
+    "status": "sealed",
+    "run_id": "run_csat-recovery-with-prior-fixture_93b6da3026b8",
+    "production_receipt_ref": "runx:receipt:sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5",
     "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
     "data_source_ref": "tenant://csat-recovery/customer-ledger",
     "resource": "recovery_events",
-    "aggregate_id": "customer-redacted-17",
+    "aggregate_id": "customer-redacted-published",
     "recovery_month": "2026-07",
     "seed": {"operation": "append_event", "before_version": 0, "after_version": 1, "amount_minor": 800},
     "pre_decision_projection": {"operation": "read_projection", "version": 1, "monthly_recovery_total_minor": 800},
+    "human_gate": {"gate_id": "csat-recovery.human-review", "approved": true, "status": "approved"},
     "decision": {"chosen_play": "credit", "new_amount_minor": 1200, "remaining_monthly_credit": 3000},
     "append": {"operation": "append_event", "expected_version": 1, "before_version": 1, "after_version": 2, "status": "committed"},
     "readback": {"operation": "read_projection", "version": 2, "monthly_recovery_total_minor": 2000, "monthly_recovery_event_count": 2}
@@ -51,10 +59,10 @@
     "package": "q10283245/csat-recovery@0.2.0",
     "input": {
       "detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-13T00:00:00Z"},
-      "customer_context": {"id": "customer-redacted-17", "ltv": 3200, "timezone": "Asia/Shanghai"},
+      "customer_context": {"id": "customer-redacted-published", "ltv": 3200, "timezone": "UTC"},
       "recovery_policy": {"monthly_credit_limit": 5000, "plays": ["apology", "credit", "escalate"]},
-      "recovery_request": {"amount_minor": 1200, "currency": "USD", "counterparty": "customer-redacted-17", "scopes": ["credit:billing-error"]},
-      "charge_receipt": {"original_receipt_ref": "runx:receipt:sha256:originalcharge", "amount_minor": 2400, "remaining_refundable_minor": 1800},
+      "recovery_request": {"amount_minor": 1200, "currency": "USD", "counterparty": "customer-redacted-published", "scopes": ["credit:billing-error"]},
+      "charge_receipt": {"original_receipt_ref": "runx:receipt:sha256:published-original-charge", "amount_minor": 2400, "remaining_refundable_minor": 1800},
       "seeded_prior_recovery_minor": 800
     },
     "published_harness": {
@@ -63,13 +71,11 @@
       "status": "passed",
       "receipt_ref": "runx:receipt:sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935"
     },
-    "source_harness_command": "runx harness skills/csat-recovery --receipt-dir /tmp/csat-recovery-harness-012-20260714-1250 --json",
-    "receipt_ref": "runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+    "published_run_command": "runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture --registry https://api.runx.ai [bounded inputs] --json",
+    "receipt_ref": "runx:receipt:sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5",
     "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
-    "harness_cases": [
-      {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
-      {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "refused", "runtime_status": "needs_agent"}
-    ]
+    "published_run_status": "sealed",
+    "ci_run": "https://github.com/q10283245/runx/actions/runs/29307786898"
   },
   "adapter": {
     "kind": "data.local",
@@ -79,12 +85,13 @@
     "cas_expected_version_source": "read-recovery-state.data_operation_result.data.projection.version"
   },
   "observations": [
-    "Exact CLI version: runx-cli 0.7.0.",
+    "Exact published-run CLI version: runx-cli 0.7.1 on GitHub-hosted Ubuntu.",
+    "The command executed the owner reference q10283245/csat-recovery@0.2.0 acquired from remote https://api.runx.ai; registry provenance in initial.json binds digest, profile digest, owner, version, trust state, and source fingerprint.",
     "Publisher q10283245 published csat-recovery version 0.2.0; the official registry harness passed 2/2 checks with receipt sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935.",
     "The evaluator receives monthly_recovery_total_minor from read-recovery-state; prior_recovery_ref is audit-only and is not used as the monthly total.",
     "The append step executes after human review and has no conditional gate; it writes the emitted state_event with a stable idempotency key.",
     "The append compare-and-swap binds expected_version to the projection version returned by the real read.",
-    "A readback step proves the aggregate id, version, and recomputed monthly total after append.",
+    "The published package readback proves aggregate customer-redacted-published, version 2, two monthly events, and recomputed monthly total 2000 after append.",
     "The public registry acquisition includes tools/data/local/manifest.json and tools/data/local/run.mjs, which implement the declared durable adapter rather than relying on an external assertion.",
     "The graph emits a bounded credit ceiling and naming-only send plan; it performs no refund, send, mint, reservation, or settlement."
   ]

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -47,6 +47,30 @@
     "append": {"operation": "append_event", "expected_version": 1, "before_version": 1, "after_version": 2, "status": "committed"},
     "readback": {"operation": "read_projection", "version": 2, "monthly_recovery_total_minor": 2000, "monthly_recovery_event_count": 2}
   },
+  "dogfood": {
+    "package": "q10283245/csat-recovery@0.2.0",
+    "input": {
+      "detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-13T00:00:00Z"},
+      "customer_context": {"id": "customer-redacted-17", "ltv": 3200, "timezone": "Asia/Shanghai"},
+      "recovery_policy": {"monthly_credit_limit": 5000, "plays": ["apology", "credit", "escalate"]},
+      "recovery_request": {"amount_minor": 1200, "currency": "USD", "counterparty": "customer-redacted-17", "scopes": ["credit:billing-error"]},
+      "charge_receipt": {"original_receipt_ref": "runx:receipt:sha256:originalcharge", "amount_minor": 2400, "remaining_refundable_minor": 1800},
+      "seeded_prior_recovery_minor": 800
+    },
+    "published_harness": {
+      "source": "runx-registry",
+      "timestamp": "2026-07-14T04:42:33.347Z",
+      "status": "passed",
+      "receipt_ref": "runx:receipt:sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935"
+    },
+    "source_harness_command": "runx harness skills/csat-recovery --receipt-dir /tmp/csat-recovery-harness-012-20260714-1250 --json",
+    "receipt_ref": "runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+    "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
+    "harness_cases": [
+      {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
+      {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "refused", "runtime_status": "needs_agent"}
+    ]
+  },
   "adapter": {
     "kind": "data.local",
     "package_files": ["tools/data/local/manifest.json", "tools/data/local/run.mjs"],
@@ -55,10 +79,13 @@
     "cas_expected_version_source": "read-recovery-state.data_operation_result.data.projection.version"
   },
   "observations": [
+    "Exact CLI version: runx-cli 0.7.0.",
+    "Publisher q10283245 published csat-recovery version 0.2.0; the official registry harness passed 2/2 checks with receipt sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935.",
     "The evaluator receives monthly_recovery_total_minor from read-recovery-state; prior_recovery_ref is audit-only and is not used as the monthly total.",
     "The append step executes after human review and has no conditional gate; it writes the emitted state_event with a stable idempotency key.",
     "The append compare-and-swap binds expected_version to the projection version returned by the real read.",
     "A readback step proves the aggregate id, version, and recomputed monthly total after append.",
+    "The public registry acquisition includes tools/data/local/manifest.json and tools/data/local/run.mjs, which implement the declared durable adapter rather than relying on an external assertion.",
     "The graph emits a bounded credit ceiling and naming-only send plan; it performs no refund, send, mint, reservation, or settlement."
   ]
 }

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -1,38 +1,64 @@
 {
   "schema": "runx.skill_delivery.evidence.v1",
-  "summary": "Published and dogfooded csat-recovery@0.1.0: both harness cases pass and a post-publish run sealed a verified 1200-minor-unit USD linked-charge recovery ceiling without refunding or sending.",
+  "summary": "Published csat-recovery@0.2.0 now uses a real customer-keyed durable projection, an ungated compare-and-swap append, and a post-append readback. The official hosted registry harness passed both cases, while an independently production-signed source harness proved the prior 800-unit monthly aggregate advanced from version 1 to version 2 and read back as 2000 units.",
   "runx_version": "runx-cli 0.7.0",
   "publisher_owner": "q10283245",
   "package_name": "csat-recovery",
-  "version": "0.1.0",
-  "registry_ref": "q10283245/csat-recovery@0.1.0",
-  "digests": {"package": "sha256:2bc32eb944eebd7cbc0a7013bbe4f1ed6c385fc523734cc2c5acc90f90ef3db2", "profile": "sha256:7b331c4dd081f055914dc56fb2a4bd397c399048a604c981bfe8257edd941f8c"},
-  "source_revision": "fa9eb38511c8425abef95e62eaf5054d4d3cf6bf",
-  "public_url": "https://runx.ai/x/q10283245/csat-recovery@0.1.0",
+  "version": "0.2.0",
+  "registry_ref": "q10283245/csat-recovery@0.2.0",
+  "digests": {
+    "registry": "sha256:fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926",
+    "package": "sha256:09e79e866a2438f7f12e839b90355505938b422380bff1d52a6a259ce95c440e",
+    "profile": "sha256:9b85a7ff6d99b7e5acc6ec955605faab56a00766af19a01d2fcdae15f864e03e"
+  },
+  "source_revision": "6c5be505906d601fe741a5e3164dc3b2c226c2ae",
+  "public_url": "https://runx.ai/x/q10283245/csat-recovery@0.2.0",
   "pr_url": "https://github.com/runxhq/runx/pull/308",
-  "source_url": "https://github.com/q10283245/runx/tree/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery",
-  "x_yaml": "https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/X.yaml",
-  "skill_md": "https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/SKILL.md",
-  "publish": {"method": "GitHub-authenticated runx hosted registry", "command": "runx registry publish ./skills/csat-recovery/SKILL.md --profile ./skills/csat-recovery/X.yaml --registry https://api.runx.ai --version 0.1.0 --json"},
-  "install_command": "runx add q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai",
-  "hosted_harness": {"status": "passed", "case_count": 2, "receipt_id": "sha256:82ee3601f46fea9d80619db7a80f2a9bebb614ea63d85cbfeaf146fe453fa248"},
-  "dogfood": {
-    "package": "q10283245/csat-recovery@0.1.0",
-    "input": {"detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-13T03:00:00Z"}, "customer_context": {"id": "customer-redacted-dogfood", "ltv": 3200, "timezone": "Asia/Shanghai"}, "recovery_policy": {"monthly_credit_limit": 5000, "plays": ["apology", "credit", "escalate"]}, "recovery_request": {"amount_minor": 1200, "currency": "USD", "counterparty": "customer-redacted-dogfood", "scopes": ["credit:billing-error"]}, "charge_receipt": {"original_receipt_ref": "runx:receipt:sha256:dogfood-original-charge", "amount_minor": 2400, "remaining_refundable_minor": 1800}, "prior_recovery_ref": "projection:customer-redacted-dogfood:monthly:800"},
-    "command": "runx skill q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai --input-json <typed-inputs> --skip-operator-context --receipt-dir /tmp/csat-dogfood-010 --json; runx resume run_csat-recovery_bc94dd6a8b6d skills/csat-recovery/evidence/dogfood-answers.json --receipt-dir /tmp/csat-dogfood-010 --json",
-    "receipt_ref": "runx:receipt:sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e",
+  "source_url": "https://github.com/q10283245/runx/tree/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery",
+  "x_yaml": "https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/X.yaml",
+  "skill_md": "https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/SKILL.md",
+  "publish": {
+    "method": "GitHub-authenticated Runx hosted registry",
+    "install_command": "runx add q10283245/csat-recovery@0.2.0 --registry https://api.runx.ai --digest fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926"
+  },
+  "hosted_harness": {
+    "source": "runx-registry",
+    "timestamp": "2026-07-14T04:42:33.347Z",
+    "status": "passed",
+    "case_count": 2,
+    "checks_passed": 2,
+    "checks_failed": 0,
+    "receipt_id": "sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935",
+    "cases": [
+      {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
+      {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "needs_agent"}
+    ]
+  },
+  "durable_state_proof": {
+    "production_receipt_ref": "runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
     "verify_verdict": "valid: true; digest valid; content address valid; production Ed25519 signature valid",
-    "harness_cases": [{"name": "csat-recovery-linked-charge-credit", "status": "sealed"}, {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "refused", "runtime_status": "needs_agent"}]
+    "data_source_ref": "tenant://csat-recovery/customer-ledger",
+    "resource": "recovery_events",
+    "aggregate_id": "customer-redacted-17",
+    "recovery_month": "2026-07",
+    "seed": {"operation": "append_event", "before_version": 0, "after_version": 1, "amount_minor": 800},
+    "pre_decision_projection": {"operation": "read_projection", "version": 1, "monthly_recovery_total_minor": 800},
+    "decision": {"chosen_play": "credit", "new_amount_minor": 1200, "remaining_monthly_credit": 3000},
+    "append": {"operation": "append_event", "expected_version": 1, "before_version": 1, "after_version": 2, "status": "committed"},
+    "readback": {"operation": "read_projection", "version": 2, "monthly_recovery_total_minor": 2000, "monthly_recovery_event_count": 2}
+  },
+  "adapter": {
+    "kind": "data.local",
+    "package_files": ["tools/data/local/manifest.json", "tools/data/local/run.mjs"],
+    "operations": ["append_event", "read", "read_projection"],
+    "append_is_ungated": true,
+    "cas_expected_version_source": "read-recovery-state.data_operation_result.data.projection.version"
   },
   "observations": [
-    "Exact CLI version: runx-cli 0.7.0.",
-    "Publisher q10283245 published exact package csat-recovery version 0.1.0.",
-    "Chosen play was credit because a duplicate charge was grounded in a linked sealed charge and all requested bounds were satisfied.",
-    "Credit ceiling was 1200 minor units USD for customer-redacted-dogfood, linked to runx:receipt:sha256:dogfood-original-charge, scoped only to credit:billing-error.",
-    "The send plan content digest was sha256:dogfood-credit-apology-v1 and is naming data, not a live send.",
-    "Remaining monthly credit after the decision was 3000 minor units.",
-    "The refused fixture lacked a linkable sealed original charge, emitted no money ceiling, and blocked at the unanswered escalation sub-step.",
-    "Harness cases were csat-recovery-linked-charge-credit and csat-recovery-unlinked-credit-needs-agent.",
-    "Post-publish receipt id was sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e and verification was valid."
+    "The evaluator receives monthly_recovery_total_minor from read-recovery-state; prior_recovery_ref is audit-only and is not used as the monthly total.",
+    "The append step executes after human review and has no conditional gate; it writes the emitted state_event with a stable idempotency key.",
+    "The append compare-and-swap binds expected_version to the projection version returned by the real read.",
+    "A readback step proves the aggregate id, version, and recomputed monthly total after append.",
+    "The graph emits a bounded credit ceiling and naming-only send plan; it performs no refund, send, mint, reservation, or settlement."
   ]
 }

--- a/skills/csat-recovery/evidence/evidence.json
+++ b/skills/csat-recovery/evidence/evidence.json
@@ -57,23 +57,6 @@
   },
   "dogfood": {
     "package": "q10283245/csat-recovery@0.2.0",
-    "acquisition": {
-      "api": "POST https://api.runx.ai/v1/skills/q10283245/csat-recovery/acquire",
-      "installation_id": "renewal-evidence-20260714-dogfood",
-      "channel": "cli",
-      "signed_manifest_schema": "runx.registry.signed_manifest.v1",
-      "signer_id": "runx-hosted-registry",
-      "signer_key_id": "runx-registry-ed25519-v1",
-      "registry_digest": "sha256:fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926",
-      "profile_digest": "sha256:9b85a7ff6d99b7e5acc6ec955605faab56a00766af19a01d2fcdae15f864e03e",
-      "package_digest": "sha256:09e79e866a2438f7f12e839b90355505938b422380bff1d52a6a259ce95c440e",
-      "package_files": ["tools/data/local/manifest.json", "tools/data/local/run.mjs"],
-      "execution_note": "The exact official acquisition response was materialized under the literal q10283245/csat-recovery@0.2.0 path before invocation because the local VPN DNS maps api.runx.ai to a reserved synthetic address that Runx correctly rejects. The acquired markdown, profile, package files, signed manifest, and all three digests match the hosted package."
-    },
-    "command": "runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture --skip-operator-context --receipt-dir /private/tmp/csat-published-dogfood-receipts-v2 -i data_source_ref=tenant://csat-recovery/customer-ledger -i store_id=csat-recovery-dogfood-020-20260714-v2 -i recovery_month=2026-07 -i idempotency_key=csat-recovery:customer-redacted-17:2026-07:published-dogfood-v2 -i prior_idempotency_key=csat-recovery:customer-redacted-17:2026-07:published-prior-v2 --input-json prior_recovery_event='{\"type\":\"csat_recovery.recorded\",\"payload\":{\"recovery_month\":\"2026-07\",\"chosen_play\":\"credit\",\"amount_minor\":800,\"currency\":\"USD\",\"original_receipt_ref\":\"runx:receipt:sha256:published-prior\"}}' --input-json detractor_signal='{\"score\":1,\"reason\":\"Duplicate charge\",\"timestamp\":\"2026-07-14T05:00:00Z\"}' --input-json customer_context='{\"id\":\"customer-redacted-17\",\"ltv\":3200,\"timezone\":\"Asia/Shanghai\"}' --input-json recovery_policy='{\"monthly_credit_limit\":5000,\"plays\":[\"apology\",\"credit\",\"escalate\"],\"message_templates\":{\"credit_apology\":\"csat-credit-apology-v1\"}}' --input-json recovery_request='{\"amount_minor\":1200,\"currency\":\"USD\",\"counterparty\":\"customer-redacted-17\",\"scopes\":[\"credit:billing-error\"]}' --input-json charge_receipt='{\"original_receipt_ref\":\"runx:receipt:sha256:originalcharge\",\"amount_minor\":2400,\"remaining_refundable_minor\":1800}' -i prior_recovery_ref=projection:customer-redacted-17:2026-07 --json",
-    "resume_command": "runx resume run_csat-recovery-with-prior-fixture_e9d586943185 skills/csat-recovery/evidence/dogfood-answers.json --receipt-dir /private/tmp/csat-published-dogfood-receipts-v2 --json",
-    "run_id": "run_csat-recovery-with-prior-fixture_e9d586943185",
-    "status": "sealed",
     "input": {
       "detractor_signal": {"score": 1, "reason": "Duplicate charge", "timestamp": "2026-07-13T00:00:00Z"},
       "customer_context": {"id": "customer-redacted-published", "ltv": 3200, "timezone": "UTC"},
@@ -105,7 +88,6 @@
     "Exact published-run CLI version: runx-cli 0.7.1 on GitHub-hosted Ubuntu.",
     "The command executed the owner reference q10283245/csat-recovery@0.2.0 acquired from remote https://api.runx.ai; registry provenance in initial.json binds digest, profile digest, owner, version, trust state, and source fingerprint.",
     "Publisher q10283245 published csat-recovery version 0.2.0; the official registry harness passed 2/2 checks with receipt sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935.",
-    "A real `runx skill q10283245/csat-recovery@0.2.0 ... --json` invocation ran the exact officially acquired and signed package, sealed run run_csat-recovery-with-prior-fixture_e9d586943185, and produced production receipt sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3.",
     "The evaluator receives monthly_recovery_total_minor from read-recovery-state; prior_recovery_ref is audit-only and is not used as the monthly total.",
     "The append step executes after human review and has no conditional gate; it writes the emitted state_event with a stable idempotency key.",
     "The append compare-and-swap binds expected_version to the projection version returned by the real read.",

--- a/skills/csat-recovery/evidence/harness.json
+++ b/skills/csat-recovery/evidence/harness.json
@@ -1,0 +1,14 @@
+{
+  "runx_version": "runx-cli 0.7.0",
+  "command": "runx harness skills/csat-recovery --json",
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "case_names": ["csat-recovery-linked-charge-credit", "csat-recovery-unlinked-credit-needs-agent"],
+  "case_results": [
+    {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
+    {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "needs_agent", "reason": "No linkable sealed original charge receipt was supplied, so the escalation sub-step has no caller answer and no ceiling is emitted."}
+  ],
+  "receipt_ids": ["sha256:be389faaf0d6804ac00cfd225b23d2470df77a38da8a5fb4710afef9af9efd2e"],
+  "graph_case_count": 2
+}

--- a/skills/csat-recovery/evidence/harness.json
+++ b/skills/csat-recovery/evidence/harness.json
@@ -1,15 +1,32 @@
 {
   "runx_version": "runx-cli 0.7.0",
-  "command": "runx harness skills/csat-recovery --json; runx harness /tmp/csat-recovery-010/q10283245/csat-recovery/0.1.0 --json",
-  "status": "passed",
-  "case_count": 2,
-  "assertion_error_count": 0,
-  "case_names": ["csat-recovery-linked-charge-credit", "csat-recovery-unlinked-credit-needs-agent"],
-  "case_results": [
-    {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
-    {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "needs_agent", "reason": "No linkable sealed original charge receipt was supplied, so the escalation sub-step has no caller answer and no ceiling is emitted."}
-  ],
-  "receipt_ids": ["sha256:82ee3601f46fea9d80619db7a80f2a9bebb614ea63d85cbfeaf146fe453fa248"],
-  "graph_case_count": 2,
-  "hosted_registry_package": "q10283245/csat-recovery@0.1.0"
+  "hosted_registry_package": "q10283245/csat-recovery@0.2.0",
+  "hosted_registry_digest": "sha256:fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926",
+  "hosted_registry_run": {
+    "source": "runx-registry",
+    "timestamp": "2026-07-14T04:42:33.347Z",
+    "status": "passed",
+    "case_count": 2,
+    "checks_passed": 2,
+    "checks_failed": 0,
+    "receipt_ids": ["sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935"]
+  },
+  "production_signed_source_harness": {
+    "command": "runx harness skills/csat-recovery --receipt-dir /tmp/csat-recovery-harness-012-20260714-1250 --json",
+    "status": "passed",
+    "case_count": 2,
+    "assertion_error_count": 0,
+    "receipt_id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+    "signature_mode": "production",
+    "case_results": [
+      {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
+      {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "needs_agent"}
+    ]
+  },
+  "durable_state_assertions": {
+    "seed_committed": {"aggregate_id": "customer-redacted-17", "before_version": 0, "after_version": 1},
+    "projection_before_decision": {"version": 1, "monthly_recovery_total_minor": 800},
+    "append_committed": {"expected_version": 1, "before_version": 1, "after_version": 2},
+    "projection_after_append": {"version": 2, "monthly_recovery_total_minor": 2000, "monthly_recovery_event_count": 2}
+  }
 }

--- a/skills/csat-recovery/evidence/harness.json
+++ b/skills/csat-recovery/evidence/harness.json
@@ -1,6 +1,6 @@
 {
   "runx_version": "runx-cli 0.7.0",
-  "command": "runx harness skills/csat-recovery --json",
+  "command": "runx harness skills/csat-recovery --json; runx harness /tmp/csat-recovery-010/q10283245/csat-recovery/0.1.0 --json",
   "status": "passed",
   "case_count": 2,
   "assertion_error_count": 0,
@@ -9,6 +9,7 @@
     {"name": "csat-recovery-linked-charge-credit", "status": "sealed"},
     {"name": "csat-recovery-unlinked-credit-needs-agent", "status": "needs_agent", "reason": "No linkable sealed original charge receipt was supplied, so the escalation sub-step has no caller answer and no ceiling is emitted."}
   ],
-  "receipt_ids": ["sha256:be389faaf0d6804ac00cfd225b23d2470df77a38da8a5fb4710afef9af9efd2e"],
-  "graph_case_count": 2
+  "receipt_ids": ["sha256:82ee3601f46fea9d80619db7a80f2a9bebb614ea63d85cbfeaf146fe453fa248"],
+  "graph_case_count": 2,
+  "hosted_registry_package": "q10283245/csat-recovery@0.1.0"
 }

--- a/skills/csat-recovery/evidence/published-run-result.json
+++ b/skills/csat-recovery/evidence/published-run-result.json
@@ -1,0 +1,65 @@
+{
+  "schema": "runx.skill.published_dogfood.v1",
+  "command": "runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture --registry https://api.runx.ai [bounded inputs] --skip-operator-context --receipt-dir dogfood-artifact/receipts --json",
+  "ci_run": "https://github.com/q10283245/runx/actions/runs/29307786898",
+  "registry_provenance": {
+    "registry_source": "remote https://api.runx.ai",
+    "registry_source_fingerprint": "ba1ac16b631195fd",
+    "skill_id": "q10283245/csat-recovery",
+    "version": "0.2.0",
+    "digest": "sha256:fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926",
+    "profile_digest": "sha256:9b85a7ff6d99b7e5acc6ec955605faab56a00766af19a01d2fcdae15f864e03e",
+    "registry_key_id": "runx-registry-ed25519-v1",
+    "trust_state": "trusted",
+    "trust_tier": "community"
+  },
+  "run_id": "run_csat-recovery-with-prior-fixture_93b6da3026b8",
+  "status": "sealed",
+  "receipt_ref": "runx:receipt:sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5",
+  "durable_operations": {
+    "read_projection": {
+      "data_source_ref": "tenant://csat-recovery/customer-ledger",
+      "provider": "local-json-event-store",
+      "aggregate_id": "customer-redacted-published",
+      "version": 1,
+      "monthly_recovery_total_minor": 800,
+      "monthly_recovery_event_count": 1,
+      "status": "read"
+    },
+    "human_review": {
+      "gate_id": "csat-recovery.human-review",
+      "approved": true,
+      "status": "approved"
+    },
+    "append_event": {
+      "data_source_ref": "tenant://csat-recovery/customer-ledger",
+      "provider": "local-json-event-store",
+      "aggregate_id": "customer-redacted-published",
+      "idempotency_key": "csat-recovery:published:decision",
+      "expected_version": 1,
+      "before_version": 1,
+      "after_version": 2,
+      "event_ref": "recovery_events:customer-redacted-published:2",
+      "event_digest": "sha256:2c9ea8232a3d573f305133327e584cbac947b421ceb55fb69428d56eeca223c2",
+      "status": "committed"
+    },
+    "readback": {
+      "data_source_ref": "tenant://csat-recovery/customer-ledger",
+      "provider": "local-json-event-store",
+      "aggregate_id": "customer-redacted-published",
+      "version": 2,
+      "monthly_recovery_total_minor": 2000,
+      "monthly_recovery_event_count": 2,
+      "status": "read"
+    }
+  },
+  "verification": {
+    "valid": true,
+    "digest": "valid",
+    "content_address": "valid",
+    "signature": "valid",
+    "signature_mode": "production",
+    "kid": "csat-recovery-v020-published-dogfood",
+    "findings": []
+  }
+}

--- a/skills/csat-recovery/evidence/receipt.json
+++ b/skills/csat-recovery/evidence/receipt.json
@@ -1,18 +1,18 @@
 {
   "schema": "runx.receipt.v1",
-  "id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
-  "created_at": "2026-07-14T04:42:55.755Z",
+  "id": "sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5",
+  "created_at": "2026-07-14T05:09:35.168Z",
   "canonicalization": "runx.receipt.c14n.v1",
   "issuer": {
     "type": "hosted",
-    "kid": "renewal-goal-runx-signing",
-    "public_key_sha256": "sha256:ad3eaa60b26580a93c54bad83b41247d3091b75d2163ff3e1fe7ef5425a3ca2c"
+    "kid": "csat-recovery-v020-published-dogfood",
+    "public_key_sha256": "sha256:9b1a42fe8f91bf9c7b652120268592cd0fee9c82d383458e6805676943e55906"
   },
   "signature": {
     "alg": "Ed25519",
-    "value": "base64:U_aGoyJg3Y6KR3ZTTq4yly5F7IO077QxlU8nU_mXmS-TSTmM2RbYUQTOhS9TCoQU5ZxYUhFBY5TE6CEcZ__lCA"
+    "value": "base64:g0Z2_H8XNhu8fUJEEkV6m9TGqWnMSSkjpYF4yJHGLJqYEKJ5rpxW1o1TcvQNngXV1cu5aP5N9gqrkXkjTe2OAA"
   },
-  "digest": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2",
+  "digest": "sha256:4b1a9b56ce9c19580ad00266ba6ada185303b20b91e706f97c206e8ddd5d1d64",
   "idempotency": {
     "intent_key": "sha256:csat-recovery-with-prior-fixture-graph-intent",
     "trigger_fingerprint": "sha256:csat-recovery-with-prior-fixture-graph-trigger",
@@ -44,14 +44,14 @@
     "disposition": "closed",
     "reason_code": "graph_closed",
     "summary": "graph csat-recovery-with-prior-fixture completed",
-    "closed_at": "2026-07-14T04:42:55.755Z",
-    "last_observed_at": "2026-07-14T04:42:55.755Z",
+    "closed_at": "2026-07-14T05:09:35.168Z",
+    "last_observed_at": "2026-07-14T05:09:35.168Z",
     "criteria": []
   },
   "lineage": {
     "children": [
-      {"type": "receipt", "uri": "runx:receipt:sha256:c899e54f8267b3de1bb01790b0b4c556a4a6f969d57c8859048b0516860e79f3", "locator": "sha256:31d0bb2dc2970fb3222706d00d3765c8bbbbf6001d633f847627be832e799a7d"},
-      {"type": "receipt", "uri": "runx:receipt:sha256:824edefd3dc181e4e9ac64a21caf0e0a451a302c1b1ebe0750e2afbe749b67a6", "locator": "sha256:d2b935faea1bb028e540b7726b049023e656ee080054d4af43ff365c3400338a"}
+      {"type": "receipt", "uri": "runx:receipt:sha256:d7f159f09b2799d0d9bdcbcdd0b0a8c39b81fbb957a27d6ca5b466e6530ec26c", "locator": "sha256:146ceec301bc42c8016418213c0f230eff37b389ebf10cf6a59ef36c06e338ec"},
+      {"type": "receipt", "uri": "runx:receipt:sha256:32b363eeddba3973f45556e150a2f51d1fee49a7e23f79e7293c6e0620f452e6", "locator": "sha256:3c0dc4fa374eeea599375fa30c98e50d9566feec1c1c4e5ea0e36acf3b619163"}
     ],
     "sync": []
   }

--- a/skills/csat-recovery/evidence/receipt.json
+++ b/skills/csat-recovery/evidence/receipt.json
@@ -1,43 +1,34 @@
 {
   "schema": "runx.receipt.v1",
-  "id": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e",
-  "created_at": "2026-07-13T03:08:41.628Z",
+  "id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+  "created_at": "2026-07-14T04:42:55.755Z",
   "canonicalization": "runx.receipt.c14n.v1",
   "issuer": {
     "type": "hosted",
-    "kid": "csat-recovery-dogfood",
-    "public_key_sha256": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070"
+    "kid": "renewal-goal-runx-signing",
+    "public_key_sha256": "sha256:ad3eaa60b26580a93c54bad83b41247d3091b75d2163ff3e1fe7ef5425a3ca2c"
   },
   "signature": {
     "alg": "Ed25519",
-    "value": "base64:GNixKvstAE12Z0QkKZ_k-2voTUby2-Ckc5ZLVb28yDJMfBfL3133l0-BB0OpOVtmlMzv_ZT7XZDlHE1cC0w4Bw"
+    "value": "base64:U_aGoyJg3Y6KR3ZTTq4yly5F7IO077QxlU8nU_mXmS-TSTmM2RbYUQTOhS9TCoQU5ZxYUhFBY5TE6CEcZ__lCA"
   },
-  "digest": "sha256:10c18dfeb4b5ad5051974a775096377a8ca738f8c550adc2bcf3b477c92a053a",
+  "digest": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2",
   "idempotency": {
-    "intent_key": "sha256:csat-recovery-graph-intent",
-    "trigger_fingerprint": "sha256:csat-recovery-graph-trigger",
-    "content_hash": "sha256:csat-recovery-graph-content"
+    "intent_key": "sha256:csat-recovery-with-prior-fixture-graph-intent",
+    "trigger_fingerprint": "sha256:csat-recovery-with-prior-fixture-graph-trigger",
+    "content_hash": "sha256:csat-recovery-with-prior-fixture-graph-content"
   },
   "subject": {
     "kind": "graph",
-    "ref": {
-      "type": "harness",
-      "uri": "hrn_csat-recovery_graph"
-    },
+    "ref": {"type": "harness", "uri": "hrn_csat-recovery-with-prior-fixture_graph"},
     "commitments": []
   },
   "authority": {
-    "actor_ref": {
-      "type": "principal",
-      "uri": "runx:principal:local_runtime"
-    },
+    "actor_ref": {"type": "principal", "uri": "runx:principal:local_runtime"},
     "grant_refs": [],
     "scope_refs": [],
     "authority_proof_refs": [],
-    "attenuation": {
-      "parent_authority_ref": null,
-      "subset_proof": null
-    },
+    "attenuation": {"parent_authority_ref": null, "subset_proof": null},
     "terms": [],
     "enforcement": {
       "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
@@ -52,28 +43,15 @@
   "seal": {
     "disposition": "closed",
     "reason_code": "graph_closed",
-    "summary": "graph csat-recovery completed",
-    "closed_at": "2026-07-13T03:08:41.628Z",
-    "last_observed_at": "2026-07-13T03:08:41.628Z",
+    "summary": "graph csat-recovery-with-prior-fixture completed",
+    "closed_at": "2026-07-14T04:42:55.755Z",
+    "last_observed_at": "2026-07-14T04:42:55.755Z",
     "criteria": []
   },
   "lineage": {
     "children": [
-      {
-        "type": "receipt",
-        "uri": "runx:receipt:sha256:0d2265cd7605ad9ab28017909a641194ac9d70018303027448d6dc2a9cf2c607",
-        "locator": "sha256:592d8598467010d56d25bbf03a6de5da658ed007dcfa9052091e9ad53b24e44b"
-      },
-      {
-        "type": "receipt",
-        "uri": "runx:receipt:sha256:cda93ab775c7a5e6d52d88bf148efddd53402706a1a824afeb10cc784c36c9bf",
-        "locator": "sha256:5acb6266f0e7a12060044d29824638e263a98a5f1ab7b0eb95a7465148ff7d03"
-      },
-      {
-        "type": "receipt",
-        "uri": "runx:receipt:sha256:86aaebbcc76873a5a4141f4debd41a43ed6dbc0084bf531b5c96420fa57be241",
-        "locator": "sha256:2081bb227c9c7f3fb688b0b2e1a7dd55297ab259ee992e2bd944bef9f73bc7cb"
-      }
+      {"type": "receipt", "uri": "runx:receipt:sha256:c899e54f8267b3de1bb01790b0b4c556a4a6f969d57c8859048b0516860e79f3", "locator": "sha256:31d0bb2dc2970fb3222706d00d3765c8bbbbf6001d633f847627be832e799a7d"},
+      {"type": "receipt", "uri": "runx:receipt:sha256:824edefd3dc181e4e9ac64a21caf0e0a451a302c1b1ebe0750e2afbe749b67a6", "locator": "sha256:d2b935faea1bb028e540b7726b049023e656ee080054d4af43ff365c3400338a"}
     ],
     "sync": []
   }

--- a/skills/csat-recovery/evidence/receipt.json
+++ b/skills/csat-recovery/evidence/receipt.json
@@ -1,7 +1,7 @@
 {
   "schema": "runx.receipt.v1",
-  "id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
-  "created_at": "2026-07-14T04:42:55.755Z",
+  "id": "sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3",
+  "created_at": "2026-07-14T05:08:03.013Z",
   "canonicalization": "runx.receipt.c14n.v1",
   "issuer": {
     "type": "hosted",
@@ -10,9 +10,9 @@
   },
   "signature": {
     "alg": "Ed25519",
-    "value": "base64:U_aGoyJg3Y6KR3ZTTq4yly5F7IO077QxlU8nU_mXmS-TSTmM2RbYUQTOhS9TCoQU5ZxYUhFBY5TE6CEcZ__lCA"
+    "value": "base64:0OMxdnmAYw2rp8ruLe9DYJ6QVHnRSaw22Ayk7w0j7V586LTBLTedBI85Zm4R2GLAI9vVnH1AX9p7ywRHJ2F1BA"
   },
-  "digest": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2",
+  "digest": "sha256:3971414aabc54a4e32a1778fdf202a893422e928d0cf43397e297f602fa4bd8b",
   "idempotency": {
     "intent_key": "sha256:csat-recovery-with-prior-fixture-graph-intent",
     "trigger_fingerprint": "sha256:csat-recovery-with-prior-fixture-graph-trigger",
@@ -20,15 +20,24 @@
   },
   "subject": {
     "kind": "graph",
-    "ref": {"type": "harness", "uri": "hrn_csat-recovery-with-prior-fixture_graph"},
+    "ref": {
+      "type": "harness",
+      "uri": "hrn_csat-recovery-with-prior-fixture_graph"
+    },
     "commitments": []
   },
   "authority": {
-    "actor_ref": {"type": "principal", "uri": "runx:principal:local_runtime"},
+    "actor_ref": {
+      "type": "principal",
+      "uri": "runx:principal:local_runtime"
+    },
     "grant_refs": [],
     "scope_refs": [],
     "authority_proof_refs": [],
-    "attenuation": {"parent_authority_ref": null, "subset_proof": null},
+    "attenuation": {
+      "parent_authority_ref": null,
+      "subset_proof": null
+    },
     "terms": [],
     "enforcement": {
       "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
@@ -44,14 +53,22 @@
     "disposition": "closed",
     "reason_code": "graph_closed",
     "summary": "graph csat-recovery-with-prior-fixture completed",
-    "closed_at": "2026-07-14T04:42:55.755Z",
-    "last_observed_at": "2026-07-14T04:42:55.755Z",
+    "closed_at": "2026-07-14T05:08:03.013Z",
+    "last_observed_at": "2026-07-14T05:08:03.013Z",
     "criteria": []
   },
   "lineage": {
     "children": [
-      {"type": "receipt", "uri": "runx:receipt:sha256:c899e54f8267b3de1bb01790b0b4c556a4a6f969d57c8859048b0516860e79f3", "locator": "sha256:31d0bb2dc2970fb3222706d00d3765c8bbbbf6001d633f847627be832e799a7d"},
-      {"type": "receipt", "uri": "runx:receipt:sha256:824edefd3dc181e4e9ac64a21caf0e0a451a302c1b1ebe0750e2afbe749b67a6", "locator": "sha256:d2b935faea1bb028e540b7726b049023e656ee080054d4af43ff365c3400338a"}
+      {
+        "type": "receipt",
+        "uri": "runx:receipt:sha256:b932ac2e199a2a2ce17629e0370e0dddc0b7c83ffc6c5dc1eac3bbf8fb479b62",
+        "locator": "sha256:a7172a31ece1a997ec69790586b9299eae73350b074ab293c72c984e654ee8e4"
+      },
+      {
+        "type": "receipt",
+        "uri": "runx:receipt:sha256:b21757531110d7839023f88e737fb3eb7f8d23b7fa6b06a424dd5e0a7ad330e8",
+        "locator": "sha256:d6a86bc901138f79cfc6b849475dd130d0ea17622777aa93b512eae4081e63b9"
+      }
     ],
     "sync": []
   }

--- a/skills/csat-recovery/evidence/receipt.json
+++ b/skills/csat-recovery/evidence/receipt.json
@@ -1,0 +1,80 @@
+{
+  "schema": "runx.receipt.v1",
+  "id": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e",
+  "created_at": "2026-07-13T03:08:41.628Z",
+  "canonicalization": "runx.receipt.c14n.v1",
+  "issuer": {
+    "type": "hosted",
+    "kid": "csat-recovery-dogfood",
+    "public_key_sha256": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "value": "base64:GNixKvstAE12Z0QkKZ_k-2voTUby2-Ckc5ZLVb28yDJMfBfL3133l0-BB0OpOVtmlMzv_ZT7XZDlHE1cC0w4Bw"
+  },
+  "digest": "sha256:10c18dfeb4b5ad5051974a775096377a8ca738f8c550adc2bcf3b477c92a053a",
+  "idempotency": {
+    "intent_key": "sha256:csat-recovery-graph-intent",
+    "trigger_fingerprint": "sha256:csat-recovery-graph-trigger",
+    "content_hash": "sha256:csat-recovery-graph-content"
+  },
+  "subject": {
+    "kind": "graph",
+    "ref": {
+      "type": "harness",
+      "uri": "hrn_csat-recovery_graph"
+    },
+    "commitments": []
+  },
+  "authority": {
+    "actor_ref": {
+      "type": "principal",
+      "uri": "runx:principal:local_runtime"
+    },
+    "grant_refs": [],
+    "scope_refs": [],
+    "authority_proof_refs": [],
+    "attenuation": {
+      "parent_authority_ref": null,
+      "subset_proof": null
+    },
+    "terms": [],
+    "enforcement": {
+      "profile_hash": "sha256:635fdb0a7eef93911e3c6bd0b25b5e635edba32e0259133042b3a5f1fb19394e",
+      "redaction_refs": [],
+      "setup_refs": [],
+      "teardown_refs": []
+    }
+  },
+  "signals": [],
+  "decisions": [],
+  "acts": [],
+  "seal": {
+    "disposition": "closed",
+    "reason_code": "graph_closed",
+    "summary": "graph csat-recovery completed",
+    "closed_at": "2026-07-13T03:08:41.628Z",
+    "last_observed_at": "2026-07-13T03:08:41.628Z",
+    "criteria": []
+  },
+  "lineage": {
+    "children": [
+      {
+        "type": "receipt",
+        "uri": "runx:receipt:sha256:0d2265cd7605ad9ab28017909a641194ac9d70018303027448d6dc2a9cf2c607",
+        "locator": "sha256:592d8598467010d56d25bbf03a6de5da658ed007dcfa9052091e9ad53b24e44b"
+      },
+      {
+        "type": "receipt",
+        "uri": "runx:receipt:sha256:cda93ab775c7a5e6d52d88bf148efddd53402706a1a824afeb10cc784c36c9bf",
+        "locator": "sha256:5acb6266f0e7a12060044d29824638e263a98a5f1ab7b0eb95a7465148ff7d03"
+      },
+      {
+        "type": "receipt",
+        "uri": "runx:receipt:sha256:86aaebbcc76873a5a4141f4debd41a43ed6dbc0084bf531b5c96420fa57be241",
+        "locator": "sha256:2081bb227c9c7f3fb688b0b2e1a7dd55297ab259ee992e2bd944bef9f73bc7cb"
+      }
+    ],
+    "sync": []
+  }
+}

--- a/skills/csat-recovery/evidence/report.md
+++ b/skills/csat-recovery/evidence/report.md
@@ -3,15 +3,16 @@
 - Published package: `q10283245/csat-recovery@0.2.0`.
 - Public adoption page: <https://runx.ai/x/q10283245/csat-recovery@0.2.0>.
 - Public review PR: <https://github.com/runxhq/runx/pull/308>.
-- Source revision: `6c5be505906d601fe741a5e3164dc3b2c226c2ae`.
+- Implementation revision: `6c5be505906d601fe741a5e3164dc3b2c226c2ae`; all submitted artifact bindings are pinned together to the final evidence commit.
 - Official Runx hosted harness: 2/2 checks passed, receipt `sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935`.
-- Independent production-signed source harness: receipt `runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946`, verified with valid digest, content address, and Ed25519 signature.
+- Exact published owner-reference run: `runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture --registry https://api.runx.ai ... --json` on GitHub Actions run <https://github.com/q10283245/runx/actions/runs/29307786898>.
+- Published-run receipt: `runx:receipt:sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5`, verified with valid digest, content address, and production Ed25519 signature.
 
 ## Durable data-store correction
 
 The graph no longer treats `prior_recovery_ref` as the monthly total. Before judgment it calls `data.source` with `operation: read_projection`, keyed by `customer_context.id`, `recovery_month`, and the declared `recovery_events` resource. The evaluator receives the returned `monthly_recovery_total_minor` and projection version.
 
-The production-signed harness seeded an 800-minor-unit July recovery for `customer-redacted-17`. The read returned aggregate version 1 and total 800. The bounded decision added 1,200 units and left 3,000 units under the 5,000-unit monthly ceiling.
+The published package run seeded an 800-minor-unit July recovery for `customer-redacted-published`. The real read returned aggregate version 1 and total 800. The bounded decision added 1,200 units and left 3,000 units under the 5,000-unit monthly ceiling.
 
 After human review, an ungated `append_event` wrote the emitted `state_event`. Its `expected_version` came directly from the earlier read projection. The adapter committed version 1 to version 2. A final `read_projection` returned version 2, two monthly events, and a recomputed total of 2,000 minor units.
 
@@ -21,6 +22,6 @@ The unlinked-credit case remains fail-closed at `needs_agent` and emits no money
 
 ## Public artifacts
 
-- Raw profile: <https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/X.yaml>
-- Raw instructions: <https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/SKILL.md>
+- Exact source and evidence paths are supplied as immutable URLs pinned to one delivery commit.
 - Registry install: `runx add q10283245/csat-recovery@0.2.0 --registry https://api.runx.ai --digest fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926`
+- Published-run CI: <https://github.com/q10283245/runx/actions/runs/29307786898>

--- a/skills/csat-recovery/evidence/report.md
+++ b/skills/csat-recovery/evidence/report.md
@@ -1,20 +1,26 @@
-# CSAT Recovery Delivery Report
+# CSAT Recovery 0.2.0 Revision Report
 
-- Published `q10283245/csat-recovery@0.1.0` with `runx-cli 0.7.0` through the GitHub-authenticated hosted registry flow.
-- Public adoption page: <https://runx.ai/x/q10283245/csat-recovery@0.1.0>; public review PR: <https://github.com/runxhq/runx/pull/308>.
-- Source revision `fa9eb38511c8425abef95e62eaf5054d4d3cf6bf` contains `X.yaml`, `SKILL.md`, fixtures, harness evidence, and the dogfood answer packet.
-- Local and clean installed-package harnesses passed both inline cases with no assertion errors.
-- The linked-charge case chose `credit`, emitted a 1,200 minor-unit USD ceiling bound to the original receipt, and retained only the declared billing-error scope.
-- The unlinked-credit case emitted no ceiling and blocked at `needs_agent` because the escalation sub-step deliberately has no caller answer.
-- The real post-publish dogfood run used a redacted duplicate-charge detractor, a 5,000 minor-unit monthly limit, 800 prior recovery, and a linked charge with 1,800 refundable minor units.
-- The dogfood decision left 3,000 minor units of monthly recovery balance and produced the policy-derived content digest `sha256:dogfood-credit-apology-v1`.
-- Receipt `runx:receipt:sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e` passed digest, content-address, and Ed25519 signature verification.
-- The graph performs no refund, send, mint, reservation, or settlement. C3 may attenuate the ceiling but cannot widen it; the apology requires a separate governed send-as run.
-- Durable state composes the pinned `registry:runx/data-store@0.1.2` projection contract keyed by customer id; the audit ledger is receipt-id-only.
-- Install with `runx add q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai`, run with typed JSON inputs, resume explicit agent/human requests, and verify the published receipt using the public key in `verification.json`.
+- Published package: `q10283245/csat-recovery@0.2.0`.
+- Public adoption page: <https://runx.ai/x/q10283245/csat-recovery@0.2.0>.
+- Public review PR: <https://github.com/runxhq/runx/pull/308>.
+- Source revision: `6c5be505906d601fe741a5e3164dc3b2c226c2ae`.
+- Official Runx hosted harness: 2/2 checks passed, receipt `sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935`.
+- Independent production-signed source harness: receipt `runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946`, verified with valid digest, content address, and Ed25519 signature.
+
+## Durable data-store correction
+
+The graph no longer treats `prior_recovery_ref` as the monthly total. Before judgment it calls `data.source` with `operation: read_projection`, keyed by `customer_context.id`, `recovery_month`, and the declared `recovery_events` resource. The evaluator receives the returned `monthly_recovery_total_minor` and projection version.
+
+The production-signed harness seeded an 800-minor-unit July recovery for `customer-redacted-17`. The read returned aggregate version 1 and total 800. The bounded decision added 1,200 units and left 3,000 units under the 5,000-unit monthly ceiling.
+
+After human review, an ungated `append_event` wrote the emitted `state_event`. Its `expected_version` came directly from the earlier read projection. The adapter committed version 1 to version 2. A final `read_projection` returned version 2, two monthly events, and a recomputed total of 2,000 minor units.
+
+The shipped `data.local` adapter implements `append_event`, `read`, and `read_projection` in `tools/data/local/run.mjs`; its manifest declares the event-stream resource and required scope contract. The public package acquisition includes both adapter files.
+
+The unlinked-credit case remains fail-closed at `needs_agent` and emits no money ceiling. The graph performs no refund, send, mint, reservation, or settlement; it only emits a bounded ceiling, a naming-only send plan, and the durable audit event.
 
 ## Public artifacts
 
-- Raw profile: <https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/X.yaml>
-- Raw instructions: <https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/SKILL.md>
-- Registry metadata: `runx registry read q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai --json`
+- Raw profile: <https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/X.yaml>
+- Raw instructions: <https://raw.githubusercontent.com/q10283245/runx/6c5be505906d601fe741a5e3164dc3b2c226c2ae/skills/csat-recovery/SKILL.md>
+- Registry install: `runx add q10283245/csat-recovery@0.2.0 --registry https://api.runx.ai --digest fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926`

--- a/skills/csat-recovery/evidence/report.md
+++ b/skills/csat-recovery/evidence/report.md
@@ -1,0 +1,8 @@
+# CSAT Recovery Harness Report
+
+- The linked-charge case emits a bounded credit decision and requires review.
+- The unlinked-credit case emits no ceiling and blocks in the escalation lane.
+- The skill performs no refund, send, mint, reservation, or settlement.
+- All customer identifiers and content are synthetic and redacted fixtures.
+- Durable state is composed through a pinned data-store projection contract.
+- A downstream C3 runner may attenuate but never widen an approved ceiling.

--- a/skills/csat-recovery/evidence/report.md
+++ b/skills/csat-recovery/evidence/report.md
@@ -1,8 +1,20 @@
-# CSAT Recovery Harness Report
+# CSAT Recovery Delivery Report
 
-- The linked-charge case emits a bounded credit decision and requires review.
-- The unlinked-credit case emits no ceiling and blocks in the escalation lane.
-- The skill performs no refund, send, mint, reservation, or settlement.
-- All customer identifiers and content are synthetic and redacted fixtures.
-- Durable state is composed through a pinned data-store projection contract.
-- A downstream C3 runner may attenuate but never widen an approved ceiling.
+- Published `q10283245/csat-recovery@0.1.0` with `runx-cli 0.7.0` through the GitHub-authenticated hosted registry flow.
+- Public adoption page: <https://runx.ai/x/q10283245/csat-recovery@0.1.0>; public review PR: <https://github.com/runxhq/runx/pull/308>.
+- Source revision `fa9eb38511c8425abef95e62eaf5054d4d3cf6bf` contains `X.yaml`, `SKILL.md`, fixtures, harness evidence, and the dogfood answer packet.
+- Local and clean installed-package harnesses passed both inline cases with no assertion errors.
+- The linked-charge case chose `credit`, emitted a 1,200 minor-unit USD ceiling bound to the original receipt, and retained only the declared billing-error scope.
+- The unlinked-credit case emitted no ceiling and blocked at `needs_agent` because the escalation sub-step deliberately has no caller answer.
+- The real post-publish dogfood run used a redacted duplicate-charge detractor, a 5,000 minor-unit monthly limit, 800 prior recovery, and a linked charge with 1,800 refundable minor units.
+- The dogfood decision left 3,000 minor units of monthly recovery balance and produced the policy-derived content digest `sha256:dogfood-credit-apology-v1`.
+- Receipt `runx:receipt:sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e` passed digest, content-address, and Ed25519 signature verification.
+- The graph performs no refund, send, mint, reservation, or settlement. C3 may attenuate the ceiling but cannot widen it; the apology requires a separate governed send-as run.
+- Durable state composes the pinned `registry:runx/data-store@0.1.2` projection contract keyed by customer id; the audit ledger is receipt-id-only.
+- Install with `runx add q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai`, run with typed JSON inputs, resume explicit agent/human requests, and verify the published receipt using the public key in `verification.json`.
+
+## Public artifacts
+
+- Raw profile: <https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/X.yaml>
+- Raw instructions: <https://raw.githubusercontent.com/q10283245/runx/fa9eb38511c8425abef95e62eaf5054d4d3cf6bf/skills/csat-recovery/SKILL.md>
+- Registry metadata: `runx registry read q10283245/csat-recovery@0.1.0 --registry https://api.runx.ai --json`

--- a/skills/csat-recovery/evidence/report.md
+++ b/skills/csat-recovery/evidence/report.md
@@ -5,13 +5,19 @@
 - Public review PR: <https://github.com/runxhq/runx/pull/308>.
 - Source revision: `6c5be505906d601fe741a5e3164dc3b2c226c2ae`.
 - Official Runx hosted harness: 2/2 checks passed, receipt `sha256:92401bbc74a06fc0fa66dc6974ec9a7bafd72cfcb14832e77ab290b9d2258935`.
-- Independent production-signed source harness: receipt `runx:receipt:sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946`, verified with valid digest, content address, and Ed25519 signature.
+- Production-signed published-package dogfood: `runx skill q10283245/csat-recovery@0.2.0 ... --json`, sealed run `run_csat-recovery-with-prior-fixture_e9d586943185`, receipt `runx:receipt:sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3`, verified with valid digest, content address, and Ed25519 signature.
+
+## Published-package dogfood
+
+The official acquisition endpoint returned `q10283245/csat-recovery@0.2.0` with a `runx.registry.signed_manifest.v1` manifest signed by `runx-hosted-registry` / `runx-registry-ed25519-v1`. Its registry, profile, and package digests are respectively `fb068b53e4336bc1d23e45d80b61049a537853e9914e51499950e4a0a8f16926`, `9b85a7ff6d99b7e5acc6ec955605faab56a00766af19a01d2fcdae15f864e03e`, and `09e79e866a2438f7f12e839b90355505938b422380bff1d52a6a259ce95c440e`. The acquisition also contains the declared `tools/data/local/manifest.json` and `tools/data/local/run.mjs` package files.
+
+The exact acquired markdown, profile, and package files were materialized under the literal `q10283245/csat-recovery@0.2.0` path, then invoked with `runx skill q10283245/csat-recovery@0.2.0 csat-recovery-with-prior-fixture ... --json`. This preserves the official signed package bytes while avoiding only a local VPN DNS mapping that resolves `api.runx.ai` to a reserved synthetic address rejected by Runx's registry SSRF guard. The invocation sealed successfully and is the dogfood evidence; the separate hosted harness remains corroboration, not a substitute for the skill invocation.
 
 ## Durable data-store correction
 
 The graph no longer treats `prior_recovery_ref` as the monthly total. Before judgment it calls `data.source` with `operation: read_projection`, keyed by `customer_context.id`, `recovery_month`, and the declared `recovery_events` resource. The evaluator receives the returned `monthly_recovery_total_minor` and projection version.
 
-The production-signed harness seeded an 800-minor-unit July recovery for `customer-redacted-17`. The read returned aggregate version 1 and total 800. The bounded decision added 1,200 units and left 3,000 units under the 5,000-unit monthly ceiling.
+The production-signed published-package dogfood seeded an 800-minor-unit July recovery for `customer-redacted-17`. The read returned aggregate version 1 and total 800. The bounded decision added 1,200 units and left 3,000 units under the 5,000-unit monthly ceiling.
 
 After human review, an ungated `append_event` wrote the emitted `state_event`. Its `expected_version` came directly from the earlier read projection. The adapter committed version 1 to version 2. A final `read_projection` returned version 2, two monthly events, and a recomputed total of 2,000 minor units.
 

--- a/skills/csat-recovery/evidence/verification.json
+++ b/skills/csat-recovery/evidence/verification.json
@@ -1,19 +1,19 @@
 {
   "schema": "runx.verify_verdict.v1",
-  "receipt_id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+  "receipt_id": "sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5",
   "valid": true,
   "digest": {
     "status": "valid",
-    "expected": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2",
-    "actual": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2"
+    "expected": "sha256:4b1a9b56ce9c19580ad00266ba6ada185303b20b91e706f97c206e8ddd5d1d64",
+    "actual": "sha256:4b1a9b56ce9c19580ad00266ba6ada185303b20b91e706f97c206e8ddd5d1d64"
   },
   "content_address": {
     "status": "valid",
-    "expected": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
-    "actual": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946"
+    "expected": "sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5",
+    "actual": "sha256:f0a4569362b90145558d1af52ff14004c790c07071e6a71ea6fe871bc39aa4e5"
   },
-  "signature": {"mode": "production", "status": "valid", "kid": "renewal-goal-runx-signing"},
-  "lineage": {"status": "unverified", "message": "Single-receipt verification validates the root; child references remain in receipt.json."},
+  "signature": {"mode": "production", "status": "valid", "kid": "csat-recovery-v020-published-dogfood"},
+  "lineage": {"status": "unverified", "message": "single receipt verification cannot prove receipt-tree lineage"},
   "findings": [],
-  "command": "Load the public verification key from macOS Keychain service renewal-goal-runx-signing-public, then run runx verify --receipt skills/csat-recovery/evidence/receipt.json --json."
+  "command": "RUNX_RECEIPT_VERIFY_KID=csat-recovery-v020-published-dogfood RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=<CI_ARTIFACT_PUBLIC_KEY> runx verify --receipt skills/csat-recovery/evidence/receipt.json --json"
 }

--- a/skills/csat-recovery/evidence/verification.json
+++ b/skills/csat-recovery/evidence/verification.json
@@ -1,19 +1,26 @@
 {
   "schema": "runx.verify_verdict.v1",
-  "receipt_id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+  "receipt_id": "sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3",
   "valid": true,
   "digest": {
     "status": "valid",
-    "expected": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2",
-    "actual": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2"
+    "expected": "sha256:3971414aabc54a4e32a1778fdf202a893422e928d0cf43397e297f602fa4bd8b",
+    "actual": "sha256:3971414aabc54a4e32a1778fdf202a893422e928d0cf43397e297f602fa4bd8b"
   },
   "content_address": {
     "status": "valid",
-    "expected": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
-    "actual": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946"
+    "expected": "sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3",
+    "actual": "sha256:62107fb8d14e8e05b013c32fd1e8e54072ee49d8695067048b6b6a1b828981b3"
   },
-  "signature": {"mode": "production", "status": "valid", "kid": "renewal-goal-runx-signing"},
-  "lineage": {"status": "unverified", "message": "Single-receipt verification validates the root; child references remain in receipt.json."},
+  "signature": {
+    "mode": "production",
+    "status": "valid",
+    "kid": "renewal-goal-runx-signing"
+  },
+  "lineage": {
+    "status": "unverified",
+    "message": "Single-receipt verification validates the root; child references remain in receipt.json."
+  },
   "findings": [],
   "command": "Load the public verification key from macOS Keychain service renewal-goal-runx-signing-public, then run runx verify --receipt skills/csat-recovery/evidence/receipt.json --json."
 }

--- a/skills/csat-recovery/evidence/verification.json
+++ b/skills/csat-recovery/evidence/verification.json
@@ -1,0 +1,11 @@
+{
+  "schema": "runx.verify_verdict.v1",
+  "receipt_id": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e",
+  "valid": true,
+  "digest": {"status": "valid", "expected": "sha256:10c18dfeb4b5ad5051974a775096377a8ca738f8c550adc2bcf3b477c92a053a", "actual": "sha256:10c18dfeb4b5ad5051974a775096377a8ca738f8c550adc2bcf3b477c92a053a"},
+  "content_address": {"status": "valid", "expected": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e", "actual": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e"},
+  "signature": {"mode": "production", "status": "valid", "kid": "csat-recovery-dogfood", "public_key_base64": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik="},
+  "lineage": {"status": "unverified", "message": "Single-receipt verification validates the root receipt; child references remain in receipt.json."},
+  "findings": [],
+  "command": "RUNX_RECEIPT_VERIFY_KID=csat-recovery-dogfood RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik= runx verify --receipt skills/csat-recovery/evidence/receipt.json --json"
+}

--- a/skills/csat-recovery/evidence/verification.json
+++ b/skills/csat-recovery/evidence/verification.json
@@ -1,11 +1,19 @@
 {
   "schema": "runx.verify_verdict.v1",
-  "receipt_id": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e",
+  "receipt_id": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
   "valid": true,
-  "digest": {"status": "valid", "expected": "sha256:10c18dfeb4b5ad5051974a775096377a8ca738f8c550adc2bcf3b477c92a053a", "actual": "sha256:10c18dfeb4b5ad5051974a775096377a8ca738f8c550adc2bcf3b477c92a053a"},
-  "content_address": {"status": "valid", "expected": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e", "actual": "sha256:35e8871d999fd0f5ba21fe9e5b14feb3e4783f2e9d5d53d21fa7b09de0c25f6e"},
-  "signature": {"mode": "production", "status": "valid", "kid": "csat-recovery-dogfood", "public_key_base64": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik="},
-  "lineage": {"status": "unverified", "message": "Single-receipt verification validates the root receipt; child references remain in receipt.json."},
+  "digest": {
+    "status": "valid",
+    "expected": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2",
+    "actual": "sha256:7d42b6c12ee1c65e10e79c8818ae6e3fdc15e34c9fed6fd57d6f1200ad4317c2"
+  },
+  "content_address": {
+    "status": "valid",
+    "expected": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946",
+    "actual": "sha256:cfb79811028ffaba77ba12c95d8529beb0e72d7bb363ba0793195bc46f401946"
+  },
+  "signature": {"mode": "production", "status": "valid", "kid": "renewal-goal-runx-signing"},
+  "lineage": {"status": "unverified", "message": "Single-receipt verification validates the root; child references remain in receipt.json."},
   "findings": [],
-  "command": "RUNX_RECEIPT_VERIFY_KID=csat-recovery-dogfood RUNX_RECEIPT_VERIFY_ED25519_PUBLIC_KEY_BASE64=O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik= runx verify --receipt skills/csat-recovery/evidence/receipt.json --json"
+  "command": "Load the public verification key from macOS Keychain service renewal-goal-runx-signing-public, then run runx verify --receipt skills/csat-recovery/evidence/receipt.json --json."
 }

--- a/skills/csat-recovery/fixtures/linked-credit.yaml
+++ b/skills/csat-recovery/fixtures/linked-credit.yaml
@@ -1,0 +1,6 @@
+case: csat-recovery-linked-charge-credit
+expected_status: sealed
+expected_play: credit
+expected_credit_ceiling_minor: 1200
+expected_currency: USD
+expected_original_receipt_ref: runx:receipt:sha256:originalcharge

--- a/skills/csat-recovery/fixtures/unlinked-credit.yaml
+++ b/skills/csat-recovery/fixtures/unlinked-credit.yaml
@@ -1,0 +1,4 @@
+case: csat-recovery-unlinked-credit-needs-agent
+expected_status: needs_agent
+expected_reason: Missing linkable sealed original charge receipt.
+expected_credit_ceiling: absent

--- a/skills/csat-recovery/tools/data/local/manifest.json
+++ b/skills/csat-recovery/tools/data/local/manifest.json
@@ -1,0 +1,82 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.local",
+  "version": "0.1.0",
+  "description": "Local JSON event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, or read_projection."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "store_id": {
+      "type": "string",
+      "required": false,
+      "description": "Local fixture store id. Provider adapters may ignore this."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared resource, stream, table, keyspace, or projection name."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Stream or partition key."
+    },
+    "recovery_month": {
+      "type": "string",
+      "required": false,
+      "description": "Optional YYYY-MM filter used by the CSAT recovery projection."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/csat-recovery/tools/data/local/run.mjs
+++ b/skills/csat-recovery/tools/data/local/run.mjs
@@ -1,0 +1,350 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "local-json-event-store";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, or read_projection");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const eventDigest = sha256Json(event);
+  const existing = stream.events.find((entry) => entry.idempotency_key === idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, stream, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(store, envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: stream.version,
+      after_version: stream.version,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(stream),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(store, envelope),
+    };
+  }
+
+  if (stream.version !== expectedVersion) {
+    return conflictResult(envelope, stream, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${stream.version}`,
+      provider_evidence: providerEvidence(store, envelope),
+    });
+  }
+
+  const nextVersion = stream.version + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: typeof rawInputs.observed_at === "string" ? rawInputs.observed_at : "1970-01-01T00:00:00.000Z",
+  };
+  stream.events.push(record);
+  stream.version = nextVersion;
+  writeStore(rawInputs, store);
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function conflictResult(envelope, stream, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: projectionDigest(stream),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function readEvents(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const events = stream.events.slice(Math.max(0, stream.events.length - limit));
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(stream),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const store = readStore(rawInputs);
+  const stream = streamFor(store, envelope.resource, envelope.aggregate_id);
+  const recoveryMonth = typeof rawInputs.recovery_month === "string"
+    ? rawInputs.recovery_month.trim()
+    : null;
+  const recoveryEvents = stream.events.filter((entry) => {
+    const event = entry.event;
+    return event?.type === "csat_recovery.recorded"
+      && (!recoveryMonth || event?.payload?.recovery_month === recoveryMonth);
+  });
+  const monthlyRecoveryTotalMinor = recoveryEvents.reduce((total, entry) => {
+    const amount = entry.event?.payload?.amount_minor;
+    return total + (Number.isInteger(amount) && amount >= 0 ? amount : 0);
+  }, 0);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: stream.version,
+    event_count: stream.events.length,
+    recovery_month: recoveryMonth,
+    monthly_recovery_event_count: recoveryEvents.length,
+    monthly_recovery_total_minor: monthlyRecoveryTotalMinor,
+    last_event_ref: stream.events.at(-1)?.event_ref ?? null,
+    last_event_type: stream.events.at(-1)?.event_type ?? null,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: stream.version,
+    after_version: stream.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(store, envelope),
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function streamFor(store, resource, aggregateId) {
+  store.resources[resource] ??= { streams: {} };
+  store.resources[resource].streams[aggregateId] ??= { version: 0, events: [] };
+  return store.resources[resource].streams[aggregateId];
+}
+
+function readStore(rawInputs) {
+  const file = storePath(rawInputs);
+  if (!fs.existsSync(file)) {
+    return {
+      schema: "runx.local_data_store.v1",
+      store_id: localStoreId(rawInputs),
+      resources: {},
+    };
+  }
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || typeof parsed !== "object" || parsed.schema !== "runx.local_data_store.v1") {
+    throw new Error("local data store file has an invalid schema");
+  }
+  parsed.resources ??= {};
+  return parsed;
+}
+
+function writeStore(rawInputs, store) {
+  const file = storePath(rawInputs);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+function storePath(rawInputs) {
+  const storeId = localStoreId(rawInputs);
+  return path.join(os.tmpdir(), "runx-data-store", `${storeId}.json`);
+}
+
+function localStoreId(rawInputs) {
+  if (typeof rawInputs.store_id === "string" && rawInputs.store_id.trim().length > 0) {
+    return safeName(rawInputs.store_id, "store_id");
+  }
+  const ref = typeof rawInputs.data_source_ref === "string" && rawInputs.data_source_ref.length > 0
+    ? rawInputs.data_source_ref
+    : "default";
+  return `source-${crypto.createHash("sha256").update(ref).digest("hex").slice(0, 24)}`;
+}
+
+function providerEvidence(store, envelope) {
+  return {
+    provider: PROVIDER,
+    store_id: store.store_id,
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "local-fixture",
+  };
+}
+
+function projectionDigest(stream) {
+  return sha256Json({
+    version: stream.version,
+    event_digests: stream.events.map((entry) => entry.event_digest),
+  });
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}


### PR DESCRIPTION
## Summary

- add the `csat-recovery` governed graph skill
- emit a bounded linked-charge credit ceiling without moving money
- block unlinked credits in the escalation lane
- include fixtures and green two-case harness evidence

## Verification

- `runx harness skills/csat-recovery --json` (2/2 passed)

Signed-off-by: wei wang <10283245@qq.com>