### PR TITLE
Document authentic RunX support evidence

### DIFF
--- a/community/runx-love/evidence.json
+++ b/community/runx-love/evidence.json
@@ -1,0 +1,27 @@
+{
+  "summary": "A reproducible RunX CLI defect report documents that supplied approval answers do not clear a pending approval during resume, with exact commands, clean receipt directories, observed state, and the expected state transition.",
+  "observations": [
+    {
+      "claim_type": "useful_issue",
+      "public_url": "https://github.com/runxhq/runx/issues/311"
+    },
+    {
+      "runx_link_found": "https://github.com/runxhq/runx"
+    },
+    {
+      "summary": "The issue isolates a deterministic runx resume approval-state bug and supplies a minimal reproduction using the published Sourcey catalog graph."
+    },
+    {
+      "audience": "RunX maintainers and contributors working on resume, approval gates, and governed graph execution"
+    },
+    {
+      "venue_policy": "The runxhq/runx issue tracker accepts actionable bug reports; this post reports a product defect rather than promoting an unrelated project."
+    },
+    {
+      "reproduction_quality": "The report includes the CLI version, initial run, two documented answer shapes, isolated receipt directories, repeated pending state, and expected behavior."
+    },
+    {
+      "public_access": "The issue and repository are readable without authentication."
+    }
+  ]
+}

--- a/community/runx-love/report.md
+++ b/community/runx-love/report.md
@@ -1,0 +1,12 @@
+# Authentic RunX support action
+
+- Public action: filed [runx resume leaves approval pending after supplied approval answer](https://github.com/runxhq/runx/issues/311).
+- Project link: the report is filed directly in the public [runxhq/runx](https://github.com/runxhq/runx) repository.
+- What it contributes: a deterministic reproduction of an approval-resume state transition that remains pending even after a supplied answer.
+- Evidence depth: the report records RunX CLI 0.7.0, the exact catalog graph invocation, the resume commands, both documented answer payload shapes, and clean receipt directories.
+- Expected behavior: a valid supplied approval should satisfy the pending gate and allow the graph to continue or fail with a specific validation error.
+- Observed behavior: every documented input shape leaves the same approval pending without a targeted validation error.
+- Audience: maintainers and contributors working on resume semantics, approval gates, or governed graph execution.
+- Public access: both the issue and this supporting evidence are readable by a stranger without signing in.
+- Venue fit: GitHub Issues is the repository's normal bug-reporting surface, and the post is a focused defect report rather than generic promotion or link spam.
+- Authenticity: the defect was encountered while running a real governed validation for an upstream documentation task, then reproduced in isolated receipt directories before filing.


### PR DESCRIPTION
## Summary

- add a public, machine-readable record of an authentic RunX support action
- link the deterministic approval-resume bug report in #311
- document reproduction quality, audience, venue fit, and public accessibility

## Context

The support action came from real use of RunX 0.7.0 while validating an upstream Sourcey workflow. The underlying defect is fixed separately in #312; this PR only records the public support evidence.

## Validation

- `git diff --check origin/main...HEAD`
- `jq empty community/runx-love/evidence.json`

Signed-off-by: wei wang <10283245@qq.com>