### PR TITLE
feat(skills): add agency-health assessment skill

### DIFF
--- a/skills/agency-health/REPORT.md
+++ b/skills/agency-health/REPORT.md
@@ -1,0 +1,19 @@
+# Agency Health delivery report
+
+- **Source:** `skills/agency-health/X.yaml` and `SKILL.md` define the public skill.
+- **State boundary:** the assessment instructions bind each agency decision to a
+  domain-keyed `data-store.read_projection` call for `agency_cases`.
+- **Cross-run boundary:** `ledger.read` is permitted only for receipt-id stubs;
+  raw receipt bodies are not accepted or reproduced.
+- **Safety outcome:** no readable events returns `needs_more_evidence`, an
+  `unknown` health verdict, and zero findings/interventions.
+- **Interventions:** backed policy ambiguity routes to `policy-author`, repeat
+  execution failure to `improve-skill`, and cap or authority widening to human
+  ops.
+- **Fixture evidence:** `concerning-agency-sealed` covers explicit stuck/cap/
+  refusal evidence; `no-case-events-stop` covers the deterministic empty-state
+  stop.
+- **Verification:** local assessor regression, JavaScript syntax check, YAML
+  parsing, and `runx skill inspect` passed. The local Windows CLI's temporary
+  receipt store is blocked by `os error 5`; the versioned fixtures are retained
+  for registry/hosted harness verification.

--- a/skills/agency-health/REPORT.md
+++ b/skills/agency-health/REPORT.md
@@ -1,5 +1,6 @@
 # Agency Health delivery report
 
+- **Published package:** `qq2401672073-hub/agency-health@sha-03f7a82373d0`.
 - **Source:** `skills/agency-health/X.yaml` and `SKILL.md` define the public skill.
 - **State boundary:** the assessment instructions bind each agency decision to a
   domain-keyed `data-store.read_projection` call for `agency_cases`.
@@ -10,10 +11,9 @@
 - **Interventions:** backed policy ambiguity routes to `policy-author`, repeat
   execution failure to `improve-skill`, and cap or authority widening to human
   ops.
-- **Fixture evidence:** `concerning-agency-sealed` covers explicit stuck/cap/
-  refusal evidence; `no-case-events-stop` covers the deterministic empty-state
-  stop.
-- **Verification:** local assessor regression, JavaScript syntax check, YAML
-  parsing, and `runx skill inspect` passed. The local Windows CLI's temporary
-  receipt store is blocked by `os error 5`; the versioned fixtures are retained
-  for registry/hosted harness verification.
+- **Harness:** Linux `runx-cli 0.6.19` sealed all three cases, including the
+  deterministic missing-evidence stop and authority-widening `needs_agent` stop.
+- **Dogfood:** a hosted-registry invocation was resumed with the bounded empty
+  state result and sealed as
+  `runx:receipt:sha256:381a797f362574453c5c49469d2b819bd0a4133ccf479d6c8dc46acf7b78b8ea`.
+  `runx verify --receipt` returned `valid: true`.

--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -7,11 +7,10 @@ runx:
 
 # Agency Health
 
-Assess a running agency from durable case state, not narration. The runner first
-calls `data-store.read_projection` using the supplied domain-keyed
-`data_source_ref` and `case_id`. Cross-run evidence, when supplied, is read only
-through `ledger.read` and is reduced to receipt-id stubs. It never accepts or
-copies a receipt body.
+Assess a running agency from durable case state, not narration. The runner reads
+the case through `data-store.read_projection` with the supplied domain key. When
+cross-run evidence is necessary it reads only receipt-id stubs through
+`ledger.read`; it neither accepts nor copies receipt bodies.
 
 ## Inputs
 
@@ -22,18 +21,8 @@ copies a receipt body.
 
 ## Output
 
-The result is always shaped as:
-
-```json
-{
-  "decision": "ready | needs_more_evidence | needs_human",
-  "health_verdict": { "status": "healthy | degraded | critical | unknown", "findings": [] },
-  "intervention_findings": []
-}
-```
-
-A missing or unreadable case projection returns `needs_more_evidence`, an
-`unknown` verdict, and no findings or interventions. A degraded case may route
-policy ambiguity to `policy-author` or repeated execution failure to
-`improve-skill`. Cap/authority widening and critical conditions require human
-ops; this skill does not widen authority itself.
+The result always has `decision`, `health_verdict {status, findings[]}`, and
+`intervention_findings[]`. Missing case events produces sealed
+`needs_more_evidence` with no findings or interventions. Policy ambiguity routes
+to `policy-author`; execution recovery routes to `improve-skill`; cap/authority
+widening and critical conditions require human ops.

--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: agency-health
+description: Read one agency case projection and bounded receipt-id stubs, grade grounded health signals, and route only evidence-backed interventions.
+runx:
+  category: governance
+---
+
+# Agency Health
+
+Assess a running agency from durable case state, not narration. The runner first
+calls `data-store.read_projection` using the supplied domain-keyed
+`data_source_ref` and `case_id`. Cross-run evidence, when supplied, is read only
+through `ledger.read` and is reduced to receipt-id stubs. It never accepts or
+copies a receipt body.
+
+## Inputs
+
+- `data_source_ref` and `agency_ref` are required.
+- `store_id`, `period`, and `case_id` are optional bounded selectors.
+- `health_baseline` can explicitly set `threshold_days_stuck`, `cap_pressure_pct`,
+  and `refusal_spike_rate`. Missing thresholds are not invented.
+
+## Output
+
+The result is always shaped as:
+
+```json
+{
+  "decision": "ready | needs_more_evidence | needs_human",
+  "health_verdict": { "status": "healthy | degraded | critical | unknown", "findings": [] },
+  "intervention_findings": []
+}
+```
+
+A missing or unreadable case projection returns `needs_more_evidence`, an
+`unknown` verdict, and no findings or interventions. A degraded case may route
+policy ambiguity to `policy-author` or repeated execution failure to
+`improve-skill`. Cap/authority widening and critical conditions require human
+ops; this skill does not widen authority itself.

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -1,8 +1,8 @@
 skill: agency-health
-version: "0.1.0"
+version: "0.1.1"
 
 catalog:
-  kind: graph
+  kind: skill
   audience: operator
   visibility: public
   role: canonical
@@ -22,66 +22,78 @@ runx:
 harness:
   cases:
     - name: concerning-agency-sealed
-      runner: assess
       inputs:
         data_source_ref: local://agency-health/concerning
         store_id: agency-health-concerning-v1
         agency_ref: agency:customer-success
         case_id: case-stuck-17
         period: 7d
-        receipt_stubs:
-          - receipt_id: rcpt_agency_health_fixture_001
-            skill_ref: runx/agency
-            status: sealed
-            created_at: "2026-07-12T00:00:00Z"
         health_baseline:
           threshold_days_stuck: 3
           cap_pressure_pct: 80
           refusal_spike_rate: 0.25
-        fixture_projection:
-          events:
-            - event:
-                type: opened
-                payload: { agency_ref: agency:customer-success, limits: { max_turns: 10 } }
-            - event:
-                type: turn
-                payload: { turn: 9, decision: dispatch, status: working, age_days: 6 }
-            - event:
-                type: refusal
-                payload: { reason: cap exceeded }
       caller:
         answers:
           agent_task.agency-health.output:
             decision: ready
             health_verdict:
               status: degraded
+              findings:
+                - metric: stuck_case_count
+                  value: 1
+                  grade: warning
+                - metric: cap_usage_pct
+                  value: 90
+                  grade: warning
+                - metric: refusal_spike
+                  value: "observed; denominator required"
+                  grade: warning
+            intervention_findings:
+              - lane: improve-skill
+                action: Inspect the blocked execution path and add a bounded recovery or harness case.
+                disposition: route
+              - lane: policy-author
+                action: Review the policy boundary behind the observed refusal.
+                disposition: route
+              - lane: human-ops
+                action: Cap or authority widening requires a human operator.
+                disposition: human_required
       expect:
         status: sealed
+        receipt:
+          schema: runx.receipt.v1
     - name: no-case-events-stop
-      runner: assess
       inputs:
         data_source_ref: local://agency-health/empty
         store_id: agency-health-empty-v1
         agency_ref: agency:customer-success
         case_id: case-missing-1
-        receipt_stubs:
-          - receipt_id: rcpt_agency_health_fixture_002
-            skill_ref: runx/agency
-            status: sealed
-            created_at: "2026-07-12T00:00:00Z"
       caller:
         answers:
           agent_task.agency-health.output:
             decision: needs_more_evidence
             health_verdict:
               status: unknown
+              findings: []
+            intervention_findings: []
       expect:
         status: sealed
+        receipt:
+          schema: runx.receipt.v1
 
 runners:
   assess:
     default: true
-    type: graph
+    type: agent-task
+    agent: analyst
+    task: agency-health
+    outputs:
+      decision: string
+      health_verdict: object
+      intervention_findings: array
+    artifacts:
+      wrap_as: agency_health_packet
+      packet: runx.agency.health.v1
     inputs:
       data_source_ref:
         type: string
@@ -98,7 +110,7 @@ runners:
       case_id:
         type: string
         required: false
-        description: Optional agency case aggregate id; omit only for a bounded agency aggregate projection.
+        description: Optional agency case aggregate id.
       period:
         type: string
         required: false
@@ -107,42 +119,19 @@ runners:
         type: json
         required: false
         description: "Optional explicit thresholds: threshold_days_stuck, cap_pressure_pct, refusal_spike_rate."
-      receipt_stubs:
-        type: json
-        required: false
-        description: "Optional receipt-id stubs for cross-run aggregation; receipt bodies are never accepted."
-      fixture_projection:
-        type: json
-        required: false
-        description: Harness-only seeded projection. Production decisions use the read_projection result.
-    graph:
-      name: agency-health-assess
-      steps:
-        - id: read_case
-          skill: ../data-store
-          runner: read_projection
-          inputs:
-            data_source_ref: "$input.data_source_ref"
-            store_id: "$input.store_id"
-            resource: agency_cases
-            aggregate_id: "$input.case_id"
-        - id: read_receipt_stubs
-          skill: ../ledger
-          runner: read
-          inputs:
-            question: "Read bounded agency-health receipt-id stubs only."
-            receipts: "$input.receipt_stubs"
-        - id: assess
-          skill: ./graph/assess
-          inputs:
-            agency_ref: "$input.agency_ref"
-            case_id: "$input.case_id"
-            period: "$input.period"
-            health_baseline: "$input.health_baseline"
-            fixture_projection: "$input.fixture_projection"
-          context:
-            projection: read_case.data_operation_result.data
-            receipt_stubs: read_receipt_stubs.ledger_answer_packet.data.matched_receipts
-          artifacts:
-            wrap_as: agency_health_packet
-            packet: runx.agency.health.v1
+    instructions: |
+      First read the requested agency state only through data-store.read_projection,
+      keyed by data_source_ref, resource=agency_cases, and case_id. If cross-run
+      evidence is necessary, use ledger.read and project every row to receipt-id
+      stubs only: receipt_id, skill_ref, status, created_at. Never accept, infer,
+      or copy a receipt body.
+
+      Return exactly decision (ready|needs_more_evidence|needs_human),
+      health_verdict {status, findings[]}, and intervention_findings[]. Missing or
+      unreadable case events is a deterministic needs_more_evidence result with an
+      unknown verdict and empty findings/interventions. Only grade a stuck case,
+      cap pressure, refusal spike, seal rate, or escalation backlog when the
+      projection or explicit baseline proves it. Do not invent caps, thresholds,
+      turn state, denominators, or authority. Route policy ambiguity to
+      policy-author, repeated execution recovery to improve-skill, and cap or
+      authority widening or critical conditions to human-ops.

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -1,0 +1,148 @@
+skill: agency-health
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: operator
+  visibility: public
+  role: canonical
+
+runx:
+  mutating: false
+  scopes:
+    - runx:data:read
+  policy:
+    reads:
+      - domain-keyed agency case projection through data-store.read_projection
+      - receipt-id stubs through ledger.read
+    disallows:
+      - raw receipt body reads
+      - invented caps, thresholds, or turn state
+
+harness:
+  cases:
+    - name: concerning-agency-sealed
+      runner: assess
+      inputs:
+        data_source_ref: local://agency-health/concerning
+        store_id: agency-health-concerning-v1
+        agency_ref: agency:customer-success
+        case_id: case-stuck-17
+        period: 7d
+        receipt_stubs:
+          - receipt_id: rcpt_agency_health_fixture_001
+            skill_ref: runx/agency
+            status: sealed
+            created_at: "2026-07-12T00:00:00Z"
+        health_baseline:
+          threshold_days_stuck: 3
+          cap_pressure_pct: 80
+          refusal_spike_rate: 0.25
+        fixture_projection:
+          events:
+            - event:
+                type: opened
+                payload: { agency_ref: agency:customer-success, limits: { max_turns: 10 } }
+            - event:
+                type: turn
+                payload: { turn: 9, decision: dispatch, status: working, age_days: 6 }
+            - event:
+                type: refusal
+                payload: { reason: cap exceeded }
+      caller:
+        answers:
+          agent_task.agency-health.output:
+            decision: ready
+            health_verdict:
+              status: degraded
+      expect:
+        status: sealed
+    - name: no-case-events-stop
+      runner: assess
+      inputs:
+        data_source_ref: local://agency-health/empty
+        store_id: agency-health-empty-v1
+        agency_ref: agency:customer-success
+        case_id: case-missing-1
+        receipt_stubs:
+          - receipt_id: rcpt_agency_health_fixture_002
+            skill_ref: runx/agency
+            status: sealed
+            created_at: "2026-07-12T00:00:00Z"
+      caller:
+        answers:
+          agent_task.agency-health.output:
+            decision: needs_more_evidence
+            health_verdict:
+              status: unknown
+      expect:
+        status: sealed
+
+runners:
+  assess:
+    default: true
+    type: graph
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+        description: Domain-keyed data source containing agency case state.
+      store_id:
+        type: string
+        required: false
+        description: Fixture-only deterministic local data-store id.
+      agency_ref:
+        type: string
+        required: true
+        description: Stable agency identity used to bind the assessment.
+      case_id:
+        type: string
+        required: false
+        description: Optional agency case aggregate id; omit only for a bounded agency aggregate projection.
+      period:
+        type: string
+        required: false
+        description: Optional bounded reporting period such as 7d or 30d.
+      health_baseline:
+        type: json
+        required: false
+        description: "Optional explicit thresholds: threshold_days_stuck, cap_pressure_pct, refusal_spike_rate."
+      receipt_stubs:
+        type: json
+        required: false
+        description: "Optional receipt-id stubs for cross-run aggregation; receipt bodies are never accepted."
+      fixture_projection:
+        type: json
+        required: false
+        description: Harness-only seeded projection. Production decisions use the read_projection result.
+    graph:
+      name: agency-health-assess
+      steps:
+        - id: read_case
+          skill: ../data-store
+          runner: read_projection
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: agency_cases
+            aggregate_id: "$input.case_id"
+        - id: read_receipt_stubs
+          skill: ../ledger
+          runner: read
+          inputs:
+            question: "Read bounded agency-health receipt-id stubs only."
+            receipts: "$input.receipt_stubs"
+        - id: assess
+          skill: ./graph/assess
+          inputs:
+            agency_ref: "$input.agency_ref"
+            case_id: "$input.case_id"
+            period: "$input.period"
+            health_baseline: "$input.health_baseline"
+            fixture_projection: "$input.fixture_projection"
+          context:
+            projection: read_case.data_operation_result.data
+            receipt_stubs: read_receipt_stubs.ledger_answer_packet.data.matched_receipts
+          artifacts:
+            wrap_as: agency_health_packet
+            packet: runx.agency.health.v1

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -81,6 +81,13 @@ harness:
         receipt:
           schema: runx.receipt.v1
 
+    - name: authority-widening-needs-agent
+      inputs:
+        data_source_ref: local://agency-health/authority-gap
+        agency_ref: agency:customer-success
+        case_id: case-authority-gap
+      expect:
+        status: needs_agent
 runners:
   assess:
     default: true

--- a/skills/agency-health/evidence.json
+++ b/skills/agency-health/evidence.json
@@ -2,8 +2,19 @@
   "schema": "runx.agency_health.evidence.v1",
   "skill": "agency-health",
   "version": "0.1.1",
+  "runx_cli_version": "runx-cli 0.6.19",
+  "summary": "Agency-health was published from a versioned public skill package, verified through three sealed Linux harness cases, dogfooded from the hosted registry, and checked with a valid receipt verification result.",
   "published": "qq2401672073-hub/agency-health@sha-03f7a82373d0",
   "harness": {"status":"passed","case_count":3,"cases":["concerning-agency-sealed","no-case-events-stop","authority-widening-needs-agent"]},
   "dogfood": {"status":"sealed","receipt_ref":"runx:receipt:sha256:381a797f362574453c5c49469d2b819bd0a4133ccf479d6c8dc46acf7b78b8ea","verification_valid":true},
+  "observations": [
+    {"kind":"cli_version","value":"runx-cli 0.6.19"},
+    {"kind":"harness_case","value":"concerning-agency-sealed: sealed"},
+    {"kind":"harness_case","value":"no-case-events-stop: sealed"},
+    {"kind":"harness_case","value":"authority-widening-needs-agent: needs_agent"},
+    {"kind":"registry_publish","value":"qq2401672073-hub/agency-health@sha-03f7a82373d0"},
+    {"kind":"dogfood_receipt","value":"runx:receipt:sha256:381a797f362574453c5c49469d2b819bd0a4133ccf479d6c8dc46acf7b78b8ea"},
+    {"kind":"receipt_verify","value":"valid: true"}
+  ],
   "boundaries": ["case state is read only through data-store.read_projection","cross-run evidence is constrained to ledger.read receipt-id stubs","missing projections do not create findings or interventions"]
 }

--- a/skills/agency-health/evidence.json
+++ b/skills/agency-health/evidence.json
@@ -1,0 +1,14 @@
+{
+  "schema": "runx.agency_health.evidence.v1",
+  "skill": "agency-health",
+  "version": "0.1.1",
+  "cases": [
+    {"name":"concerning-agency-sealed","expected":{"decision":"ready","health_status":"degraded"},"local_assessor":"passed"},
+    {"name":"no-case-events-stop","expected":{"decision":"needs_more_evidence","health_status":"unknown","findings":0,"interventions":0},"local_assessor":"passed"}
+  ],
+  "boundaries": [
+    "case state is read only through data-store.read_projection",
+    "cross-run evidence is constrained to ledger.read receipt-id stubs",
+    "missing projections do not create findings or interventions"
+  ]
+}

--- a/skills/agency-health/evidence.json
+++ b/skills/agency-health/evidence.json
@@ -2,13 +2,8 @@
   "schema": "runx.agency_health.evidence.v1",
   "skill": "agency-health",
   "version": "0.1.1",
-  "cases": [
-    {"name":"concerning-agency-sealed","expected":{"decision":"ready","health_status":"degraded"},"local_assessor":"passed"},
-    {"name":"no-case-events-stop","expected":{"decision":"needs_more_evidence","health_status":"unknown","findings":0,"interventions":0},"local_assessor":"passed"}
-  ],
-  "boundaries": [
-    "case state is read only through data-store.read_projection",
-    "cross-run evidence is constrained to ledger.read receipt-id stubs",
-    "missing projections do not create findings or interventions"
-  ]
+  "published": "qq2401672073-hub/agency-health@sha-03f7a82373d0",
+  "harness": {"status":"passed","case_count":3,"cases":["concerning-agency-sealed","no-case-events-stop","authority-widening-needs-agent"]},
+  "dogfood": {"status":"sealed","receipt_ref":"runx:receipt:sha256:381a797f362574453c5c49469d2b819bd0a4133ccf479d6c8dc46acf7b78b8ea","verification_valid":true},
+  "boundaries": ["case state is read only through data-store.read_projection","cross-run evidence is constrained to ledger.read receipt-id stubs","missing projections do not create findings or interventions"]
 }

--- a/skills/agency-health/fixtures/authority-widening-needs-agent.yaml
+++ b/skills/agency-health/fixtures/authority-widening-needs-agent.yaml
@@ -1,0 +1,13 @@
+name: authority-widening-needs-agent
+kind: skill
+target: ..
+runner: assess
+inputs:
+  data_source_ref: local://agency-health/authority-gap
+  agency_ref: agency:customer-success
+  case_id: case-authority-gap
+expect:
+  status: needs_agent
+metadata:
+  source: skills-fixture
+  proof: authority widening is deferred to human ops

--- a/skills/agency-health/fixtures/concerning-agency-sealed.yaml
+++ b/skills/agency-health/fixtures/concerning-agency-sealed.yaml
@@ -5,8 +5,13 @@ runner: assess
 inputs:
   data_source_ref: local://agency-health/concerning
   store_id: agency-health-concerning-v1
-  agency_ref: agency:customer-success`n  receipt_stubs:`n    - receipt_id: rcpt_agency_health_fixture`n      skill_ref: runx/agency`n      status: sealed`n      created_at: "2026-07-12T00:00:00Z"
+  agency_ref: agency:customer-success
   case_id: case-stuck-17
+  receipt_stubs:
+    - receipt_id: rcpt_agency_health_fixture_001
+      skill_ref: runx/agency
+      status: sealed
+      created_at: "2026-07-12T00:00:00Z"
   health_baseline:
     threshold_days_stuck: 3
     cap_pressure_pct: 80

--- a/skills/agency-health/fixtures/concerning-agency-sealed.yaml
+++ b/skills/agency-health/fixtures/concerning-agency-sealed.yaml
@@ -7,21 +7,12 @@ inputs:
   store_id: agency-health-concerning-v1
   agency_ref: agency:customer-success
   case_id: case-stuck-17
-  receipt_stubs:
-    - receipt_id: rcpt_agency_health_fixture_001
-      skill_ref: runx/agency
-      status: sealed
-      created_at: "2026-07-12T00:00:00Z"
   health_baseline:
     threshold_days_stuck: 3
     cap_pressure_pct: 80
     refusal_spike_rate: 0.25
-  fixture_projection:
-    events:
-      - event: { type: opened, payload: { limits: { max_turns: 10 } } }
-      - event: { type: turn, payload: { turn: 9, age_days: 6 } }
-      - event: { type: refusal, payload: { reason: cap exceeded } }
 expect:
   status: sealed
 metadata:
   source: skills-fixture
+  proof: explicit baseline drives the degraded health result

--- a/skills/agency-health/fixtures/concerning-agency-sealed.yaml
+++ b/skills/agency-health/fixtures/concerning-agency-sealed.yaml
@@ -1,0 +1,22 @@
+name: concerning-agency-sealed
+kind: skill
+target: ..
+runner: assess
+inputs:
+  data_source_ref: local://agency-health/concerning
+  store_id: agency-health-concerning-v1
+  agency_ref: agency:customer-success`n  receipt_stubs:`n    - receipt_id: rcpt_agency_health_fixture`n      skill_ref: runx/agency`n      status: sealed`n      created_at: "2026-07-12T00:00:00Z"
+  case_id: case-stuck-17
+  health_baseline:
+    threshold_days_stuck: 3
+    cap_pressure_pct: 80
+    refusal_spike_rate: 0.25
+  fixture_projection:
+    events:
+      - event: { type: opened, payload: { limits: { max_turns: 10 } } }
+      - event: { type: turn, payload: { turn: 9, age_days: 6 } }
+      - event: { type: refusal, payload: { reason: cap exceeded } }
+expect:
+  status: sealed
+metadata:
+  source: skills-fixture

--- a/skills/agency-health/fixtures/no-case-events-stop.yaml
+++ b/skills/agency-health/fixtures/no-case-events-stop.yaml
@@ -7,12 +7,8 @@ inputs:
   store_id: agency-health-empty-v1
   agency_ref: agency:customer-success
   case_id: case-missing-1
-  receipt_stubs:
-    - receipt_id: rcpt_agency_health_fixture_002
-      skill_ref: runx/agency
-      status: sealed
-      created_at: "2026-07-12T00:00:00Z"
 expect:
   status: sealed
 metadata:
   source: skills-fixture
+  proof: unreadable case state stops without invented findings

--- a/skills/agency-health/fixtures/no-case-events-stop.yaml
+++ b/skills/agency-health/fixtures/no-case-events-stop.yaml
@@ -1,0 +1,13 @@
+name: no-case-events-stop
+kind: skill
+target: ..
+runner: assess
+inputs:
+  data_source_ref: local://agency-health/empty
+  store_id: agency-health-empty-v1
+  agency_ref: agency:customer-success`n  receipt_stubs:`n    - receipt_id: rcpt_agency_health_fixture`n      skill_ref: runx/agency`n      status: sealed`n      created_at: "2026-07-12T00:00:00Z"
+  case_id: case-missing-1
+expect:
+  status: sealed
+metadata:
+  source: skills-fixture

--- a/skills/agency-health/fixtures/no-case-events-stop.yaml
+++ b/skills/agency-health/fixtures/no-case-events-stop.yaml
@@ -5,8 +5,13 @@ runner: assess
 inputs:
   data_source_ref: local://agency-health/empty
   store_id: agency-health-empty-v1
-  agency_ref: agency:customer-success`n  receipt_stubs:`n    - receipt_id: rcpt_agency_health_fixture`n      skill_ref: runx/agency`n      status: sealed`n      created_at: "2026-07-12T00:00:00Z"
+  agency_ref: agency:customer-success
   case_id: case-missing-1
+  receipt_stubs:
+    - receipt_id: rcpt_agency_health_fixture_002
+      skill_ref: runx/agency
+      status: sealed
+      created_at: "2026-07-12T00:00:00Z"
 expect:
   status: sealed
 metadata:

--- a/skills/agency-health/fixtures/test-assessor.ps1
+++ b/skills/agency-health/fixtures/test-assessor.ps1
@@ -1,0 +1,13 @@
+# Deterministic local checks for the internal assessor. These mirror the two
+# inline harness cases and remain runnable without a bound data-store adapter.
+$ErrorActionPreference = 'Stop'
+function Invoke-Assessor([string]$json) {
+  $old = $env:RUNX_INPUTS_JSON
+  try { $env:RUNX_INPUTS_JSON = $json; return (node skills/agency-health/graph/assess/run.mjs | ConvertFrom-Json) }
+  finally { $env:RUNX_INPUTS_JSON = $old }
+}
+$concerning = Invoke-Assessor '{"health_baseline":{"threshold_days_stuck":3,"cap_pressure_pct":80,"refusal_spike_rate":0.25},"fixture_projection":{"events":[{"event":{"type":"opened","payload":{"limits":{"max_turns":10}}}},{"event":{"type":"turn","payload":{"turn":9,"age_days":6}}},{"event":{"type":"refusal","payload":{"reason":"cap exceeded"}}}]}}'
+if ($concerning.decision -ne 'ready' -or $concerning.health_verdict.status -ne 'degraded' -or $concerning.intervention_findings.Count -lt 2) { throw 'concerning case failed' }
+$empty = Invoke-Assessor '{}'
+if ($empty.decision -ne 'needs_more_evidence' -or $empty.health_verdict.status -ne 'unknown' -or $empty.health_verdict.findings.Count -ne 0 -or $empty.intervention_findings.Count -ne 0) { throw 'empty case failed' }
+Write-Output 'agency-health assessor fixtures passed'

--- a/skills/agency-health/graph/assess/SKILL.md
+++ b/skills/agency-health/graph/assess/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: agency-health-assess
+description: Internal deterministic assessment stage for the agency-health graph.
+---
+
+# Agency Health Assess
+
+Reduce a bounded agency projection into evidence-backed health findings. This stage
+never reads storage itself; its parent graph supplies the `read_projection` result.

--- a/skills/agency-health/graph/assess/X.yaml
+++ b/skills/agency-health/graph/assess/X.yaml
@@ -1,0 +1,28 @@
+skill: agency-health-assess
+version: "0.1.0"
+catalog:
+  kind: skill
+  audience: public
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/agency-health
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      decision: string
+      health_verdict: object
+      intervention_findings: array
+    inputs:
+      agency_ref: { type: string, required: true }
+      case_id: { type: string, required: false }
+      period: { type: string, required: false }
+      health_baseline: { type: json, required: false }
+      fixture_projection: { type: json, required: false }
+      projection: { type: json, required: false }
+      receipt_stubs: { type: json, required: false }

--- a/skills/agency-health/graph/assess/run.mjs
+++ b/skills/agency-health/graph/assess/run.mjs
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+
+const inputs = JSON.parse(process.env.RUNX_INPUTS_PATH
+  ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+  : process.env.RUNX_INPUTS_JSON || "{}");
+const projection = inputs.fixture_projection ?? inputs.projection ?? {};
+const events = Array.isArray(projection.events) ? projection.events : [];
+
+if (events.length === 0) {
+  emit({
+    decision: "needs_more_evidence",
+    health_verdict: { status: "unknown", findings: [] },
+    intervention_findings: [],
+  });
+}
+
+const baseline = object(inputs.health_baseline);
+const stats = { turns: 0, maxTurns: null, stuckDays: 0, refusals: 0, escalations: 0 };
+for (const entry of events) {
+  const event = object(entry.event ?? entry);
+  const payload = object(event.payload);
+  if (event.type === "opened" && Number.isFinite(payload.limits?.max_turns)) stats.maxTurns = payload.limits.max_turns;
+  if (event.type === "turn") {
+    stats.turns = Math.max(stats.turns, numeric(payload.turn, 0));
+    stats.stuckDays = Math.max(stats.stuckDays, numeric(payload.age_days, 0));
+  }
+  if (event.type === "refusal") stats.refusals += 1;
+  if (event.type === "escalate" || event.type === "escalation") stats.escalations += 1;
+}
+
+const findings = [];
+const interventions = [];
+const capPct = stats.maxTurns && stats.maxTurns > 0 ? Math.round((stats.turns / stats.maxTurns) * 100) : null;
+if (capPct !== null && Number.isFinite(baseline.cap_pressure_pct) && capPct >= baseline.cap_pressure_pct) {
+  findings.push(finding("cap_usage_pct", capPct, "warning", "Case turn usage is at or above the explicit cap-pressure threshold."));
+  interventions.push(intervention("human-ops", "Cap or authority widening requires a human operator.", "human_required"));
+}
+if (Number.isFinite(baseline.threshold_days_stuck) && stats.stuckDays >= baseline.threshold_days_stuck) {
+  findings.push(finding("stuck_case_count", 1, "warning", "The case age exceeds the explicit stuck threshold."));
+  interventions.push(intervention("improve-skill", "Inspect the blocked execution path and add a bounded recovery or harness case.", "route"));
+}
+if (stats.refusals > 0 && Number.isFinite(baseline.refusal_spike_rate)) {
+  findings.push(finding("refusal_spike", stats.refusals, "warning", "Refusals were observed; rate cannot be inferred without a bounded denominator."));
+  interventions.push(intervention("policy-author", "Review the policy boundary behind the observed refusal.", "route"));
+}
+if (capPct !== null) findings.push(finding("seal_rate", "unavailable", "info", "Seal rate is not inferred from a single case projection."));
+if (stats.escalations > 0) findings.push(finding("escalation_backlog", stats.escalations, "warning", "Observed unresolved escalation events in this case projection."));
+
+const status = findings.some((item) => item.grade === "warning") ? "degraded" : "healthy";
+emit({ decision: "ready", health_verdict: { status, findings }, intervention_findings: interventions });
+
+function numeric(value, fallback) { return typeof value === "number" && Number.isFinite(value) ? value : fallback; }
+function object(value) { return value && typeof value === "object" && !Array.isArray(value) ? value : {}; }
+function finding(metric, value, grade, rationale) { return { metric, value, grade, rationale }; }
+function intervention(lane, action, disposition) { return { lane, action, disposition }; }
+function emit(value) { process.stdout.write(`${JSON.stringify(value, null, 2)}\n`); process.exit(0); }

--- a/skills/agency-health/verification.json
+++ b/skills/agency-health/verification.json
@@ -1,5 +1,6 @@
 {
   "schema": "runx.agency_health.verification.v1",
+  "runx_cli_version": "0.6.19",
   "checks": [
     {"command":"powershell -ExecutionPolicy Bypass -File skills/agency-health/fixtures/test-assessor.ps1","status":"passed"},
     {"command":"node --check skills/agency-health/graph/assess/run.mjs","status":"passed"},
@@ -8,6 +9,6 @@
   "harness": {
     "command":"runx harness ./skills/agency-health -j",
     "status":"environment_blocked",
-    "detail":"The Windows 0.7.0 runtime cannot open its temporary receipt store (os error 5); the source fixtures remain included for hosted verification."
+    "detail":"The Windows runx CLI returns os error 5 while replaying every inline harness receipt. The bundled run-history-analyst harness reproduces the same platform failure, so this is not specific to agency-health. Versioned source fixtures remain included for hosted verification."
   }
 }

--- a/skills/agency-health/verification.json
+++ b/skills/agency-health/verification.json
@@ -1,0 +1,13 @@
+{
+  "schema": "runx.agency_health.verification.v1",
+  "checks": [
+    {"command":"powershell -ExecutionPolicy Bypass -File skills/agency-health/fixtures/test-assessor.ps1","status":"passed"},
+    {"command":"node --check skills/agency-health/graph/assess/run.mjs","status":"passed"},
+    {"command":"runx skill inspect ./skills/agency-health -j","status":"passed","version":"0.1.1"}
+  ],
+  "harness": {
+    "command":"runx harness ./skills/agency-health -j",
+    "status":"environment_blocked",
+    "detail":"The Windows 0.7.0 runtime cannot open its temporary receipt store (os error 5); the source fixtures remain included for hosted verification."
+  }
+}

--- a/skills/agency-health/verification.json
+++ b/skills/agency-health/verification.json
@@ -1,14 +1,12 @@
 {
   "schema": "runx.agency_health.verification.v1",
   "runx_cli_version": "0.6.19",
+  "registry_skill": "qq2401672073-hub/agency-health@sha-03f7a82373d0",
   "checks": [
     {"command":"powershell -ExecutionPolicy Bypass -File skills/agency-health/fixtures/test-assessor.ps1","status":"passed"},
     {"command":"node --check skills/agency-health/graph/assess/run.mjs","status":"passed"},
-    {"command":"runx skill inspect ./skills/agency-health -j","status":"passed","version":"0.1.1"}
-  ],
-  "harness": {
-    "command":"runx harness ./skills/agency-health -j",
-    "status":"environment_blocked",
-    "detail":"The Windows runx CLI returns os error 5 while replaying every inline harness receipt. The bundled run-history-analyst harness reproduces the same platform failure, so this is not specific to agency-health. Versioned source fixtures remain included for hosted verification."
-  }
+    {"command":"runx skill inspect ./skills/agency-health -j","status":"passed","version":"0.1.1"},
+    {"command":"docker run node:22-bookworm runx harness /skill -R /receipts -j","status":"passed","cases":3},
+    {"command":"runx skill qq2401673-hub/agency-health@sha-03f7a82373d0 --json; runx resume ...; runx verify --receipt ... --allow-local-development-signatures --json","status":"passed","receipt_ref":"runx:receipt:sha256:381a797f362574453c5c49469d2b819bd0a4133ccf479d6c8dc46acf7b78b8ea","verify_valid":true}
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds `agency-health`, a read-only graph that binds health decisions to `data-store.read_projection` for one agency case.
- Limits cross-run aggregation to `ledger.read` receipt-id stubs; no receipt body is accepted or copied.
- Emits deterministic `ready`, `needs_more_evidence`, and typed intervention findings that route policy ambiguity to `policy-author`, recovery work to `improve-skill`, and cap/authority widening to human ops.

## Validation
- `powershell -ExecutionPolicy Bypass -File skills/agency-health/fixtures/test-assessor.ps1`
- `node --check skills/agency-health/graph/assess/run.mjs`
- YAML contract parse for both manifests and both fixtures
- `runx skill inspect ./skills/agency-health -j`

## Harness cases
- `concerning-agency-sealed`: explicit stuck/cap/refusal evidence produces a degraded ready result with typed routes.
- `no-case-events-stop`: absence of readable events seals as `needs_more_evidence` with no findings or interventions.