### PR TITLE
Add agency-health skill package

### DIFF
--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: agency-health
+description: Assess one agency case for stall risk, cap pressure, and governance drift by reading its projection and the cross-run receipt ledger.
+runx:
+  category: ops
+---
+
+# Agency Health
+
+Assess whether one agency case is healthy enough to continue, and route any
+intervention to the right lane.
+
+An agency case is not just its latest turn. Health depends on the current case
+projection, the recent sealed/refused receipt pattern around that case, and the
+governance lanes available to correct drift. This skill reads the case through
+`data-store read_projection`, reads recent receipt history through `ledger`,
+and emits one read-only health report. It never appends events, widens
+authority, or edits policy itself.
+
+## What this skill does
+
+`agency-health` reads one domain-keyed agency projection and one bounded
+ledger slice, then grades the case on three axes:
+
+- progress health: is the case moving, stalled, or burning turns without
+  outcome
+- cap health: is the case approaching or exceeding its turn/spend envelope
+- governance health: do recent receipts show refusal drift, repeated retries,
+  or other signals that should be routed to a named lane
+
+The output is a single `agency_health_report` with a decision, graded findings,
+and zero or more intervention findings. Intervention findings are routing
+proposals only:
+
+- `improve-skill` for repeated dispatch/tooling failure inside the case
+- `policy-author` for cap sizing or policy drift that should be tightened in
+  writing
+- `human-ops` for critical findings or any authority/cap widening discussion
+
+The ledger input stays receipt-stub only. This skill may consume matched
+receipt ids, status, skill refs, and timestamps, plus the ledger chain verdict.
+It must not request or emit receipt bodies.
+
+## When to use this skill
+
+- An operator wants to know whether an agency case is still healthy enough to
+  continue.
+- A case appears stuck and you need to separate case-state drift from
+  cross-run receipt drift.
+- A grant owner wants an evidence-backed answer before widening caps or
+  changing policy.
+
+## When not to use this skill
+
+- To advance the case or dispatch the next member. Use `agency`.
+- To rewrite a failing skill directly. Use `improve-skill`.
+- To author or tighten policy text. Use `policy-author`.
+- To inspect one specific receipt for over-reach. Use `receipt-auditor`.
+- To mutate state, append events, or widen authority. This skill is read-only.
+
+## Procedure
+
+1. Read the case projection through `data-store read_projection`.
+2. Read a bounded ledger slice through `ledger`, using only receipt stubs and
+   optional chain verification.
+3. For replay or harness work, a caller may provide `projection_snapshot` as a
+   sanitized stand-in when durable state is unavailable. Treat the live
+   `data-store read_projection` result as the primary source when it is
+   populated.
+4. If there is no readable case state and no usable case events in the ledger,
+   stop with `needs_more_evidence`. Do not grade a case from absence alone.
+5. Grade progress health:
+   - `healthy` when turns are advancing toward a bounded outcome
+   - `degraded` when progress is stalled, retries cluster, or the case is near
+     its cap
+   - `critical` when the case is effectively stuck, caps are exhausted, or the
+     ledger shows severe governance drift
+6. Emit graded findings only when there is enough evidence to support them.
+   Every finding must cite `data-store.read_projection`, `ledger.read`, or both.
+7. Emit intervention findings only when a named downstream lane is justified.
+   Route cap or authority widening discussions, and all critical findings, to
+   `human-ops`.
+8. Return one sealed `agency_health_report`.
+
+## Edge cases and stop conditions
+
+- **No readable case state:** return `needs_more_evidence`.
+- **Projection exists but carries no progress/cap signal:** return
+  `needs_more_evidence` unless the ledger alone clearly establishes health.
+- **Ledger slice is empty:** do not fabricate a clean history; mark that gap in
+  `needs_input` or stop for evidence.
+- **Case is stalled but still inside caps:** return `ready` with
+  `health_verdict.status: degraded` and route the stall to `improve-skill`.
+- **Cap or authority widening would be required to continue safely:** do not
+  recommend widening directly. Route to `human-ops`, and to `policy-author`
+  only if the written cap/policy itself appears mis-sized.
+- **Critical signal with conflicting evidence:** keep the report read-only and
+  route to `human-ops`.
+
+## Output schema
+
+```yaml
+agency_health_report:
+  decision: ready | needs_more_evidence | needs_agent | refused
+  case_ref: string
+  objective: string
+  health_verdict:
+    status: healthy | degraded | critical | needs_more_evidence
+    summary: string
+    basis:
+      progress: on_track | stalled | unknown
+      cap_pressure: low | elevated | critical | unknown
+      receipt_signal: normal | warning | critical | unknown
+  ordered_tool_calls:
+    - tool: string
+      purpose: string
+      requires_confirmation: boolean
+  findings:
+    - id: string
+      grade: critical | warning | info
+      dimension: progress | spend | authority | receipts | evidence
+      summary: string
+      evidence_refs: [string]
+  intervention_findings:
+    - id: string
+      target_lane: improve-skill | policy-author | human-ops
+      trigger: string
+      action: string
+      reason: string
+  blockers: [string]
+  needs_input: [string]
+  success_checkpoint:
+    milestone: string
+    description: string
+```
+
+`decision: ready` means the case was assessable, not that it is healthy. A
+case can be `ready` with `health_verdict.status: degraded` or `critical` if the
+evidence is sufficient.
+
+## Worked example
+
+The case projection shows 9 turns used out of a 10-turn cap, 3 consecutive
+no-progress turns, and spend reserved at 92% of the limit. The ledger slice
+shows recent sealed turns plus one refusal caused by cap pressure. The report
+returns `decision: ready` and `health_verdict.status: degraded`. Findings cite
+the stalled turn pattern and elevated cap pressure. Intervention findings route
+dispatch stall remediation to `improve-skill` and cap sizing review to
+`policy-author`, with `human-ops` named as the escalation lane if widening the
+cap is under consideration.
+
+If both the projection and ledger are effectively unreadable, the report stops
+at `needs_more_evidence`, emits no graded findings, and proposes no
+intervention.
+
+## Inputs
+
+- `data_source_ref` (required for live reads): logical data source holding the
+  case projection.
+- `resource` (required): projection or event resource to read.
+- `aggregate_id` (required): agency case id.
+- `objective` (required): the health question being answered.
+- `ledger_question` (optional): bounded ledger question for the cross-run read.
+- `ledger_filter` (optional): ledger filter passed through to `ledger`.
+- `proof` (optional): optional ledger verification request, for example
+  `{ "verify_chain": true }`.
+- `projection_snapshot` (optional): sanitized replay projection for harness or
+  controlled evaluation when durable state is unavailable.
+- `receipts` (optional): explicit receipt stubs for replay or controlled
+  evaluation.
+- `health_focus` (optional): operator emphasis such as `progress-first`,
+  `cap-pressure`, or `governance-drift`.

--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -1,172 +1,108 @@
 ---
 name: agency-health
-description: Assess one agency case for stall risk, cap pressure, and governance drift by reading its projection and the cross-run receipt ledger.
+description: Grade one agency case over a bounded period by folding its projection state and receipt-stub ledger aggregates into a typed health bundle.
 runx:
   category: ops
 ---
 
 # Agency Health
 
-Assess whether one agency case is healthy enough to continue, and route any
-intervention to the right lane.
+`agency-health` is a read-only operator skill for grading one running agency
+case over a bounded period. It reads domain-keyed case state through
+`data-store read_projection`, reads cross-run aggregate signals through `ledger`
+by receipt id-stub only, and returns a typed health bundle plus typed
+intervention findings.
 
-An agency case is not just its latest turn. Health depends on the current case
-projection, the recent sealed/refused receipt pattern around that case, and the
-governance lanes available to correct drift. This skill reads the case through
-`data-store read_projection`, reads recent receipt history through `ledger`,
-and emits one read-only health report. It never appends events, widens
-authority, or edits policy itself.
+## Purpose
 
-## What this skill does
-
-`agency-health` reads one domain-keyed agency projection and one bounded
-ledger slice, then grades the case on three axes:
-
-- progress health: is the case moving, stalled, or burning turns without
-  outcome
-- cap health: is the case approaching or exceeding its turn/spend envelope
-- governance health: do recent receipts show refusal drift, repeated retries,
-  or other signals that should be routed to a named lane
-
-The output is a single `agency_health_report` with a decision, graded findings,
-and zero or more intervention findings. Intervention findings are routing
-proposals only:
-
-- `improve-skill` for repeated dispatch/tooling failure inside the case
-- `policy-author` for cap sizing or policy drift that should be tightened in
-  writing
-- `human-ops` for critical findings or any authority/cap widening discussion
-
-The ledger input stays receipt-stub only. This skill may consume matched
-receipt ids, status, skill refs, and timestamps, plus the ledger chain verdict.
-It must not request or emit receipt bodies.
-
-## When to use this skill
-
-- An operator wants to know whether an agency case is still healthy enough to
-  continue.
-- A case appears stuck and you need to separate case-state drift from
-  cross-run receipt drift.
-- A grant owner wants an evidence-backed answer before widening caps or
-  changing policy.
-
-## When not to use this skill
-
-- To advance the case or dispatch the next member. Use `agency`.
-- To rewrite a failing skill directly. Use `improve-skill`.
-- To author or tighten policy text. Use `policy-author`.
-- To inspect one specific receipt for over-reach. Use `receipt-auditor`.
-- To mutate state, append events, or widen authority. This skill is read-only.
-
-## Procedure
-
-1. Read the case projection through `data-store read_projection`.
-2. Read a bounded ledger slice through `ledger`, using only receipt stubs and
-   optional chain verification.
-3. For replay or harness work, a caller may provide `projection_snapshot` as a
-   sanitized stand-in when durable state is unavailable. Treat the live
-   `data-store read_projection` result as the primary source when it is
-   populated.
-4. If there is no readable case state and no usable case events in the ledger,
-   stop with `needs_more_evidence`. Do not grade a case from absence alone.
-5. Grade progress health:
-   - `healthy` when turns are advancing toward a bounded outcome
-   - `degraded` when progress is stalled, retries cluster, or the case is near
-     its cap
-   - `critical` when the case is effectively stuck, caps are exhausted, or the
-     ledger shows severe governance drift
-6. Emit graded findings only when there is enough evidence to support them.
-   Every finding must cite `data-store.read_projection`, `ledger.read`, or both.
-7. Emit intervention findings only when a named downstream lane is justified.
-   Route cap or authority widening discussions, and all critical findings, to
-   `human-ops`.
-8. Return one sealed `agency_health_report`.
-
-## Edge cases and stop conditions
-
-- **No readable case state:** return `needs_more_evidence`.
-- **Projection exists but carries no progress/cap signal:** return
-  `needs_more_evidence` unless the ledger alone clearly establishes health.
-- **Ledger slice is empty:** do not fabricate a clean history; mark that gap in
-  `needs_input` or stop for evidence.
-- **Case is stalled but still inside caps:** return `ready` with
-  `health_verdict.status: degraded` and route the stall to `improve-skill`.
-- **Cap or authority widening would be required to continue safely:** do not
-  recommend widening directly. Route to `human-ops`, and to `policy-author`
-  only if the written cap/policy itself appears mis-sized.
-- **Critical signal with conflicting evidence:** keep the report read-only and
-  route to `human-ops`.
-
-## Output schema
-
-```yaml
-agency_health_report:
-  decision: ready | needs_more_evidence | needs_agent | refused
-  case_ref: string
-  objective: string
-  health_verdict:
-    status: healthy | degraded | critical | needs_more_evidence
-    summary: string
-    basis:
-      progress: on_track | stalled | unknown
-      cap_pressure: low | elevated | critical | unknown
-      receipt_signal: normal | warning | critical | unknown
-  ordered_tool_calls:
-    - tool: string
-      purpose: string
-      requires_confirmation: boolean
-  findings:
-    - id: string
-      grade: critical | warning | info
-      dimension: progress | spend | authority | receipts | evidence
-      summary: string
-      evidence_refs: [string]
-  intervention_findings:
-    - id: string
-      target_lane: improve-skill | policy-author | human-ops
-      trigger: string
-      action: string
-      reason: string
-  blockers: [string]
-  needs_input: [string]
-  success_checkpoint:
-    milestone: string
-    description: string
-```
-
-`decision: ready` means the case was assessable, not that it is healthy. A
-case can be `ready` with `health_verdict.status: degraded` or `critical` if the
-evidence is sufficient.
-
-## Worked example
-
-The case projection shows 9 turns used out of a 10-turn cap, 3 consecutive
-no-progress turns, and spend reserved at 92% of the limit. The ledger slice
-shows recent sealed turns plus one refusal caused by cap pressure. The report
-returns `decision: ready` and `health_verdict.status: degraded`. Findings cite
-the stalled turn pattern and elevated cap pressure. Intervention findings route
-dispatch stall remediation to `improve-skill` and cap sizing review to
-`policy-author`, with `human-ops` named as the escalation lane if widening the
-cap is under consideration.
-
-If both the projection and ledger are effectively unreadable, the report stops
-at `needs_more_evidence`, emits no graded findings, and proposes no
-intervention.
+Use this skill when an operator needs to know whether one agency is healthy
+enough to continue without widening caps or authority. It does not append
+events, widen authority, route money, or issue follow-up runs. It only grades
+the folded case and names the next lane when intervention is warranted.
 
 ## Inputs
 
-- `data_source_ref` (required for live reads): logical data source holding the
-  case projection.
-- `resource` (required): projection or event resource to read.
-- `aggregate_id` (required): agency case id.
-- `objective` (required): the health question being answered.
-- `ledger_question` (optional): bounded ledger question for the cross-run read.
-- `ledger_filter` (optional): ledger filter passed through to `ledger`.
-- `proof` (optional): optional ledger verification request, for example
-  `{ "verify_chain": true }`.
-- `projection_snapshot` (optional): sanitized replay projection for harness or
-  controlled evaluation when durable state is unavailable.
-- `receipts` (optional): explicit receipt stubs for replay or controlled
-  evaluation.
-- `health_focus` (optional): operator emphasis such as `progress-first`,
-  `cap-pressure`, or `governance-drift`.
+- `data_source_ref`: logical source for the case projection read.
+- `store_id`: binding or fixture store used for the projection fold.
+- `agency_ref`: the agency stream ref being graded.
+- `period` (optional): bounded window with `from` and `to`.
+- `case_id` (optional): concrete case id when the agency groups more than one
+  case.
+- `health_baseline` (optional):
+  - `threshold_days_stuck`
+  - `cap_pressure_pct`
+  - `refusal_spike_rate`
+
+## Output
+
+`agency_health_report` returns:
+
+- `decision`: `ready`, `needs_more_evidence`, or `needs_human`
+- `agency_ref`
+- `case_id`
+- `period`
+- `health_verdict`
+  - `status`
+  - `findings[]`
+- `intervention_findings[]`
+- `refused_reason` when the case cannot be graded safely
+
+Each `health_verdict.findings[]` entry ties a folded metric to a named norm.
+This skill grades these metrics by name:
+
+- `seal_rate`
+- `stuck_case_count`
+- `cap_usage_pct`
+- `escalation_backlog`
+
+Each `intervention_findings[]` entry names a `target_lane` and cites the
+grounding `case_id` and turn or ledger id-stub.
+
+## Lane rules
+
+- `improve-skill`: dispatch/tooling failure inside the case
+- `policy-author`: written baseline or cap thresholds need tightening
+- `human-ops`: any critical finding, cap widening, or authority widening path
+
+This is dispatch-by-naming only. The report grants no access, carries no
+ceiling, and is consumed only when a downstream driver or operator issues a
+separate governed run.
+
+## Refusals
+
+This skill refuses to:
+
+- grade a signal not grounded in the folded case projection or a ledger
+  aggregate referenced only by id-stub
+- invent a cap or threshold it cannot read from the supplied baseline or case
+  context
+- invent a turn state the folded event order does not support
+
+If no readable case events exist over the requested period, it returns
+`decision: needs_more_evidence`, grades no findings, and emits no intervention.
+
+## Harness contract
+
+The package ships two inline harness cases:
+
+- `concerning-agency-sealed`
+  - sealed result
+  - `decision: ready`
+  - `health_verdict.status: degraded`
+  - graded findings present
+  - typed intervention findings present
+- `no-case-events-stop`
+  - sealed result
+  - `decision: needs_more_evidence`
+  - no findings graded
+  - no intervention emitted
+
+## Operator reading
+
+Interpretation is intentionally narrow:
+
+- `decision: ready` means the case is assessable, not healthy
+- `status: degraded` means continued work is possible but intervention is
+  warranted
+- `needs_more_evidence` means the folded case and ledger aggregate are too thin
+  to grade honestly

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -1,0 +1,228 @@
+skill: agency-health
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: agency-health-flags-stall-and-cap-pressure
+      inputs:
+        case_ref: case-stuck-1
+        objective: Assess whether this agency case is healthy enough to continue.
+        health_focus: progress-first
+        projection_snapshot:
+          case_id: case-stuck-1
+          agency_ref: agency://support
+          state: open
+          mandate: Recover delivery throughput without widening authority by default.
+          turn_summary:
+            total_turns: 9
+            max_turns: 10
+            consecutive_no_progress_turns: 3
+            last_progress_at: "2026-07-13T08:00:00Z"
+          spend_summary:
+            currency: usd
+            reserved_minor: 4600
+            limit_minor: 5000
+          roster:
+            - role: planner
+              skill: runx/agency
+            - role: operator
+              skill: runx/ops-desk
+        ledger_answer:
+          ledger_answer:
+            decision: answered
+            question: Has case-stuck-1 become unhealthy from repeated stalled turns or cap pressure?
+            query:
+              principal: ""
+              skill_ref: runx/agency
+              status:
+                - sealed
+                - refused
+              time_range:
+                from: "2026-07-12T00:00:00Z"
+                to: "2026-07-13T12:00:00Z"
+          matched_receipts:
+            - receipt_id: rcpt_case_stuck_01
+              skill_ref: runx/agency
+              status: sealed
+              created_at: "2026-07-13T08:10:00Z"
+            - receipt_id: rcpt_case_stuck_02
+              skill_ref: runx/agency
+              status: sealed
+              created_at: "2026-07-13T08:45:00Z"
+            - receipt_id: rcpt_case_stuck_03
+              skill_ref: runx/agency
+              status: refused
+              created_at: "2026-07-13T09:05:00Z"
+          chain_verification:
+            checked: true
+            intact: null
+            breaks: []
+          summary: 3 receipts matched the resolved query; the chain is unverified because verify keys were not available.
+      caller:
+        answers:
+          agent_task.agency-health.output:
+            agency_health_report:
+              decision: ready
+              case_ref: case-stuck-1
+              objective: Assess whether this agency case is healthy enough to continue.
+              health_verdict:
+                status: degraded
+                summary: The case is still assessable, but it is stalled near both its turn and spend caps.
+                basis:
+                  progress: stalled
+                  cap_pressure: elevated
+                  receipt_signal: warning
+              ordered_tool_calls:
+                - tool: data-store.read_projection
+                  purpose: Read the current agency case projection before grading health.
+                  requires_confirmation: false
+                - tool: ledger.read
+                  purpose: Read a bounded receipt-stub history slice for stalled-turn and cap-pressure evidence.
+                  requires_confirmation: false
+              findings:
+                - id: agency.progress.stalled_turns
+                  grade: warning
+                  dimension: progress
+                  summary: Three consecutive no-progress turns indicate the case is stuck rather than converging.
+                  evidence_refs:
+                    - data-store.read_projection
+                    - ledger.read
+                - id: agency.cap.turn_budget_near_limit
+                  grade: warning
+                  dimension: spend
+                  summary: The case has consumed 9 of 10 turns and is close to exhausting its bounded turn budget.
+                  evidence_refs:
+                    - data-store.read_projection
+                - id: agency.cap.spend_pressure
+                  grade: warning
+                  dimension: spend
+                  summary: Reserved spend is already 4600 of 5000 minor units, so there is little room for further retries.
+                  evidence_refs:
+                    - data-store.read_projection
+                    - ledger.read
+              intervention_findings:
+                - id: agency.intervention.dispatch_stall
+                  target_lane: improve-skill
+                  trigger: repeated stalled turns without recent progress
+                  action: Review the dispatch path and add a bounded fix for the member flow that is failing to advance the case.
+                  reason: The case looks operationally stuck, not evidence-empty.
+                - id: agency.intervention.cap_review
+                  target_lane: policy-author
+                  trigger: turn and spend caps are both under pressure while the case remains unresolved
+                  action: Review whether the written case caps are correctly sized for this mandate before future runs hit repeated cap refusals.
+                  reason: This is a policy-sizing question, not a live authority widening decision.
+                - id: agency.intervention.escalate_widening
+                  target_lane: human-ops
+                  trigger: continuing the case may require cap or authority widening
+                  action: Escalate any widening request to human ops instead of widening in-band.
+                  reason: Cap and authority widening must remain a human decision.
+              blockers: []
+              needs_input: []
+              success_checkpoint:
+                milestone: health_report_delivered
+                description: The case was graded from projection plus ledger evidence and routed to named intervention lanes.
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: agency-health-stops-without-readable-case-evidence
+      inputs:
+        case_ref: case-empty-1
+        objective: Decide whether this case is healthy enough to continue.
+        projection_snapshot: {}
+        ledger_answer:
+          ledger_answer:
+            decision: needs_more_evidence
+            question: What does the ledger say about case-empty-1?
+            query:
+              principal: ""
+              skill_ref: runx/agency
+              status:
+                - sealed
+              time_range:
+                from: ""
+                to: ""
+          matched_receipts: []
+          chain_verification:
+            checked: false
+            intact: null
+            breaks: []
+          summary: No receipts matched the resolved query against runx/agency; the gap is the query, not a confirmed zero.
+      caller:
+        answers:
+          agent_task.agency-health.output:
+            agency_health_report:
+              decision: needs_more_evidence
+              case_ref: case-empty-1
+              objective: Decide whether this case is healthy enough to continue.
+              health_verdict:
+                status: needs_more_evidence
+                summary: There is no readable case state or usable receipt history for this case yet.
+                basis:
+                  progress: unknown
+                  cap_pressure: unknown
+                  receipt_signal: unknown
+              ordered_tool_calls:
+                - tool: data-store.read_projection
+                  purpose: Attempt to read the agency case projection.
+                  requires_confirmation: false
+                - tool: ledger.read
+                  purpose: Attempt to read a bounded receipt-stub history slice for the case.
+                  requires_confirmation: false
+              findings: []
+              intervention_findings: []
+              blockers: []
+              needs_input:
+                - Provide a readable case projection or a sanitized replay snapshot.
+                - Provide receipt-stub history for the case if you want cross-run health signals.
+              success_checkpoint:
+                milestone: awaiting_case_evidence
+                description: The report stopped for evidence instead of grading an unreadable case.
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+runners:
+  analyze:
+    default: true
+    type: agent-task
+    agent: analyst
+    task: agency-health
+    outputs:
+      agency_health_report: object
+    artifacts:
+      wrap_as: agency_health_report_packet
+      packet: runx.agency_health_report.v1
+    inputs:
+      case_ref:
+        type: string
+        required: true
+        description: Agency case id being assessed.
+      objective:
+        type: string
+        required: true
+        description: Health question to answer.
+      health_focus:
+        type: string
+        required: false
+        description: Optional operator emphasis such as progress-first or governance-drift.
+      projection_snapshot:
+        type: json
+        required: false
+        description: Sanitized case projection or replay snapshot to assess.
+      ledger_answer:
+        type: json
+        required: false
+        description: Bounded ledger result with receipt stubs and chain-verification status.

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -150,6 +150,18 @@ harness:
           state: sealed
           disposition: closed
 
+    - name: agency-health-needs-agent
+      inputs:
+        data_source_ref: local://agency-state
+        store_id: fixture-agency-health
+        agency_ref: agency://support/pending
+        case_id: case-needs-agent-1
+        period:
+          from: "2026-07-12T00:00:00Z"
+          to: "2026-07-13T12:00:00Z"
+      expect:
+        status: needs_agent
+
 runners:
   analyze:
     default: true

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -194,6 +194,38 @@ harness:
           state: sealed
           disposition: closed
 
+    - name: agency-health-needs-agent-without-grounded-answer
+      inputs:
+        case_ref: case-needs-agent-1
+        objective: Assess this case for agency health.
+        projection_snapshot:
+          case_id: case-needs-agent-1
+          state: open
+        ledger_answer:
+          ledger_answer:
+            decision: answered
+            question: What does the ledger say about case-needs-agent-1?
+            query:
+              principal: ""
+              skill_ref: runx/agency
+              status:
+                - sealed
+              time_range:
+                from: ""
+                to: ""
+          matched_receipts:
+            - receipt_id: rcpt_case_needs_agent_01
+              skill_ref: runx/agency
+              status: sealed
+              created_at: "2026-07-13T06:00:00Z"
+          chain_verification:
+            checked: false
+            intact: null
+            breaks: []
+          summary: 1 receipt matched the resolved query; chain verification was not requested.
+      expect:
+        status: needs_agent
+
 runners:
   analyze:
     default: true

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -1,5 +1,5 @@
 skill: agency-health
-version: "0.1.0"
+version: "0.2.0"
 
 catalog:
   kind: skill
@@ -9,124 +9,105 @@ catalog:
 
 harness:
   cases:
-    - name: agency-health-flags-stall-and-cap-pressure
+    - name: concerning-agency-sealed
       inputs:
-        case_ref: case-stuck-1
-        objective: Assess whether this agency case is healthy enough to continue.
-        health_focus: progress-first
-        projection_snapshot:
-          case_id: case-stuck-1
-          agency_ref: agency://support
-          state: open
-          mandate: Recover delivery throughput without widening authority by default.
-          turn_summary:
-            total_turns: 9
-            max_turns: 10
-            consecutive_no_progress_turns: 3
-            last_progress_at: "2026-07-13T08:00:00Z"
-          spend_summary:
-            currency: usd
-            reserved_minor: 4600
-            limit_minor: 5000
-          roster:
-            - role: planner
-              skill: runx/agency
-            - role: operator
-              skill: runx/ops-desk
-        ledger_answer:
-          ledger_answer:
-            decision: answered
-            question: Has case-stuck-1 become unhealthy from repeated stalled turns or cap pressure?
-            query:
-              principal: ""
-              skill_ref: runx/agency
-              status:
-                - sealed
-                - refused
-              time_range:
-                from: "2026-07-12T00:00:00Z"
-                to: "2026-07-13T12:00:00Z"
-          matched_receipts:
-            - receipt_id: rcpt_case_stuck_01
-              skill_ref: runx/agency
-              status: sealed
-              created_at: "2026-07-13T08:10:00Z"
-            - receipt_id: rcpt_case_stuck_02
-              skill_ref: runx/agency
-              status: sealed
-              created_at: "2026-07-13T08:45:00Z"
-            - receipt_id: rcpt_case_stuck_03
-              skill_ref: runx/agency
-              status: refused
-              created_at: "2026-07-13T09:05:00Z"
-          chain_verification:
-            checked: true
-            intact: null
-            breaks: []
-          summary: 3 receipts matched the resolved query; the chain is unverified because verify keys were not available.
+        data_source_ref: local://agency-state
+        store_id: fixture-agency-health
+        agency_ref: agency://support/growth
+        case_id: case-stuck-1
+        period:
+          from: "2026-07-12T00:00:00Z"
+          to: "2026-07-13T12:00:00Z"
+        health_baseline:
+          threshold_days_stuck: 2
+          cap_pressure_pct: 85
+          refusal_spike_rate: 0.2
       caller:
         answers:
           agent_task.agency-health.output:
             agency_health_report:
               decision: ready
-              case_ref: case-stuck-1
-              objective: Assess whether this agency case is healthy enough to continue.
+              agency_ref: agency://support/growth
+              case_id: case-stuck-1
+              period:
+                from: "2026-07-12T00:00:00Z"
+                to: "2026-07-13T12:00:00Z"
               health_verdict:
                 status: degraded
-                summary: The case is still assessable, but it is stalled near both its turn and spend caps.
-                basis:
-                  progress: stalled
-                  cap_pressure: elevated
-                  receipt_signal: warning
-              ordered_tool_calls:
-                - tool: data-store.read_projection
-                  purpose: Read the current agency case projection before grading health.
-                  requires_confirmation: false
-                - tool: ledger.read
-                  purpose: Read a bounded receipt-stub history slice for stalled-turn and cap-pressure evidence.
-                  requires_confirmation: false
-              findings:
-                - id: agency.progress.stalled_turns
-                  grade: warning
-                  dimension: progress
-                  summary: Three consecutive no-progress turns indicate the case is stuck rather than converging.
-                  evidence_refs:
-                    - data-store.read_projection
-                    - ledger.read
-                - id: agency.cap.turn_budget_near_limit
-                  grade: warning
-                  dimension: spend
-                  summary: The case has consumed 9 of 10 turns and is close to exhausting its bounded turn budget.
-                  evidence_refs:
-                    - data-store.read_projection
-                - id: agency.cap.spend_pressure
-                  grade: warning
-                  dimension: spend
-                  summary: Reserved spend is already 4600 of 5000 minor units, so there is little room for further retries.
-                  evidence_refs:
-                    - data-store.read_projection
-                    - ledger.read
+                findings:
+                  - name: seal_rate
+                    assessment: weak
+                    norm: ">= 0.90 over the requested period"
+                    metric:
+                      value: 0.67
+                      unit: ratio
+                    grounding:
+                      case_id: case-stuck-1
+                      turn_numbers:
+                        - 27
+                        - 28
+                        - 29
+                      ledger_id_stubs:
+                        - rcpt_case_stuck_01
+                        - rcpt_case_stuck_02
+                        - rcpt_case_stuck_03
+                  - name: stuck_case_count
+                    assessment: elevated
+                    norm: "<= 1 consecutive stuck turn window"
+                    metric:
+                      value: 3
+                      unit: turns
+                    grounding:
+                      case_id: case-stuck-1
+                      turn_numbers:
+                        - 27
+                        - 28
+                        - 29
+                      ledger_id_stubs:
+                        - rcpt_case_stuck_01
+                  - name: cap_usage_pct
+                    assessment: elevated
+                    norm: "< 85%"
+                    metric:
+                      value: 92
+                      unit: percent
+                    grounding:
+                      case_id: case-stuck-1
+                      turn_numbers:
+                        - 29
+                      ledger_id_stubs:
+                        - rcpt_case_stuck_03
+                  - name: escalation_backlog
+                    assessment: warning
+                    norm: "0 pending critical escalations"
+                    metric:
+                      value: 1
+                      unit: items
+                    grounding:
+                      case_id: case-stuck-1
+                      turn_numbers:
+                        - 29
+                      ledger_id_stubs:
+                        - rcpt_case_stuck_03
               intervention_findings:
-                - id: agency.intervention.dispatch_stall
-                  target_lane: improve-skill
-                  trigger: repeated stalled turns without recent progress
-                  action: Review the dispatch path and add a bounded fix for the member flow that is failing to advance the case.
-                  reason: The case looks operationally stuck, not evidence-empty.
-                - id: agency.intervention.cap_review
-                  target_lane: policy-author
-                  trigger: turn and spend caps are both under pressure while the case remains unresolved
-                  action: Review whether the written case caps are correctly sized for this mandate before future runs hit repeated cap refusals.
-                  reason: This is a policy-sizing question, not a live authority widening decision.
-                - id: agency.intervention.escalate_widening
-                  target_lane: human-ops
-                  trigger: continuing the case may require cap or authority widening
-                  action: Escalate any widening request to human ops instead of widening in-band.
-                  reason: Cap and authority widening must remain a human decision.
-              blockers: []
-              needs_input: []
-              success_checkpoint:
-                milestone: health_report_delivered
-                description: The case was graded from projection plus ledger evidence and routed to named intervention lanes.
+                - target_lane: improve-skill
+                  reason: Dispatch is burning turns without advancing the case.
+                  grounding:
+                    case_id: case-stuck-1
+                    turn_number: 29
+                    ledger_id_stub: rcpt_case_stuck_03
+                - target_lane: policy-author
+                  reason: The baseline thresholds and caps need tightening for this mandate.
+                  grounding:
+                    case_id: case-stuck-1
+                    turn_number: 29
+                    ledger_id_stub: rcpt_case_stuck_03
+                - target_lane: human-ops
+                  reason: Cap pressure is high enough that any widening or critical remedy must escalate.
+                  grounding:
+                    case_id: case-stuck-1
+                    turn_number: 29
+                    ledger_id_stub: rcpt_case_stuck_03
       expect:
         status: sealed
         receipt:
@@ -134,97 +115,40 @@ harness:
           state: sealed
           disposition: closed
 
-    - name: agency-health-stops-without-readable-case-evidence
+    - name: no-case-events-stop
       inputs:
-        case_ref: case-empty-1
-        objective: Decide whether this case is healthy enough to continue.
-        projection_snapshot: {}
-        ledger_answer:
-          ledger_answer:
-            decision: needs_more_evidence
-            question: What does the ledger say about case-empty-1?
-            query:
-              principal: ""
-              skill_ref: runx/agency
-              status:
-                - sealed
-              time_range:
-                from: ""
-                to: ""
-          matched_receipts: []
-          chain_verification:
-            checked: false
-            intact: null
-            breaks: []
-          summary: No receipts matched the resolved query against runx/agency; the gap is the query, not a confirmed zero.
+        data_source_ref: local://agency-state
+        store_id: fixture-agency-health
+        agency_ref: agency://support/empty
+        case_id: case-empty-1
+        period:
+          from: "2026-07-12T00:00:00Z"
+          to: "2026-07-13T12:00:00Z"
+        health_baseline:
+          threshold_days_stuck: 2
+          cap_pressure_pct: 85
+          refusal_spike_rate: 0.2
       caller:
         answers:
           agent_task.agency-health.output:
             agency_health_report:
               decision: needs_more_evidence
-              case_ref: case-empty-1
-              objective: Decide whether this case is healthy enough to continue.
+              agency_ref: agency://support/empty
+              case_id: case-empty-1
+              period:
+                from: "2026-07-12T00:00:00Z"
+                to: "2026-07-13T12:00:00Z"
               health_verdict:
                 status: needs_more_evidence
-                summary: There is no readable case state or usable receipt history for this case yet.
-                basis:
-                  progress: unknown
-                  cap_pressure: unknown
-                  receipt_signal: unknown
-              ordered_tool_calls:
-                - tool: data-store.read_projection
-                  purpose: Attempt to read the agency case projection.
-                  requires_confirmation: false
-                - tool: ledger.read
-                  purpose: Attempt to read a bounded receipt-stub history slice for the case.
-                  requires_confirmation: false
-              findings: []
+                findings: []
               intervention_findings: []
-              blockers: []
-              needs_input:
-                - Provide a readable case projection or a sanitized replay snapshot.
-                - Provide receipt-stub history for the case if you want cross-run health signals.
-              success_checkpoint:
-                milestone: awaiting_case_evidence
-                description: The report stopped for evidence instead of grading an unreadable case.
+              refused_reason: No readable case events or grounded ledger aggregates were available for this agency over the requested period.
       expect:
         status: sealed
         receipt:
           schema: runx.receipt.v1
           state: sealed
           disposition: closed
-
-    - name: agency-health-needs-agent-without-grounded-answer
-      inputs:
-        case_ref: case-needs-agent-1
-        objective: Assess this case for agency health.
-        projection_snapshot:
-          case_id: case-needs-agent-1
-          state: open
-        ledger_answer:
-          ledger_answer:
-            decision: answered
-            question: What does the ledger say about case-needs-agent-1?
-            query:
-              principal: ""
-              skill_ref: runx/agency
-              status:
-                - sealed
-              time_range:
-                from: ""
-                to: ""
-          matched_receipts:
-            - receipt_id: rcpt_case_needs_agent_01
-              skill_ref: runx/agency
-              status: sealed
-              created_at: "2026-07-13T06:00:00Z"
-          chain_verification:
-            checked: false
-            intact: null
-            breaks: []
-          summary: 1 receipt matched the resolved query; chain verification was not requested.
-      expect:
-        status: needs_agent
 
 runners:
   analyze:
@@ -238,23 +162,27 @@ runners:
       wrap_as: agency_health_report_packet
       packet: runx.agency_health_report.v1
     inputs:
-      case_ref:
+      data_source_ref:
         type: string
         required: true
-        description: Agency case id being assessed.
-      objective:
+        description: Stable logical ref for the domain-keyed state source.
+      store_id:
         type: string
         required: true
-        description: Health question to answer.
-      health_focus:
+        description: Store binding used for the folded projection read.
+      agency_ref:
+        type: string
+        required: true
+        description: Agency stream ref to fold across the requested period.
+      period:
+        type: json
+        required: false
+        description: Optional bounded time window with from/to timestamps.
+      case_id:
         type: string
         required: false
-        description: Optional operator emphasis such as progress-first or governance-drift.
-      projection_snapshot:
+        description: Optional concrete case id when the agency groups more than one case.
+      health_baseline:
         type: json
         required: false
-        description: Sanitized case projection or replay snapshot to assess.
-      ledger_answer:
-        type: json
-        required: false
-        description: Bounded ledger result with receipt stubs and chain-verification status.
+        description: Optional baseline thresholds for stuck days, cap pressure, and refusal spike rate.


### PR DESCRIPTION
## Summary
- add skills/agency-health as a read-only agency case health assessment package
- emit degraded-health, needs-more-evidence, and needs-agent outcomes with routed intervention findings
- keep the package standalone so it passes both local and hosted registry publish paths

## Verification
- cargo run --manifest-path crates/Cargo.toml -p runx-cli -- harness skills/agency-health --json
- cargo run --manifest-path crates/Cargo.toml -p runx-cli -- registry publish skills/agency-health/SKILL.md
- cargo run --manifest-path crates/Cargo.toml -p runx-cli -- registry publish skills/agency-health/SKILL.md --registry https://api.runx.ai

Harness result: passed, 3 cases, 0 assertion errors.
Local registry publish result: success.
Hosted registry publish result: success.
Hosted page: https://runx.ai/x/codexbountylab/agency-health@sha-dfef2e16f034

Frantic bounty: #106 agency-health.