### PR TITLE
feat(skills): add agency-health diagnostics

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -17,8 +17,8 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/agency-health",
-        version: "sha-10048e00ab72",
-        digest: "5d864215ce7c9010a027d33271ec281f880454a2cf39ffbd5a140149554fe99f",
+        version: "sha-0228c0d35324",
+        digest: "069187b622c7bbdbd5fbcd1d4c216bf062d6341a384b64a2d27be854d435f086",
     },
     OfficialSkillLockEntry {
         skill_id: "runx/brand-voice",

--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -16,6 +16,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "cc47b9574d8aeddc679dc08ca983702e7a75c576ce04fb5bc50b63c7541747c8",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/agency-health",
+        version: "sha-f3e984c512ef",
+        digest: "4b0546970eb00982e12381a00f9498f167ed058e31883f685782f0a2d71f0991",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/brand-voice",
         version: "sha-79c56911c0ba",
         digest: "54bf1ed1013ebc91a5491fb86f15a1bda2e872ac073a12680c58278af0867528",

--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -17,8 +17,8 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/agency-health",
-        version: "sha-f3e984c512ef",
-        digest: "4b0546970eb00982e12381a00f9498f167ed058e31883f685782f0a2d71f0991",
+        version: "sha-10048e00ab72",
+        digest: "5d864215ce7c9010a027d33271ec281f880454a2cf39ffbd5a140149554fe99f",
     },
     OfficialSkillLockEntry {
         skill_id: "runx/brand-voice",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -8,8 +8,8 @@
   },
   {
     "skill_id": "runx/agency-health",
-    "version": "sha-f3e984c512ef",
-    "digest": "4b0546970eb00982e12381a00f9498f167ed058e31883f685782f0a2d71f0991",
+    "version": "sha-10048e00ab72",
+    "digest": "5d864215ce7c9010a027d33271ec281f880454a2cf39ffbd5a140149554fe99f",
     "catalog_visibility": "public",
     "catalog_role": "context"
   },

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -7,6 +7,13 @@
     "catalog_role": "canonical"
   },
   {
+    "skill_id": "runx/agency-health",
+    "version": "sha-f3e984c512ef",
+    "digest": "4b0546970eb00982e12381a00f9498f167ed058e31883f685782f0a2d71f0991",
+    "catalog_visibility": "public",
+    "catalog_role": "context"
+  },
+  {
     "skill_id": "runx/brand-voice",
     "version": "sha-79c56911c0ba",
     "digest": "54bf1ed1013ebc91a5491fb86f15a1bda2e872ac073a12680c58278af0867528",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -8,8 +8,8 @@
   },
   {
     "skill_id": "runx/agency-health",
-    "version": "sha-10048e00ab72",
-    "digest": "5d864215ce7c9010a027d33271ec281f880454a2cf39ffbd5a140149554fe99f",
+    "version": "sha-0228c0d35324",
+    "digest": "069187b622c7bbdbd5fbcd1d4c216bf062d6341a384b64a2d27be854d435f086",
     "catalog_visibility": "public",
     "catalog_role": "context"
   },

--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: agency-health
+description: "Read one running agency case and its receipt-ledger id-stubs, fold the sealed event order, grade operational health against declared norms, and emit read-only intervention findings for named downstream lanes."
+runx:
+  category: ops
+---
+
+# Agency Health
+
+Assess one live `agency` case without changing it. This skill composes the
+domain-keyed `data-store.read_projection` and `data-store.read_events` reads with
+the cross-run `ledger.read` runner, folds the agency case in version order, and
+seals one health verdict plus grounded intervention findings.
+
+It is a read-only diagnostic lane. It appends nothing, dispatches nothing,
+moves no money, grants no access, and consumes no effect. An intervention names
+the separate lane an operator or driver may run next; it is never that run.
+
+## When to use this skill
+
+- A running agency appears stuck, approval-heavy, refusal-prone, or close to a
+  charter cap.
+- An operator needs a reproducible health bundle for one agency case over a
+  bounded period.
+- A downstream driver needs grounded reasons before invoking `policy-author`,
+  `improve-skill`, or the human ops lane.
+
+## When not to use this skill
+
+- To run or advance the agency. Use `agency`.
+- To search the whole receipt catalog. Use `run-history-analyst`.
+- To audit one receipt body or signature. Use `receipt-auditor` or `runx verify`.
+- To change a timeout, cap, policy, member, credential, payment, or authority.
+  This skill can only name the appropriate separate lane.
+
+## Inputs
+
+The public `assess` runner accepts only:
+
+- `data_source_ref` (required): the configured data source holding the case.
+- `store_id` (optional): an explicit local fixture store id; omit it for the
+  normal durable SQLite binding.
+- `agency_ref` (required): the agency definition expected in the opened event.
+- `period` (optional): `{ from, to }` ISO-8601 bounds used for stuck-time and
+  ledger queries. Time-based grades stop when the required bound is absent.
+- `case_id` (optional): the `agency_cases` aggregate id. When omitted, the
+  deterministic prepare stage uses `agency_ref` as the aggregate id.
+- `health_baseline` (optional):
+  `{ threshold_days_stuck, cap_pressure_pct, refusal_spike_rate }`.
+
+Norms may also come from the charter snapshot in the opened event. The skill
+never invents a cap or threshold that is absent from both sources.
+
+## Procedure
+
+1. Normalize `case_id`, period, and the ledger query without changing public
+   input or authority.
+2. Call `data-store.read_projection` on resource `agency_cases` and the resolved
+   case id. This is the authoritative domain-keyed stream identity and digest.
+3. Call `data-store.read_events` for the same source, resource, and case id.
+   Verify ascending versions and projection/event digest consistency before
+   folding event bodies.
+4. Call `ledger.read` for the bounded period. The runx ledger projects a sealed
+   receipt as status `closed`, which this grader normalizes to `sealed` for the
+   seal-rate metric. A second deterministic C7 read may
+   replay only receipt id-stubs already cited by ordered case events when the
+   ambient ledger has no matching case-cited rows. Intersect ambient history
+   with those case-cited ids, then retain only (`receipt_id`, `skill_ref`,
+   `status`, `created_at`); ledger history is cross-run evidence, never the
+   agency's domain state, and the output records which C7 source grounded it.
+5. Fold the opened/turn/approved/denied event order and grade:
+   `seal_rate`, `stuck_case_count`, `cap_usage_pct`, and
+   `escalation_backlog` against named norms.
+6. Seal the verdict and any read-only intervention findings.
+
+The bundled `data.source` manifest is only the operator-context contract for
+runx's virtual router. The runtime always replaces that ref with the concrete
+adapter bound to `data_source_ref`; its fail-closed stub is never a state reader.
+
+## Output
+
+The sealed `runx.agency_health.v1` packet contains:
+
+```yaml
+decision: ready | needs_more_evidence | needs_human
+health_verdict:
+  status: healthy | degraded | critical | unknown
+  findings:
+    - metric: seal_rate | stuck_case_count | cap_usage_pct | escalation_backlog
+      value: number
+      norm: string
+      assessment: within_norm | concerning | breached
+      severity: info | warning | critical
+      evidence_refs: [string]
+intervention_findings:
+  - target_lane: policy-author | improve-skill | human-ops
+    severity: warning | critical
+    reason: string
+    grounding:
+      case_id: string
+      turns: [number]
+      ledger_id_stubs: [string]
+evidence:
+  folded_case_id: string
+  turn_numbers: [number]
+  ledger_id_stubs: [string]
+  refused_reasons: [string]
+```
+
+An intervention deliberately has no ceiling and no effect bound. It is consumed
+only when a downstream operator or driver issues a separate governed run.
+
+## Decision and routing rules
+
+- `ready`: the readable case supports a health verdict. Routine tightening or
+  debugging suggestions name `policy-author` or `improve-skill`.
+- `needs_more_evidence`: no events are readable, event/projection integrity does
+  not reconcile, an agency id conflicts, or a requested signal lacks a declared
+  norm. No ungrounded finding or intervention is emitted.
+- `needs_human`: any critical finding, cap-widening remedy, or
+  authority-widening remedy routes only to `human-ops`.
+
+`policy-author` may tighten a policy or timeout but cannot be used here to widen
+a cap. `improve-skill` may diagnose a member associated with a refusal spike or
+stalled turn. Neither lane runs automatically.
+
+## Refusals and evidence rules
+
+- Refuse to grade a signal not grounded in the folded case projection or ledger
+  id-stub aggregate.
+- Refuse to invent a turn, case state, cap, or threshold.
+- Refuse event rows that are out of order, duplicate a version, disagree with
+  the projection version/digests, or belong to another case.
+- Refuse ledger bodies as domain-keyed state and expose only id-stubs.
+- Refuse to emit an intervention when no case events are readable.
+- Never expose credentials, signing material, private receipt bodies, or provider
+  dumps in the output or evidence.
+
+## Worked example
+
+A case has three sealed turn events, one unresolved approval, no progress for
+six days, and 90% of its declared spend cap consumed. With a five-day stuck norm
+and an 80% cap-pressure norm, the skill returns `ready`, a `degraded` verdict,
+grounded stuck/cap/backlog findings, and named `policy-author` and
+`improve-skill` interventions. It does not tighten the timeout or dispatch the
+member itself.
+
+For an `agency_ref` whose resolved case has zero readable events, the same graph
+seals `needs_more_evidence`, `unknown`, empty findings, and no intervention.
+
+## Verification
+
+Run the local harness and verify a real receipt:
+
+```text
+runx harness ./skills/agency-health --json
+runx skill ./skills/agency-health --input data_source_ref=local://agency-health/real --input agency_ref=agent-17af92 --input case_id=case-frantic-revenue-001 --input-json period={...} --input-json health_baseline={...} --json
+runx verify --receipt <receipt.json> --json
+```
+
+For registry use, install the exact immutable version, run that registry ref on
+the real durable case, and verify the distinct post-publish receipt.
+
+## Quality Bar
+
+- The projection read, ordered event read, and ledger read must all execute in
+  the sealed graph; prose or caller-authored metrics are not substitutes.
+- Every grade names its norm and evidence reference.
+- Every intervention cites its case/turn or ledger id-stubs and names only a
+  separate downstream lane.
+- Missing evidence produces a truthful non-ready packet, never a fake healthy or
+  degraded result.

--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -12,6 +12,12 @@ domain-keyed `data-store.read_projection` and `data-store.read_events` reads wit
 the cross-run `ledger.read` runner, folds the agency case in version order, and
 seals one health verdict plus grounded intervention findings.
 
+For isolated registry installs, the package vendors the exact read-only C2/C7
+runner surfaces pinned by the source commit: `runx/data-store@sha-ca3a75ec5f21`
+and `runx/ledger@sha-3e6341beba7f`. The package-local copies preserve the
+upstream runner names and execution logic; they add no replacement metrics or
+caller-authored answers.
+
 It is a read-only diagnostic lane. It appends nothing, dispatches nothing,
 moves no money, grants no access, and consumes no effect. An intervention names
 the separate lane an operator or driver may run next; it is never that run.

--- a/skills/agency-health/SKILL.md
+++ b/skills/agency-health/SKILL.md
@@ -22,6 +22,10 @@ It is a read-only diagnostic lane. It appends nothing, dispatches nothing,
 moves no money, grants no access, and consumes no effect. An intervention names
 the separate lane an operator or driver may run next; it is never that run.
 
+The inline harness keeps the two domain cases named by the public contract and
+adds one registry-admission boundary: omitting required `agency_ref` must stop
+as `needs_agent` before any read is attempted.
+
 ## When to use this skill
 
 - A running agency appears stuck, approval-heavy, refusal-prone, or close to a

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -1,0 +1,169 @@
+skill: agency-health
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: concerning-agency-sealed
+      runner: assess
+      env:
+        RUNX_TOOL_ROOTS: skills/agency-health/tools
+        RUNX_DATA_SOURCES: '{"data_sources":{"local://agency-health/harness":{"adapter":"data.agency-health-harness","profile":"agency-health-harness-v1","cases":{"case-concerning-001":[{"committed_at":"2026-07-01T00:00:00Z","event":{"type":"opened","payload":{"agency_ref":"agency:revenue-ops","mandate":"Recover governed revenue opportunities","roster":[{"role":"operator","skill":"ops-desk","scope":["read"]}],"limits":{"max_turns":4,"spend":{"max_per_run":{"amount":50,"currency":"USD"}}}}}},{"committed_at":"2026-07-02T00:00:00Z","event":{"type":"turn","payload":{"turn":1,"decision":"dispatch","dispatch":{"member":"operator","skill":"ops-desk","task":"inspect claim"},"member_result":{"member":"operator","outcome":"sealed","status":"sealed","receipt_id":"rcpt_agency_turn_001","spend":{"amount":45,"currency":"USD"}}}}},{"committed_at":"2026-07-03T00:00:00Z","event":{"type":"turn","payload":{"turn":2,"decision":"escalate","escalation":{"ask":"Approve a narrower retry"},"member_result":{"member":"operator","outcome":"refused","status":"refused","receipt_id":"rcpt_agency_turn_002"}}}}]}}}}'
+      inputs:
+        data_source_ref: local://agency-health/harness
+        store_id: concerning-agency-sealed
+        agency_ref: agency:revenue-ops
+        case_id: case-concerning-001
+        period:
+          from: "2026-07-01T00:00:00Z"
+          to: "2026-07-09T00:00:00Z"
+        health_baseline:
+          threshold_days_stuck: 5
+          cap_pressure_pct: 80
+          refusal_spike_rate: 0.25
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+        steps:
+          - prepare
+          - read-projection
+          - read-events
+          - read-ledger
+          - project-ledger-stubs
+          - read-case-ledger
+          - grade
+    - name: no-case-events-stop
+      runner: assess
+      env:
+        RUNX_TOOL_ROOTS: skills/agency-health/tools
+        RUNX_DATA_SOURCES: '{"data_sources":{"local://agency-health/harness":{"adapter":"data.agency-health-harness","profile":"agency-health-harness-v1","cases":{"case-concerning-001":[]}}}}'
+      inputs:
+        data_source_ref: local://agency-health/harness
+        store_id: no-case-events-stop
+        agency_ref: agency:missing
+        case_id: case-no-events-001
+        period:
+          from: "2026-07-01T00:00:00Z"
+          to: "2026-07-09T00:00:00Z"
+        health_baseline:
+          threshold_days_stuck: 5
+          cap_pressure_pct: 80
+          refusal_spike_rate: 0.25
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+        steps:
+          - prepare
+          - read-projection
+          - read-events
+          - read-ledger
+          - project-ledger-stubs
+          - read-case-ledger
+          - grade
+
+runners:
+  assess:
+    default: true
+    type: graph
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+        description: Stable logical data source holding the agency case.
+      store_id:
+        type: string
+        required: false
+        description: Explicit local fixture store id; omit for durable SQLite.
+      agency_ref:
+        type: string
+        required: true
+        description: Agency definition expected in the opened case event.
+      period:
+        type: json
+        required: false
+        description: Optional ISO-8601 query bounds as {from,to}.
+      case_id:
+        type: string
+        required: false
+        description: Agency case aggregate id; defaults deterministically to agency_ref.
+      health_baseline:
+        type: json
+        required: false
+        description: Optional thresholds {threshold_days_stuck,cap_pressure_pct,refusal_spike_rate}.
+    graph:
+      name: agency-health-assess
+      steps:
+        - id: prepare
+          skill: ./graph/prepare
+          inputs:
+            agency_ref: "$input.agency_ref"
+            case_id: "$input.case_id"
+            period: "$input.period"
+            health_baseline: "$input.health_baseline"
+          artifacts:
+            wrap_as: query_plan
+            packet: runx.agency_health.query.v1
+        - id: read-projection
+          skill: ../data-store
+          runner: read_projection
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: agency_cases
+          context:
+            aggregate_id: prepare.query_plan.data.case_id
+        - id: read-events
+          skill: ../data-store
+          runner: read_events
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: agency_cases
+            limit: 500
+          context:
+            aggregate_id: prepare.query_plan.data.case_id
+        - id: read-ledger
+          skill: ../ledger
+          runner: read
+          context:
+            question: prepare.query_plan.data.ledger_question
+            filter: prepare.query_plan.data.ledger_filter
+            proof: prepare.query_plan.data.ledger_proof
+        - id: project-ledger-stubs
+          skill: ./graph/ledger-stubs
+          context:
+            events: read-events.data_operation_result.data.events
+            period: prepare.query_plan.data.period
+          artifacts:
+            wrap_as: ledger_seed
+            packet: runx.agency_health.ledger_seed.v1
+        - id: read-case-ledger
+          skill: ../ledger
+          runner: read
+          context:
+            question: prepare.query_plan.data.ledger_question
+            filter: prepare.query_plan.data.ledger_filter
+            proof: prepare.query_plan.data.ledger_proof
+            receipts: project-ledger-stubs.ledger_seed.data.receipts
+        - id: grade
+          skill: ./graph/grade
+          inputs:
+            agency_ref: "$input.agency_ref"
+          context:
+            case_id: prepare.query_plan.data.case_id
+            period: prepare.query_plan.data.period
+            health_baseline: prepare.query_plan.data.health_baseline
+            projection: read-projection.data_operation_result.data.projection
+            events: read-events.data_operation_result.data.events
+            ledger: read-ledger.ledger_answer_packet.data
+            case_ledger: read-case-ledger.ledger_answer_packet.data
+          artifacts:
+            wrap_as: health_bundle
+            packet: runx.agency_health.v1

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -111,7 +111,7 @@ runners:
             wrap_as: query_plan
             packet: runx.agency_health.query.v1
         - id: read-projection
-          skill: ../data-store
+          skill: ./dependencies/data-store
           runner: read_projection
           inputs:
             data_source_ref: "$input.data_source_ref"
@@ -120,7 +120,7 @@ runners:
           context:
             aggregate_id: prepare.query_plan.data.case_id
         - id: read-events
-          skill: ../data-store
+          skill: ./dependencies/data-store
           runner: read_events
           inputs:
             data_source_ref: "$input.data_source_ref"
@@ -130,7 +130,7 @@ runners:
           context:
             aggregate_id: prepare.query_plan.data.case_id
         - id: read-ledger
-          skill: ../ledger
+          skill: ./dependencies/ledger
           runner: read
           context:
             question: prepare.query_plan.data.ledger_question
@@ -145,7 +145,7 @@ runners:
             wrap_as: ledger_seed
             packet: runx.agency_health.ledger_seed.v1
         - id: read-case-ledger
-          skill: ../ledger
+          skill: ./dependencies/ledger
           runner: read
           context:
             question: prepare.query_plan.data.ledger_question

--- a/skills/agency-health/X.yaml
+++ b/skills/agency-health/X.yaml
@@ -67,6 +67,15 @@ harness:
           - project-ledger-stubs
           - read-case-ledger
           - grade
+    - name: missing-agency-ref-needs-agent
+      runner: assess
+      inputs:
+        data_source_ref: local://agency-health/harness
+        store_id: missing-agency-ref-needs-agent
+      expect:
+        status: needs_agent
+        receipt:
+          schema: runx.receipt.v1
 
 runners:
   assess:

--- a/skills/agency-health/dependencies/data-store/SKILL.md
+++ b/skills/agency-health/dependencies/data-store/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: data-store
+description: "Pinned read-only C2 surface for domain-keyed event and projection reads inside the isolated agency-health registry package."
+runx:
+  category: internal
+---
+
+# Pinned data-store read surface
+
+This package-local dependency preserves only the `read_events` and
+`read_projection` runners from `runx/data-store@sha-ca3a75ec5f21` at source
+commit `46e85c59bfdc1fc91c380d2d4b0852c1edfc8b77`. Its official lock digest is
+`fbf0c7356f063f4fa12c9ff3bd944587f9202fb1520238a6652c90c907cb062f`.
+
+Both runners call the runtime's governed `data.source` virtual router with
+`runx:data:read`. No append runner, write scope, fixture row, or private binding
+is included. This compatibility snapshot exists because a published skill is
+reconstructed in isolation and cannot reach sibling packages from the source
+monorepo.
+
+The package also carries the upstream `data.sqlite@0.1.0` tool implementation
+so an installed registry package can read a durable local case. The public
+`agency-health` graph exposes only the two read runners above and never invokes
+the adapter's append operation.

--- a/skills/agency-health/dependencies/data-store/X.yaml
+++ b/skills/agency-health/dependencies/data-store/X.yaml
@@ -1,0 +1,92 @@
+skill: data-store
+version: "0.2.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/agency-health
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+  deny:
+    - raw_sql_from_model
+    - unrestricted_export
+    - secret_material
+
+emits:
+  - name: data_operation_result
+    packet: runx.data.operation_result.v1
+
+runners:
+  read_events:
+    type: graph
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+      store_id:
+        type: string
+        required: false
+      resource:
+        type: string
+        required: true
+      aggregate_id:
+        type: string
+        required: true
+      limit:
+        type: number
+        required: false
+        default: 50
+      after_version:
+        type: number
+        required: false
+    graph:
+      name: data-store-read-events
+      steps:
+        - id: read
+          tool: data.source
+          scopes:
+            - runx:data:read
+          inputs:
+            operation: read_events
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+            limit: "$input.limit"
+            after_version: "$input.after_version"
+
+  read_projection:
+    type: graph
+    inputs:
+      data_source_ref:
+        type: string
+        required: true
+      store_id:
+        type: string
+        required: false
+      resource:
+        type: string
+        required: true
+      aggregate_id:
+        type: string
+        required: true
+    graph:
+      name: data-store-read-projection
+      steps:
+        - id: read
+          tool: data.source
+          scopes:
+            - runx:data:read
+          inputs:
+            operation: read_projection
+            data_source_ref: "$input.data_source_ref"
+            store_id: "$input.store_id"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"

--- a/skills/agency-health/dependencies/ledger/SKILL.md
+++ b/skills/agency-health/dependencies/ledger/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: ledger
+description: "Pinned read-only C7 receipt-ledger runner for the isolated agency-health registry package."
+runx:
+  category: internal
+---
+
+# Pinned ledger read surface
+
+This package-local dependency preserves the `read` runner and runtime from
+`runx/ledger@sha-3e6341beba7f` at source commit
+`46e85c59bfdc1fc91c380d2d4b0852c1edfc8b77`. Its official lock digest is
+`f91e656d6fcef27dec6e12725c8015be47762514278f37342ff40761838e9f6c`.
+
+The runner shells the shipped `runx history`/`runx verify` engine for ambient
+history or accepts controlled receipt rows for deterministic evaluation, then
+projects them to id-stubs. It never returns a receipt body and has no write or
+effect surface.

--- a/skills/agency-health/dependencies/ledger/X.yaml
+++ b/skills/agency-health/dependencies/ledger/X.yaml
@@ -1,0 +1,39 @@
+skill: ledger
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/agency-health
+
+runners:
+  read:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      ledger_answer: object
+      matched_receipts: array
+      chain_verification: object
+      summary: string
+    artifacts:
+      wrap_as: ledger_answer_packet
+      packet: runx.ledger_answer.v1
+    inputs:
+      question:
+        type: string
+        required: false
+      filter:
+        type: json
+        required: false
+      proof:
+        type: json
+        required: false
+      receipts:
+        type: json
+        required: false

--- a/skills/agency-health/dependencies/ledger/run.mjs
+++ b/skills/agency-health/dependencies/ledger/run.mjs
@@ -1,0 +1,218 @@
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+// In-sandbox receipt-ledger reader. Shells the shipped `runx history`/`runx
+// verify` engine (the one source of truth for the no-body projection and the
+// tree-rooted chain verdict) and projects each matched receipt down to an
+// id-stub. A `receipts` caller-override input replays a fixed ledger without
+// shelling out, mirroring reflect-digest's reflect_projections override, so the
+// inline harness is deterministic regardless of the receipt store or binary
+// linkage. The reader never writes and never copies a receipt body.
+
+const inputs = readInputs();
+const question = stringValue(inputs.question);
+const filter = readFilter(inputs.filter);
+const proofRequested = readProofRequested(inputs.proof);
+const overrideRows = Array.isArray(inputs.receipts) && inputs.receipts.length > 0
+  ? inputs.receipts
+  : undefined;
+
+const query = {
+  principal: filter.principal || "",
+  skill_ref: filter.skill_ref || "",
+  status: filter.status,
+  time_range: {
+    from: filter.from || "",
+    to: filter.to || "",
+  },
+};
+
+let packet;
+if (!question) {
+  // No question bounds the read. The reader is deterministic and always seals,
+  // so it reports the stop in the packet rather than deferring to an agent.
+  packet = {
+    ledger_answer: {
+      decision: "needs_agent",
+      question: "",
+      query,
+    },
+    matched_receipts: [],
+    chain_verification: { checked: false, intact: null, breaks: [] },
+    summary: "No audit question was provided, so there is nothing to query against the ledger.",
+  };
+} else {
+  const rows = overrideRows !== undefined ? overrideRows : historyRows(filter);
+  const matched = rows.map(projectIdStub).filter((stub) => matchesFilter(stub, filter));
+
+  let chain;
+  if (!proofRequested) {
+    chain = { checked: false, intact: null, breaks: [] };
+  } else if (overrideRows !== undefined) {
+    // The override path replays a fixed ledger and does not consult the verify
+    // engine, so the chain cannot be proven here. Fail closed: unverified.
+    chain = { checked: true, intact: null, breaks: [] };
+  } else {
+    chain = verifyChain();
+  }
+
+  const decision = matched.length === 0 ? "needs_more_evidence" : "answered";
+  packet = {
+    ledger_answer: {
+      decision,
+      question,
+      query,
+    },
+    matched_receipts: matched,
+    chain_verification: chain,
+    summary: renderSummary({ decision, matched, chain, proofRequested, query }),
+  };
+}
+
+process.stdout.write(`${JSON.stringify(packet, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function readFilter(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { principal: null, skill_ref: null, status: [], from: null, to: null, source: null, actor: null };
+  }
+  const timeRange = value.time_range && typeof value.time_range === "object" ? value.time_range : {};
+  const status = Array.isArray(value.status)
+    ? value.status.map(String).filter((entry) => entry.trim().length > 0)
+    : stringValue(value.status)
+      ? [stringValue(value.status)]
+      : [];
+  return {
+    principal: stringValue(value.principal),
+    skill_ref: stringValue(value.skill_ref),
+    status,
+    from: stringValue(timeRange.from),
+    to: stringValue(timeRange.to),
+    source: stringValue(value.source),
+    actor: stringValue(value.actor) || stringValue(value.principal),
+  };
+}
+
+function readProofRequested(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return value.verify_chain === true;
+}
+
+// Shell the shipped `runx history --json` so the no-body projection (store.rs)
+// and signature policy stay the one source of truth. Inherits RUNX_RECEIPT_DIR
+// from the sandbox env; never re-reads the store with a custom parser.
+function historyRows(filter) {
+  const args = ["history", "--json"];
+  if (filter.skill_ref) args.push("--skill", filter.skill_ref);
+  if (filter.status.length === 1) args.push("--status", filter.status[0]);
+  if (filter.source) args.push("--source", filter.source);
+  if (filter.actor) args.push("--actor", filter.actor);
+  if (filter.from) args.push("--since", filter.from);
+  if (filter.to) args.push("--until", filter.to);
+  const result = spawnSync("runx", args, { env: process.env, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || "").trim() || "runx history failed");
+  }
+  const projection = JSON.parse(result.stdout || "{}");
+  return Array.isArray(projection.receipts) ? projection.receipts : [];
+}
+
+// Shell the shipped `runx verify --json`, which is TREE-grouped, not a linear
+// link walk. Reconcile the tree verdict honestly: intact <- report.valid,
+// breaks <- each tree's parent_missing plus its findings, named by id ref.
+// When the engine ran without verify keys (signature_mode != production), the
+// chain is reported unverified (fail closed), never silently intact.
+function verifyChain() {
+  const result = spawnSync("runx", ["verify", "--json"], { env: process.env, encoding: "utf8" });
+  // verify exits non-zero when the chain is invalid; the JSON report still
+  // carries the verdict, so parse it before treating the exit as a hard error.
+  let report;
+  try {
+    report = JSON.parse(result.stdout || "{}");
+  } catch {
+    throw new Error((result.stderr || "").trim() || "runx verify failed");
+  }
+  if (report.signature_mode !== "production") {
+    return { checked: true, intact: null, breaks: [] };
+  }
+  const breaks = [];
+  for (const tree of Array.isArray(report.trees) ? report.trees : []) {
+    if (tree.parent_missing) {
+      breaks.push({
+        from_receipt_id: String(tree.parent_missing),
+        to_receipt_id: String(tree.root_receipt_id || ""),
+        reason: "parent receipt missing from the verified tree",
+      });
+    }
+    for (const finding of Array.isArray(tree.findings) ? tree.findings : []) {
+      breaks.push({
+        from_receipt_id: String(tree.root_receipt_id || ""),
+        to_receipt_id: String(finding.path || ""),
+        reason: stringValue(finding.message) || stringValue(finding.code) || "verification finding",
+      });
+    }
+  }
+  return { checked: true, intact: report.valid === true, breaks };
+}
+
+// Project ONE receipt down to an id-stub. Accepts the engine row shape
+// (id/name) or an already-stubbed override row (receipt_id/skill_ref). Copies
+// ONLY {receipt_id, skill_ref, status, created_at}; summary, actors,
+// artifact_types, verification, and any harness body are dropped.
+function projectIdStub(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    throw new Error("ledger row must be an object");
+  }
+  const receiptId = stringValue(row.receipt_id) || stringValue(row.id);
+  if (!receiptId) {
+    throw new Error("ledger row is missing a receipt id");
+  }
+  return {
+    receipt_id: receiptId,
+    skill_ref: stringValue(row.skill_ref) || stringValue(row.name) || "",
+    status: stringValue(row.status) || "",
+    created_at: stringValue(row.created_at) || "",
+  };
+}
+
+// The engine already filters by skill/status/time when shelled. The override
+// replay path supplies raw rows, so apply the same narrowing in-process so a
+// seeded ledger and a shelled ledger answer the same query.
+function matchesFilter(stub, filter) {
+  if (filter.skill_ref && stub.skill_ref !== filter.skill_ref) return false;
+  if (filter.status.length > 0 && !filter.status.includes(stub.status)) return false;
+  if (filter.from && stub.created_at && stub.created_at < filter.from) return false;
+  if (filter.to && stub.created_at && stub.created_at > filter.to) return false;
+  return true;
+}
+
+function renderSummary({ decision, matched, chain, proofRequested, query }) {
+  if (decision === "needs_more_evidence") {
+    const scope = query.skill_ref || query.principal || "the ledger";
+    return `No receipts matched the resolved query against ${scope}; the gap is the query, not a confirmed zero.`;
+  }
+  const count = matched.length;
+  const noun = count === 1 ? "receipt" : "receipts";
+  if (!proofRequested) {
+    return `${count} ${noun} matched the resolved query; chain verification was not requested.`;
+  }
+  if (chain.intact === null) {
+    return `${count} ${noun} matched the resolved query; the chain is unverified because verify keys were not available.`;
+  }
+  if (chain.intact) {
+    return `${count} ${noun} matched the resolved query, and the engine's tree-rooted verify verdict is intact.`;
+  }
+  return `${count} ${noun} matched the resolved query, but the engine's tree-rooted verify verdict reports ${chain.breaks.length} break(s).`;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}

--- a/skills/agency-health/fixtures/concerning-agency-sealed.yaml
+++ b/skills/agency-health/fixtures/concerning-agency-sealed.yaml
@@ -1,0 +1,31 @@
+name: concerning-agency-sealed
+kind: skill
+target: ..
+runner: assess
+env:
+  RUNX_TOOL_ROOTS: skills/agency-health/tools
+  RUNX_DATA_SOURCES: '{"data_sources":{"local://agency-health/harness":{"adapter":"data.agency-health-harness","profile":"agency-health-harness-v1","cases":{"case-concerning-001":[{"committed_at":"2026-07-01T00:00:00Z","event":{"type":"opened","payload":{"agency_ref":"agency:revenue-ops","mandate":"Recover governed revenue opportunities","roster":[{"role":"operator","skill":"ops-desk","scope":["read"]}],"limits":{"max_turns":4,"spend":{"max_per_run":{"amount":50,"currency":"USD"}}}}}},{"committed_at":"2026-07-02T00:00:00Z","event":{"type":"turn","payload":{"turn":1,"decision":"dispatch","dispatch":{"member":"operator","skill":"ops-desk","task":"inspect claim"},"member_result":{"member":"operator","outcome":"sealed","status":"sealed","receipt_id":"rcpt_agency_turn_001","spend":{"amount":45,"currency":"USD"}}}}},{"committed_at":"2026-07-03T00:00:00Z","event":{"type":"turn","payload":{"turn":2,"decision":"escalate","escalation":{"ask":"Approve a narrower retry"},"member_result":{"member":"operator","outcome":"refused","status":"refused","receipt_id":"rcpt_agency_turn_002"}}}}]}}}}'
+inputs:
+  data_source_ref: local://agency-health/harness
+  store_id: concerning-agency-sealed
+  agency_ref: agency:revenue-ops
+  case_id: case-concerning-001
+  period:
+    from: "2026-07-01T00:00:00Z"
+    to: "2026-07-09T00:00:00Z"
+  health_baseline:
+    threshold_days_stuck: 5
+    cap_pressure_pct: 80
+    refusal_spike_rate: 0.25
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+  steps:
+    - prepare
+    - read-projection
+    - read-events
+    - read-ledger
+    - project-ledger-stubs
+    - read-case-ledger
+    - grade

--- a/skills/agency-health/fixtures/missing-agency-ref-needs-agent.yaml
+++ b/skills/agency-health/fixtures/missing-agency-ref-needs-agent.yaml
@@ -1,0 +1,11 @@
+name: missing-agency-ref-needs-agent
+kind: skill
+target: ..
+runner: assess
+inputs:
+  data_source_ref: local://agency-health/harness
+  store_id: missing-agency-ref-needs-agent
+expect:
+  status: needs_agent
+  receipt:
+    schema: runx.receipt.v1

--- a/skills/agency-health/fixtures/no-case-events-stop.yaml
+++ b/skills/agency-health/fixtures/no-case-events-stop.yaml
@@ -1,0 +1,31 @@
+name: no-case-events-stop
+kind: skill
+target: ..
+runner: assess
+env:
+  RUNX_TOOL_ROOTS: skills/agency-health/tools
+  RUNX_DATA_SOURCES: '{"data_sources":{"local://agency-health/harness":{"adapter":"data.agency-health-harness","profile":"agency-health-harness-v1","cases":{}}}}'
+inputs:
+  data_source_ref: local://agency-health/harness
+  store_id: no-case-events-stop
+  agency_ref: agency:missing
+  case_id: case-no-events-001
+  period:
+    from: "2026-07-01T00:00:00Z"
+    to: "2026-07-09T00:00:00Z"
+  health_baseline:
+    threshold_days_stuck: 5
+    cap_pressure_pct: 80
+    refusal_spike_rate: 0.25
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+  steps:
+    - prepare
+    - read-projection
+    - read-events
+    - read-ledger
+    - project-ledger-stubs
+    - read-case-ledger
+    - grade

--- a/skills/agency-health/graph/grade/SKILL.md
+++ b/skills/agency-health/graph/grade/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: agency-health-grade
+description: Validate composed agency projection, event, and ledger evidence, then deterministically grade a typed read-only health verdict.
+---
+
+# Agency Health Grade
+
+Internal deterministic stage for `agency-health`. It reconciles projection and
+event order, folds the case, grades only signals with declared norms, and emits
+grounded dispatch-by-naming findings. Missing or conflicting evidence produces
+`needs_more_evidence`; this stage has no effect capability.

--- a/skills/agency-health/graph/grade/X.yaml
+++ b/skills/agency-health/graph/grade/X.yaml
@@ -1,0 +1,51 @@
+skill: agency-health-grade
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/agency-health
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      agency_ref:
+        type: string
+        required: true
+        description: Agency definition expected in the opened event.
+      case_id:
+        type: string
+        required: true
+        description: Resolved agency case aggregate id.
+      period:
+        type: json
+        required: false
+        description: Normalized ISO-8601 period.
+      health_baseline:
+        type: json
+        required: false
+        description: Normalized declared health thresholds.
+      projection:
+        type: json
+        required: false
+        description: data-store.read_projection output for the case.
+      events:
+        type: json
+        required: false
+        description: data-store.read_events rows for the same case.
+      ledger:
+        type: json
+        required: false
+        description: ledger.read packet containing id-stubs only.
+      case_ledger:
+        type: json
+        required: false
+        description: Second ledger.read packet over receipt id-stubs already cited by ordered case events.

--- a/skills/agency-health/graph/grade/run.mjs
+++ b/skills/agency-health/graph/grade/run.mjs
@@ -1,0 +1,381 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const agencyRef = requiredString(inputs.agency_ref, "agency_ref");
+const caseId = requiredString(inputs.case_id, "case_id");
+const projection = objectValue(inputs.projection);
+const events = Array.isArray(inputs.events) ? inputs.events : [];
+const ledger = objectValue(inputs.ledger);
+const caseLedger = objectValue(inputs.case_ledger);
+const period = objectValue(inputs.period);
+
+const integrityReasons = validateIntegrity({ projection, events, caseId });
+if (events.length === 0) {
+  emit(nonReady(caseId, "No readable case events exist for the resolved agency case over the requested period."));
+}
+if (integrityReasons.length > 0) {
+  emit(nonReady(caseId, integrityReasons.join(" ")));
+}
+
+const state = foldEvents(events);
+if (!state.opened) {
+  emit(nonReady(caseId, "The readable stream has no opened event, so no agency charter snapshot can be grounded."));
+}
+if (state.agency_ref !== agencyRef) {
+  emit(nonReady(caseId, `The opened event belongs to ${state.agency_ref || "an unknown agency"}, not ${agencyRef}.`));
+}
+
+const suppliedBaseline = objectValue(inputs.health_baseline);
+const charterBaseline = objectValue(state.limits.health_baseline);
+const baseline = { ...charterBaseline, ...suppliedBaseline };
+const refusedReasons = [];
+const findings = [];
+const actualLedgerStubs = normalizeLedgerStubs(ledger.matched_receipts);
+const caseLedgerStubs = normalizeLedgerStubs(caseLedger.matched_receipts);
+const caseReceiptIds = new Set(state.receipt_ids.map(normalizeReceiptIdentity));
+const actualCaseLedgerStubs = actualLedgerStubs.filter((stub) => caseReceiptIds.has(normalizeReceiptIdentity(stub.receipt_id)));
+const ledgerStubs = actualCaseLedgerStubs.length > 0 ? actualCaseLedgerStubs : caseLedgerStubs;
+const ledgerSource = actualCaseLedgerStubs.length > 0 ? "actual-ledger-read" : caseLedgerStubs.length > 0 ? "case-referenced-ledger-read" : "none";
+const turnRefs = state.turn_numbers.map((turn) => `agency_cases:${caseId}:turn:${turn}`);
+
+gradeSealRate();
+gradeStuckCases();
+gradeCapUsage();
+gradeEscalationBacklog();
+
+const critical = findings.some((finding) => finding.severity === "critical");
+const concerning = findings.some((finding) => finding.assessment !== "within_norm");
+const decision = critical ? "needs_human" : refusedReasons.length > 0 ? "needs_more_evidence" : "ready";
+const status = critical ? "critical" : concerning ? "degraded" : findings.length > 0 ? "healthy" : "unknown";
+const interventions = decision === "needs_more_evidence"
+  ? []
+  : buildInterventions({ findings, caseId, turnNumbers: state.turn_numbers, ledgerStubs, critical });
+
+emit({
+  schema: "runx.agency_health.v1",
+  decision,
+  health_verdict: {
+    status,
+    findings,
+  },
+  intervention_findings: interventions,
+  evidence: {
+    folded_case_id: caseId,
+    projection_version: numberValue(projection.version),
+    turn_numbers: state.turn_numbers,
+    turn_refs: turnRefs,
+    ledger_id_stubs: ledgerStubs.map((stub) => stub.receipt_id),
+    ledger_source: ledgerSource,
+    refused_reasons: refusedReasons,
+  },
+});
+
+function gradeSealRate() {
+  const refusalThreshold = finiteNumber(baseline.refusal_spike_rate);
+  if (refusalThreshold === null) {
+    refusedReasons.push("seal_rate was not graded because refusal_spike_rate is absent from the charter snapshot and supplied baseline.");
+    return;
+  }
+  if (ledgerStubs.length === 0) {
+    refusedReasons.push("seal_rate was not graded because ledger.read returned no grounded receipt id-stubs.");
+    return;
+  }
+  const relevant = ledgerStubs.filter((stub) => stub.status === "sealed" || stub.status === "refused");
+  if (relevant.length === 0) {
+    refusedReasons.push("seal_rate was not graded because no ledger id-stub had sealed or refused status.");
+    return;
+  }
+  const sealed = relevant.filter((stub) => stub.status === "sealed").length;
+  const rate = round(sealed / relevant.length, 4);
+  const minimum = round(1 - refusalThreshold, 4);
+  const breached = rate < minimum;
+  findings.push(finding({
+    metric: "seal_rate",
+    value: rate,
+    norm: `seal_rate >= ${minimum} (1 - refusal_spike_rate ${refusalThreshold})`,
+    assessment: breached ? "breached" : "within_norm",
+    severity: breached ? "warning" : "info",
+    evidenceRefs: relevant.map((stub) => `ledger:${stub.receipt_id}`),
+  }));
+}
+
+function gradeStuckCases() {
+  const threshold = finiteNumber(baseline.threshold_days_stuck);
+  const to = isoMillis(period.to);
+  const lastProgress = isoMillis(state.last_progress_at);
+  if (threshold === null) {
+    refusedReasons.push("stuck_case_count was not graded because threshold_days_stuck is absent from the charter snapshot and supplied baseline.");
+    return;
+  }
+  if (to === null || lastProgress === null) {
+    refusedReasons.push("stuck_case_count was not graded because period.to or a grounded progress timestamp is unavailable.");
+    return;
+  }
+  const days = Math.max(0, (to - lastProgress) / 86_400_000);
+  const count = state.closed ? 0 : days >= threshold ? 1 : 0;
+  const critical = count === 1 && days >= threshold * 2;
+  findings.push(finding({
+    metric: "stuck_case_count",
+    value: count,
+    norm: `0 cases without grounded progress for ${threshold} days`,
+    assessment: count === 0 ? "within_norm" : critical ? "breached" : "concerning",
+    severity: count === 0 ? "info" : critical ? "critical" : "warning",
+    evidenceRefs: state.last_turn === null
+      ? [`agency_cases:${caseId}:opened`]
+      : [`agency_cases:${caseId}:turn:${state.last_turn}`],
+  }));
+}
+
+function gradeCapUsage() {
+  const threshold = finiteNumber(baseline.cap_pressure_pct);
+  if (threshold === null) {
+    refusedReasons.push("cap_usage_pct was not graded because cap_pressure_pct is absent from the charter snapshot and supplied baseline.");
+    return;
+  }
+  const ratios = [];
+  const maxTurns = positiveNumber(state.limits.max_turns);
+  if (maxTurns !== null) ratios.push((state.acts / maxTurns) * 100);
+  const spendCap = positiveNumber(state.limits.spend?.max_per_run?.amount);
+  if (spendCap !== null) ratios.push((state.spend_amount / spendCap) * 100);
+  if (ratios.length === 0) {
+    refusedReasons.push("cap_usage_pct was not graded because the opened charter snapshot contains no readable turn or spend cap.");
+    return;
+  }
+  const value = round(Math.max(...ratios), 2);
+  const critical = value >= 100;
+  const concerning = value >= threshold;
+  findings.push(finding({
+    metric: "cap_usage_pct",
+    value,
+    norm: `cap_usage_pct < ${threshold} until the declared cap is exhausted`,
+    assessment: critical ? "breached" : concerning ? "concerning" : "within_norm",
+    severity: critical ? "critical" : concerning ? "warning" : "info",
+    evidenceRefs: [`agency_cases:${caseId}:opened`, ...state.turn_numbers.map((turn) => `agency_cases:${caseId}:turn:${turn}`)],
+  }));
+}
+
+function gradeEscalationBacklog() {
+  const value = state.pending_escalations.length;
+  findings.push(finding({
+    metric: "escalation_backlog",
+    value,
+    norm: "0 unresolved agency escalation events",
+    assessment: value > 0 ? "concerning" : "within_norm",
+    severity: value > 0 ? "warning" : "info",
+    evidenceRefs: value > 0
+      ? state.pending_escalations.map((turn) => `agency_cases:${caseId}:turn:${turn}`)
+      : [`agency_cases:${caseId}:projection:${projection.version ?? events.length}`],
+  }));
+}
+
+function validateIntegrity({ projection, events, caseId }) {
+  const reasons = [];
+  const version = numberValue(projection.version);
+  const count = numberValue(projection.event_count);
+  if (projection.aggregate_id && projection.aggregate_id !== caseId) {
+    reasons.push("Projection aggregate_id does not match the resolved case_id.");
+  }
+  if (version !== null && version !== events.length) {
+    reasons.push(`Projection version ${version} does not match ${events.length} readable events.`);
+  }
+  if (count !== null && count !== events.length) {
+    reasons.push(`Projection event_count ${count} does not match ${events.length} readable events.`);
+  }
+  const digests = Array.isArray(projection.event_digests) ? projection.event_digests : [];
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index];
+    if (numberValue(event?.version) !== index + 1) {
+      reasons.push(`Event order is not contiguous at index ${index}.`);
+      break;
+    }
+    if (digests.length > 0 && event?.event_digest !== digests[index]) {
+      reasons.push(`Event digest does not match projection order at version ${index + 1}.`);
+      break;
+    }
+  }
+  return reasons;
+}
+
+function foldEvents(entries) {
+  const state = {
+    opened: false,
+    agency_ref: "",
+    limits: {},
+    turn_numbers: [],
+    last_turn: null,
+    last_progress_at: null,
+    acts: 0,
+    spend_amount: 0,
+    pending_escalations: [],
+    receipt_ids: [],
+    closed: false,
+  };
+  for (const entry of entries) {
+    const event = objectValue(entry?.event);
+    const payload = objectValue(event.payload);
+    const committedAt = optionalString(entry?.committed_at);
+    if (event.type === "opened") {
+      state.opened = true;
+      state.agency_ref = optionalString(payload.agency_ref) ?? "";
+      state.limits = objectValue(payload.limits);
+      state.last_progress_at = committedAt;
+      continue;
+    }
+    if (event.type === "turn") {
+      const turn = numberValue(payload.turn);
+      if (turn !== null) {
+        state.turn_numbers.push(turn);
+        state.last_turn = turn;
+      }
+      const result = objectValue(payload.member_result);
+      if (Object.keys(result).length > 0) {
+        state.acts += 1;
+        const receiptId = optionalString(result.receipt_id) ?? optionalString(result.receipt_ref);
+        if (receiptId) state.receipt_ids.push(receiptId);
+        const spend = finiteNumber(result.spend?.amount);
+        if (spend !== null) state.spend_amount += spend;
+        const outcome = (optionalString(result.status) ?? optionalString(result.outcome) ?? "").toLowerCase();
+        const resultAt = optionalString(result.created_at) ?? committedAt;
+        if (!["refused", "blocked", "no_progress", "failed"].includes(outcome) && resultAt) {
+          state.last_progress_at = resultAt;
+        }
+      }
+      if (payload.decision === "escalate") {
+        if (turn !== null) state.pending_escalations.push(turn);
+      } else if (payload.decision === "done" || payload.decision === "failed") {
+        state.closed = true;
+        state.pending_escalations = [];
+      }
+      continue;
+    }
+    if (event.type === "approved" || event.type === "denied") {
+      state.pending_escalations.shift();
+      if (committedAt) state.last_progress_at = committedAt;
+    }
+  }
+  return state;
+}
+
+function buildInterventions({ findings, caseId, turnNumbers, ledgerStubs, critical }) {
+  const ledgerIds = ledgerStubs.map((stub) => stub.receipt_id);
+  if (critical) {
+    return [{
+      target_lane: "human-ops",
+      severity: "critical",
+      reason: "A critical grounded finding requires human review; any cap or authority widening is outside this read-only lane.",
+      grounding: { case_id: caseId, turns: turnNumbers, ledger_id_stubs: ledgerIds },
+    }];
+  }
+  const interventions = [];
+  const byMetric = new Map(findings.map((entry) => [entry.metric, entry]));
+  if (["concerning", "breached"].includes(byMetric.get("cap_usage_pct")?.assessment)
+      || ["concerning", "breached"].includes(byMetric.get("escalation_backlog")?.assessment)) {
+    interventions.push({
+      target_lane: "policy-author",
+      severity: "warning",
+      reason: "Review a narrower policy or approval timeout; do not widen the declared cap or authority.",
+      grounding: { case_id: caseId, turns: turnNumbers, ledger_id_stubs: [] },
+    });
+  }
+  if (["concerning", "breached"].includes(byMetric.get("stuck_case_count")?.assessment)
+      || ["concerning", "breached"].includes(byMetric.get("seal_rate")?.assessment)) {
+    interventions.push({
+      target_lane: "improve-skill",
+      severity: "warning",
+      reason: "Inspect the member or skill behind the grounded stall or refusal pattern in a separate governed run.",
+      grounding: { case_id: caseId, turns: turnNumbers, ledger_id_stubs: ledgerIds },
+    });
+  }
+  return interventions;
+}
+
+function finding({ metric, value, norm, assessment, severity, evidenceRefs }) {
+  return { metric, value, norm, assessment, severity, evidence_refs: evidenceRefs };
+}
+
+function normalizeLedgerStubs(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((row) => ({
+    receipt_id: optionalString(row?.receipt_id) ?? "",
+    skill_ref: optionalString(row?.skill_ref) ?? "",
+    status: normalizeLedgerStatus(row?.status),
+    created_at: optionalString(row?.created_at) ?? "",
+  })).filter((row) => row.receipt_id.length > 0);
+}
+
+function normalizeLedgerStatus(value) {
+  const status = (optionalString(value) ?? "").toLowerCase();
+  return status === "closed" ? "sealed" : status;
+}
+
+function normalizeReceiptIdentity(value) {
+  return (optionalString(value) ?? "").replace(/^runx:receipt:/, "");
+}
+
+function nonReady(caseId, reason) {
+  return {
+    schema: "runx.agency_health.v1",
+    decision: "needs_more_evidence",
+    health_verdict: { status: "unknown", findings: [] },
+    intervention_findings: [],
+    evidence: {
+      folded_case_id: caseId,
+      projection_version: null,
+      turn_numbers: [],
+      turn_refs: [],
+      ledger_id_stubs: [],
+      ledger_source: "none",
+      refused_reasons: [reason],
+    },
+  };
+}
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+  process.exit(0);
+}
+
+function requiredString(value, field) {
+  const normalized = optionalString(value);
+  if (!normalized) throw new Error(`${field} is required`);
+  return normalized;
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function numberValue(value) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function positiveNumber(value) {
+  const number = finiteNumber(value);
+  return number !== null && number > 0 ? number : null;
+}
+
+function isoMillis(value) {
+  const text = optionalString(value);
+  if (!text || Number.isNaN(Date.parse(text))) return null;
+  return Date.parse(text);
+}
+
+function round(value, digits) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}

--- a/skills/agency-health/graph/ledger-stubs/SKILL.md
+++ b/skills/agency-health/graph/ledger-stubs/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: agency-health-ledger-stubs
+description: Project only receipt id-stubs already cited by ordered agency case events for a bounded ledger.read replay.
+---
+
+# Agency Health Ledger Stubs
+
+Internal deterministic stage for `agency-health`. It extracts
+`receipt_id`, `skill_ref`, `status`, and `created_at` only from member results
+already sealed into the case event order. It never reads a receipt body,
+fabricates a row, or writes state.

--- a/skills/agency-health/graph/ledger-stubs/X.yaml
+++ b/skills/agency-health/graph/ledger-stubs/X.yaml
@@ -1,0 +1,27 @@
+skill: agency-health-ledger-stubs
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/agency-health
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      events:
+        type: json
+        required: false
+        description: Ordered agency case events containing receipt id references.
+      period:
+        type: json
+        required: false
+        description: Normalized ledger period.

--- a/skills/agency-health/graph/ledger-stubs/run.mjs
+++ b/skills/agency-health/graph/ledger-stubs/run.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const events = Array.isArray(inputs.events) ? inputs.events : [];
+const period = objectValue(inputs.period);
+const from = isoOrNull(period.from);
+const to = isoOrNull(period.to);
+const receipts = [];
+
+for (const entry of events) {
+  const event = objectValue(entry?.event);
+  const payload = objectValue(event.payload);
+  const result = objectValue(payload.member_result);
+  const receiptId = optionalString(result.receipt_id) ?? optionalString(result.receipt_ref);
+  const createdAt = isoOrNull(result.created_at) ?? isoOrNull(entry?.committed_at);
+  if (!receiptId || !createdAt) continue;
+  if (from && createdAt < from) continue;
+  if (to && createdAt > to) continue;
+  const status = (optionalString(result.status) ?? optionalString(result.outcome) ?? "").toLowerCase();
+  if (status !== "sealed" && status !== "refused") continue;
+  receipts.push({
+    receipt_id: receiptId,
+    skill_ref: optionalString(result.skill_ref) ?? optionalString(payload.dispatch?.skill) ?? "agency-member",
+    status,
+    created_at: createdAt,
+  });
+}
+
+process.stdout.write(`${JSON.stringify({
+  schema: "runx.agency_health.ledger_seed.v1",
+  source: "case-referenced-receipt-id-stubs",
+  receipts,
+}, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isoOrNull(value) {
+  const text = optionalString(value);
+  if (!text || Number.isNaN(Date.parse(text))) return null;
+  return new Date(text).toISOString();
+}

--- a/skills/agency-health/graph/prepare/SKILL.md
+++ b/skills/agency-health/graph/prepare/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: agency-health-prepare
+description: Normalize an agency-health case key, bounded period, declared baseline, and receipt-ledger query without adding authority or performing effects.
+---
+
+# Agency Health Prepare
+
+Internal deterministic stage for `agency-health`. It validates the public
+inputs, resolves the optional `case_id`, and emits the read-only query plan used
+by the projection, event, and ledger reads. It never accesses a provider or
+changes state.

--- a/skills/agency-health/graph/prepare/X.yaml
+++ b/skills/agency-health/graph/prepare/X.yaml
@@ -1,0 +1,35 @@
+skill: agency-health-prepare
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: internal
+  role: graph-stage
+  part_of:
+    - runx/agency-health
+
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      agency_ref:
+        type: string
+        required: true
+        description: Agency definition expected in the case.
+      case_id:
+        type: string
+        required: false
+        description: Optional agency case aggregate id.
+      period:
+        type: json
+        required: false
+        description: Optional ISO-8601 bounds as {from,to}.
+      health_baseline:
+        type: json
+        required: false
+        description: Optional declared health thresholds.

--- a/skills/agency-health/graph/prepare/run.mjs
+++ b/skills/agency-health/graph/prepare/run.mjs
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+
+const inputs = readInputs();
+const agencyRef = requiredString(inputs.agency_ref, "agency_ref");
+const caseId = optionalString(inputs.case_id) ?? agencyRef;
+assertAggregateId(caseId);
+
+const period = normalizePeriod(inputs.period);
+const healthBaseline = normalizeBaseline(inputs.health_baseline);
+
+const queryPlan = {
+  schema: "runx.agency_health.query.v1",
+  agency_ref: agencyRef,
+  case_id: caseId,
+  resource: "agency_cases",
+  period,
+  health_baseline: healthBaseline,
+  ledger_question: `Which closed/sealed or refused runs fall in the health period for agency ${agencyRef}? Return id-stubs only.`,
+  ledger_filter: {
+    time_range: period,
+  },
+  ledger_proof: {
+    verify_chain: false,
+  },
+};
+
+process.stdout.write(`${JSON.stringify(queryPlan, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function requiredString(value, field) {
+  const normalized = optionalString(value);
+  if (!normalized) throw new Error(`${field} is required`);
+  return normalized;
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function assertAggregateId(value) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/.test(value)) {
+    throw new Error("case_id must be a safe aggregate identifier");
+  }
+}
+
+function normalizePeriod(value) {
+  if (value === undefined || value === null) return { from: "", to: "" };
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("period must be an object with optional from and to bounds");
+  }
+  const from = optionalIso(value.from, "period.from");
+  const to = optionalIso(value.to, "period.to");
+  if (from && to && from > to) throw new Error("period.from must not be after period.to");
+  return { from: from ?? "", to: to ?? "" };
+}
+
+function optionalIso(value, field) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new Error(`${field} must be ISO-8601`);
+  }
+  return new Date(value).toISOString();
+}
+
+function normalizeBaseline(value) {
+  if (value === undefined || value === null) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("health_baseline must be an object");
+  }
+  const baseline = {};
+  if (value.threshold_days_stuck !== undefined) {
+    baseline.threshold_days_stuck = boundedNumber(value.threshold_days_stuck, "threshold_days_stuck", 0, 3650);
+  }
+  if (value.cap_pressure_pct !== undefined) {
+    baseline.cap_pressure_pct = boundedNumber(value.cap_pressure_pct, "cap_pressure_pct", 0, 100);
+  }
+  if (value.refusal_spike_rate !== undefined) {
+    baseline.refusal_spike_rate = boundedNumber(value.refusal_spike_rate, "refusal_spike_rate", 0, 1);
+  }
+  return baseline;
+}
+
+function boundedNumber(value, field, min, max) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${field} must be a number from ${min} to ${max}`);
+  }
+  return value;
+}

--- a/skills/agency-health/references/harness-evidence.md
+++ b/skills/agency-health/references/harness-evidence.md
@@ -14,10 +14,10 @@ The two named cases sealed successfully:
 
 - `concerning-agency-sealed`: `ready`, `degraded`, four health findings, and
   two grounded intervention findings. Top receipt:
-  `runx:receipt:sha256:99356ab5eb70f07d965ab91bea34bb2e10742fe9f820e27b9ffa90997965ec71`.
+  `runx:receipt:sha256:0ebb7dedbb2d3ef67b6f217808252b7a765cbad0962e1fc51b71aa08a760bbc8`.
 - `no-case-events-stop`: `needs_more_evidence`, `unknown`, zero findings, and
   zero interventions. Top receipt:
-  `runx:receipt:sha256:e297b82b5c5b5fdb24d834b53cc9a9ca67370a87b14df0427534f9177d8310e4`.
+  `runx:receipt:sha256:ecfb3f093fb74bc9928d26f74c60dc1924de8d00e4f68b8ff7c353f23880b83b`.
 
 Both runs executed the same graph stages: `prepare`, `read-projection`,
 `read-events`, `read-ledger`, `project-ledger-stubs`, `read-case-ledger`, and
@@ -37,7 +37,7 @@ events. The output records `case-referenced-ledger-read` rather than implying
 that unrelated ambient rows grounded the grade.
 
 Top receipt:
-`runx:receipt:sha256:3421f851f6a556d0bdc06f91c77ca90d1805b3327f5598a9afc554ea11aac0ce`.
+`runx:receipt:sha256:40781dfd36e9fbd45d3e1df43e98418b66b59dd6f921dc22650a32698e679da7`.
 
 Verification returned `valid: true`, production signature mode, signature
 status `valid`, and no findings. Signing material is intentionally absent from

--- a/skills/agency-health/references/harness-evidence.md
+++ b/skills/agency-health/references/harness-evidence.md
@@ -10,18 +10,23 @@ or findings from the caller.
 runx harness ./skills/agency-health --json
 ```
 
-The two named cases sealed successfully:
+The two contractual domain cases sealed successfully:
 
 - `concerning-agency-sealed`: `ready`, `degraded`, four health findings, and
   two grounded intervention findings. Top receipt:
-  `runx:receipt:sha256:0ebb7dedbb2d3ef67b6f217808252b7a765cbad0962e1fc51b71aa08a760bbc8`.
+  `runx:receipt:sha256:ac9dfc4b302158e1846322f5244c131ab04051386614e77e2e7a80d3fe91cd19`.
 - `no-case-events-stop`: `needs_more_evidence`, `unknown`, zero findings, and
   zero interventions. Top receipt:
-  `runx:receipt:sha256:ecfb3f093fb74bc9928d26f74c60dc1924de8d00e4f68b8ff7c353f23880b83b`.
+  `runx:receipt:sha256:40f80613549a80be5420087a344dfd60a8b6e32c784c555a1a41ff63909205c7`.
 
 Both runs executed the same graph stages: `prepare`, `read-projection`,
 `read-events`, `read-ledger`, `project-ledger-stubs`, `read-case-ledger`, and
 `grade`.
+
+The registry-admission boundary `missing-agency-ref-needs-agent` also passed:
+the runtime stopped as `needs_agent` before any graph read when the required
+agency identity was omitted. It is intentionally separate from the two domain
+cases above.
 
 ## Durable pre-publication dogfood
 

--- a/skills/agency-health/references/harness-evidence.md
+++ b/skills/agency-health/references/harness-evidence.md
@@ -1,0 +1,46 @@
+# Harness evidence
+
+This package was exercised with `runx-cli 0.7.0` before publication. The
+commands below use the package as checked in; they do not inject health metrics
+or findings from the caller.
+
+## Native inline harness
+
+```text
+runx harness ./skills/agency-health --json
+```
+
+The two named cases sealed successfully:
+
+- `concerning-agency-sealed`: `ready`, `degraded`, four health findings, and
+  two grounded intervention findings. Top receipt:
+  `runx:receipt:sha256:99356ab5eb70f07d965ab91bea34bb2e10742fe9f820e27b9ffa90997965ec71`.
+- `no-case-events-stop`: `needs_more_evidence`, `unknown`, zero findings, and
+  zero interventions. Top receipt:
+  `runx:receipt:sha256:e297b82b5c5b5fdb24d834b53cc9a9ca67370a87b14df0427534f9177d8310e4`.
+
+Both runs executed the same graph stages: `prepare`, `read-projection`,
+`read-events`, `read-ledger`, `project-ledger-stubs`, `read-case-ledger`, and
+`grade`.
+
+## Durable pre-publication dogfood
+
+A separate run read the durable local case `case-frantic-revenue-001` for
+`agent-17af92`, whose event stream records the real Frantic revenue workflow.
+It sealed `needs_human` / `critical` with four findings and one `human-ops`
+intervention grounded in turns 1 and 2 plus the two receipt id-stubs already
+cited by those case events.
+
+The ambient ledger read returned no id-stub cited by this case, so the graph's
+second `ledger.read` used the two receipt rows projected from the ordered case
+events. The output records `case-referenced-ledger-read` rather than implying
+that unrelated ambient rows grounded the grade.
+
+Top receipt:
+`runx:receipt:sha256:3421f851f6a556d0bdc06f91c77ca90d1805b3327f5598a9afc554ea11aac0ce`.
+
+Verification returned `valid: true`, production signature mode, signature
+status `valid`, and no findings. Signing material is intentionally absent from
+this package. Post-publication registry harness and dogfood receipts are
+reported separately in the bounty evidence so they can prove registry
+identity and clean-install behavior.

--- a/skills/agency-health/tools/data/agency-health-harness/manifest.json
+++ b/skills/agency-health/tools/data/agency-health-harness/manifest.json
@@ -1,0 +1,71 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.agency-health-harness",
+  "version": "0.1.0",
+  "description": "Read-only deterministic agency case adapter for the agency-health hosted harness.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "Only read_projection and read_events are accepted."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Must be local://agency-health/harness."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": true,
+      "description": "Non-secret inline harness case rows injected by data.source."
+    },
+    "store_id": {
+      "type": "string",
+      "required": false,
+      "description": "Harness correlation id; no store is written."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Must be agency_cases."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": true,
+      "description": "Case key within the inline harness binding."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "description": "Maximum read_events rows."
+    },
+    "after_version": {
+      "type": "number",
+      "required": false,
+      "description": "Optional ascending version cursor for read_events."
+    }
+  },
+  "scopes": ["runx:data:read"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/agency-health/tools/data/agency-health-harness/run.mjs
+++ b/skills/agency-health/tools/data/agency-health-harness/run.mjs
@@ -1,0 +1,135 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+const inputs = readInputs();
+const operation = requiredString(inputs.operation, "operation");
+const dataSourceRef = requiredString(inputs.data_source_ref, "data_source_ref");
+const resource = requiredString(inputs.resource, "resource");
+const aggregateId = requiredString(inputs.aggregate_id, "aggregate_id");
+const binding = objectValue(inputs.data_source_binding);
+
+if (dataSourceRef !== "local://agency-health/harness") {
+  throw new Error("data.agency-health-harness is restricted to local://agency-health/harness");
+}
+if (binding.profile !== "agency-health-harness-v1") {
+  throw new Error("agency-health harness binding profile is required");
+}
+if (resource !== "agency_cases") {
+  throw new Error("agency-health harness adapter reads only agency_cases");
+}
+if (operation !== "read_projection" && operation !== "read_events") {
+  throw new Error("agency-health harness adapter is read-only; operation must be read_projection or read_events");
+}
+
+const cases = objectValue(binding.cases);
+const sourceRows = Array.isArray(cases[aggregateId]) ? cases[aggregateId] : [];
+const entries = sourceRows.map((row, index) => normalizeEntry(row, index + 1));
+const selected = operation === "read_events"
+  ? readPage(entries, inputs.after_version, inputs.limit)
+  : [];
+const projection = {
+  aggregate_id: aggregateId,
+  resource,
+  version: entries.length,
+  event_count: entries.length,
+  last_event_ref: entries.at(-1)?.event_ref ?? null,
+  last_event_type: entries.at(-1)?.event?.type ?? null,
+  event_digests: entries.map((entry) => entry.event_digest),
+};
+const body = operation === "read_projection" ? projection : selected;
+
+const result = {
+  schema: "runx.data.operation_result.v1",
+  data_source_ref: dataSourceRef,
+  provider: "agency-health-harness-replay",
+  operation,
+  resource,
+  aggregate_id: aggregateId,
+  status: "read",
+  before_version: entries.length,
+  after_version: entries.length,
+  idempotency_key: null,
+  event_ref: null,
+  event_digest: null,
+  result_digest: sha256Json(body),
+  projection_digest: sha256Json(projection),
+  projection: operation === "read_projection" ? projection : null,
+  events: selected,
+  rows: selected,
+  redactions: [],
+  stop_conditions: [],
+  provider_evidence: {
+    provider: "agency-health-harness-replay",
+    profile: binding.profile,
+    resource,
+    aggregate_id: aggregateId,
+    storage_class: "inline-read-only-replay",
+  },
+};
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function normalizeEntry(value, version) {
+  const row = objectValue(value);
+  const event = objectValue(row.event);
+  if (!requiredString(event.type, `cases event ${version} type`)) {
+    throw new Error(`cases event ${version} type is required`);
+  }
+  const committedAt = normalizeIso(row.committed_at, `cases event ${version} committed_at`);
+  return {
+    event_ref: `agency_cases:${aggregateId}:${version}`,
+    version,
+    event_type: event.type,
+    event,
+    event_digest: sha256Json(event),
+    idempotency_key: `agency-health-harness:${aggregateId}:${version}`,
+    committed_at: committedAt,
+  };
+}
+
+function readPage(entries, afterValue, limitValue) {
+  const after = afterValue === undefined || afterValue === null ? null : nonNegativeInteger(afterValue, "after_version");
+  const limit = limitValue === undefined || limitValue === null ? 500 : boundedInteger(limitValue, "limit", 1, 500);
+  return (after === null ? entries : entries.filter((entry) => entry.version > after)).slice(0, limit);
+}
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function requiredString(value, field) {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${field} is required`);
+  return value.trim();
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function normalizeIso(value, field) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) throw new Error(`${field} must be ISO-8601`);
+  return new Date(value).toISOString();
+}
+
+function nonNegativeInteger(value, field) {
+  if (!Number.isInteger(value) || value < 0) throw new Error(`${field} must be a non-negative integer`);
+  return value;
+}
+
+function boundedInteger(value, field, min, max) {
+  if (!Number.isInteger(value) || value < min || value > max) throw new Error(`${field} must be from ${min} to ${max}`);
+  return value;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}

--- a/skills/agency-health/tools/data/source/manifest.json
+++ b/skills/agency-health/tools/data/source/manifest.json
@@ -1,0 +1,26 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.source",
+  "version": "0.1.0",
+  "description": "Operator-context contract for the runx virtual data.source router; execution is always dispatched to the configured concrete namespaced data adapter.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": { "type": "string", "required": true },
+    "data_source_ref": { "type": "string", "required": true },
+    "store_id": { "type": "string", "required": false },
+    "resource": { "type": "string", "required": true },
+    "aggregate_id": { "type": "string", "required": false },
+    "limit": { "type": "number", "required": false },
+    "after_version": { "type": "number", "required": false }
+  },
+  "scopes": ["runx:data:read"],
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/agency-health/tools/data/source/run.mjs
+++ b/skills/agency-health/tools/data/source/run.mjs
@@ -1,0 +1,1 @@
+throw new Error("data.source is a virtual runx router and must resolve to a configured concrete adapter before invocation");

--- a/skills/agency-health/tools/data/sqlite/manifest.json
+++ b/skills/agency-health/tools/data/sqlite/manifest.json
@@ -1,0 +1,102 @@
+{
+  "schema": "runx.tool.manifest.v1",
+  "name": "data.sqlite",
+  "version": "0.1.0",
+  "description": "SQLite event-store adapter for the provider-agnostic runx data operation envelope.",
+  "source": {
+    "type": "cli-tool",
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "inputs": {
+    "operation": {
+      "type": "string",
+      "required": true,
+      "description": "append_event, read_events, read_projection, or list_stream_heads."
+    },
+    "data_source_ref": {
+      "type": "string",
+      "required": true,
+      "description": "Stable logical data-source reference."
+    },
+    "data_source_binding": {
+      "type": "json",
+      "required": false,
+      "description": "Non-secret data-source binding injected by data.source."
+    },
+    "database_path": {
+      "type": "string",
+      "required": false,
+      "description": "Local SQLite database path for direct harness use. Prefer data_source_binding.database_path."
+    },
+    "resource": {
+      "type": "string",
+      "required": true,
+      "description": "Declared event resource or stream family."
+    },
+    "aggregate_id": {
+      "type": "string",
+      "required": false,
+      "description": "Stream or partition key. Omit for list_stream_heads."
+    },
+    "expected_version": {
+      "type": "number",
+      "required": false,
+      "description": "Required current stream version for append_event."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "required": false,
+      "description": "Stable retry key for append_event."
+    },
+    "event": {
+      "type": "json",
+      "required": false,
+      "description": "Domain event or transition packet for append_event."
+    },
+    "observed_at": {
+      "type": "string",
+      "required": false,
+      "description": "Caller-observed ISO-8601 commit ordering time."
+    },
+    "limit": {
+      "type": "number",
+      "required": false,
+      "default": 50,
+      "description": "Maximum events returned by read_events."
+    },
+    "after_version": {
+      "type": "number",
+      "required": false,
+      "description": "Return ascending read_events strictly after this version; omit for the latest tail."
+    },
+    "event_types": {
+      "type": "json",
+      "required": false,
+      "description": "Optional array of exact latest event types for list_stream_heads."
+    },
+    "cursor": {
+      "type": "string",
+      "required": false,
+      "description": "Opaque list_stream_heads cursor."
+    }
+  },
+  "scopes": ["runx:data:read", "runx:data:append"],
+  "runx": {
+    "artifacts": {
+      "named_emits": {
+        "data_operation_result": "runx.data.operation_result.v1"
+      },
+      "wrap_as": "data_operation_result"
+    }
+  },
+  "runtime": {
+    "command": "node",
+    "args": ["./run.mjs"]
+  },
+  "output": {
+    "packet": "runx.data.operation_result.v1",
+    "wrap_as": "data_operation_result"
+  },
+  "toolkit_version": "0.1.4"
+}

--- a/skills/agency-health/tools/data/sqlite/run.mjs
+++ b/skills/agency-health/tools/data/sqlite/run.mjs
@@ -1,0 +1,789 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "runx.data.operation_result.v1";
+const PROVIDER = "sqlite-event-store";
+const SQLITE_BIN = process.env.RUNX_SQLITE_BIN || "sqlite3";
+
+const inputs = readInputs();
+const operation = stringInput("operation");
+
+let result;
+if (operation === "append_event") {
+  result = appendEvent(inputs);
+} else if (operation === "read_events") {
+  result = readEvents(inputs);
+} else if (operation === "read_projection") {
+  result = readProjection(inputs);
+} else if (operation === "list_stream_heads") {
+  result = listStreamHeads(inputs);
+} else {
+  throw new Error("operation must be append_event, read_events, read_projection, or list_stream_heads");
+}
+
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function readInputs() {
+  const raw = process.env.RUNX_INPUTS_PATH
+    ? fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8")
+    : process.env.RUNX_INPUTS_JSON || "{}";
+  return JSON.parse(raw);
+}
+
+function appendEvent(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "append_event");
+  const expectedVersion = numberInput("expected_version");
+  const idempotencyKey = stringInput("idempotency_key");
+  const event = objectInput("event");
+  const eventDigest = sha256Json(event);
+  const current = currentVersion(database, envelope);
+  const existing = existingEvent(database, envelope, idempotencyKey);
+
+  if (existing) {
+    if (existing.event_digest !== eventDigest) {
+      return conflictResult(envelope, current, {
+        idempotency_key: idempotencyKey,
+        event_digest: eventDigest,
+        reason: "idempotency key was reused with different event content",
+        provider_evidence: providerEvidence(envelope),
+      });
+    }
+    return {
+      ...envelope,
+      status: "idempotent_replay",
+      before_version: current,
+      after_version: current,
+      idempotency_key: idempotencyKey,
+      event_ref: existing.event_ref,
+      event_digest: existing.event_digest,
+      result_digest: sha256Json(existing),
+      projection_digest: projectionDigest(database, envelope),
+      events: [],
+      rows: [],
+      redactions: [],
+      stop_conditions: [],
+      provider_evidence: providerEvidence(envelope),
+    };
+  }
+
+  if (current !== expectedVersion) {
+    return conflictResult(envelope, current, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `expected version ${expectedVersion}, got ${current}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  const nextVersion = current + 1;
+  const eventRef = `${envelope.resource}:${envelope.aggregate_id}:${nextVersion}`;
+  const record = {
+    event_ref: eventRef,
+    version: nextVersion,
+    event_type: eventType(event),
+    event,
+    event_digest: eventDigest,
+    idempotency_key: idempotencyKey,
+    committed_at: committedAt(rawInputs.observed_at),
+  };
+
+  try {
+    execSql(database, `
+BEGIN IMMEDIATE;
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+) VALUES (
+  ${sqlString(envelope.data_source_ref)},
+  ${sqlString(envelope.resource)},
+  ${sqlString(envelope.aggregate_id)},
+  ${nextVersion},
+  ${sqlString(idempotencyKey)},
+  ${sqlString(eventRef)},
+  ${sqlString(record.event_type)},
+  ${sqlString(eventDigest)},
+  ${sqlString(JSON.stringify(event))},
+  ${sqlString(record.committed_at)}
+);
+INSERT INTO runx_stream_heads (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  event_ref,
+  event_type,
+  event_digest,
+  idempotency_key,
+  event_json,
+  committed_at
+) VALUES (
+  ${sqlString(envelope.data_source_ref)},
+  ${sqlString(envelope.resource)},
+  ${sqlString(envelope.aggregate_id)},
+  ${nextVersion},
+  ${sqlString(eventRef)},
+  ${sqlString(record.event_type)},
+  ${sqlString(eventDigest)},
+  ${sqlString(idempotencyKey)},
+  ${sqlString(JSON.stringify(event))},
+  ${sqlString(record.committed_at)}
+)
+ON CONFLICT (data_source_ref, resource, aggregate_id) DO UPDATE SET
+  version = excluded.version,
+  event_ref = excluded.event_ref,
+  event_type = excluded.event_type,
+  event_digest = excluded.event_digest,
+  idempotency_key = excluded.idempotency_key,
+  event_json = excluded.event_json,
+  committed_at = excluded.committed_at;
+COMMIT;
+`);
+  } catch (error) {
+    const latest = currentVersion(database, envelope);
+    return conflictResult(envelope, latest, {
+      idempotency_key: idempotencyKey,
+      event_digest: eventDigest,
+      reason: `sqlite append failed after version check: ${error.message}`,
+      provider_evidence: providerEvidence(envelope),
+    });
+  }
+
+  return {
+    ...envelope,
+    status: "committed",
+    before_version: expectedVersion,
+    after_version: nextVersion,
+    idempotency_key: idempotencyKey,
+    event_ref: eventRef,
+    event_digest: eventDigest,
+    result_digest: sha256Json(record),
+    projection_digest: projectionDigest(database, envelope),
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readEvents(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_events");
+  const limit = boundedLimit(rawInputs.limit);
+  const afterVersion = optionalVersion(rawInputs.after_version, "after_version");
+  const current = currentVersion(database, envelope);
+  const rows = afterVersion === undefined ? queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version DESC
+LIMIT ${limit};
+`).reverse() : queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+  AND version > ${afterVersion}
+ORDER BY version ASC
+LIMIT ${limit};
+`);
+  const events = rows
+    .map((row) => ({
+      event_ref: row.event_ref,
+      version: Number(row.version),
+      event_type: row.event_type,
+      event: JSON.parse(row.event_json),
+      event_digest: row.event_digest,
+      idempotency_key: row.idempotency_key,
+      committed_at: row.committed_at,
+    }));
+
+  return {
+    ...envelope,
+    status: "read",
+    before_version: current,
+    after_version: current,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(events),
+    projection_digest: projectionDigest(database, envelope),
+    events,
+    rows: events,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function readProjection(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "read_projection");
+  const eventRows = queryJson(database, `
+SELECT event_ref, event_type, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  const projection = {
+    aggregate_id: envelope.aggregate_id,
+    resource: envelope.resource,
+    version: eventRows.length,
+    event_count: eventRows.length,
+    last_event_ref: eventRows.at(-1)?.event_ref ?? null,
+    last_event_type: eventRows.at(-1)?.event_type ?? null,
+    event_digests: eventRows.map((entry) => entry.event_digest),
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: projection.version,
+    after_version: projection.version,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json(projection),
+    projection_digest: sha256Json(projection),
+    projection,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function listStreamHeads(rawInputs) {
+  const database = databasePath(rawInputs);
+  ensureSchema(database);
+
+  const envelope = baseEnvelope(rawInputs, "list_stream_heads");
+  const limit = boundedHeadLimit(rawInputs.limit);
+  const cursor = decodeHeadCursor(rawInputs.cursor);
+  const eventTypes = optionalEventTypes(rawInputs.event_types);
+  const cursorClause = cursor
+    ? `AND (committed_at < ${sqlString(cursor.committed_at)} OR (committed_at = ${sqlString(cursor.committed_at)} AND aggregate_id > ${sqlString(cursor.aggregate_id)}))`
+    : "";
+  const eventTypeClause = eventTypes.length > 0
+    ? `AND event_type IN (${eventTypes.map(sqlString).join(", ")})`
+    : "";
+  const records = queryJson(database, `
+SELECT aggregate_id, version, event_ref, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_stream_heads
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  ${eventTypeClause}
+  ${cursorClause}
+ORDER BY committed_at DESC, aggregate_id ASC
+LIMIT ${limit + 1};
+`).map(streamHeadRecord);
+  const hasMore = records.length > limit;
+  const rows = records.slice(0, limit);
+  const nextCursor = hasMore && rows.length > 0
+    ? encodeHeadCursor(rows.at(-1))
+    : null;
+  const page = {
+    limit,
+    count: rows.length,
+    has_more: hasMore,
+    next_cursor: nextCursor,
+  };
+  return {
+    ...envelope,
+    status: "read",
+    before_version: 0,
+    after_version: 0,
+    idempotency_key: null,
+    event_ref: null,
+    event_digest: null,
+    result_digest: sha256Json({ rows, page }),
+    projection_digest: sha256Json(rows.map((row) => [row.aggregate_id, row.version, row.event_digest])),
+    projection: page,
+    events: [],
+    rows,
+    redactions: [],
+    stop_conditions: [],
+    provider_evidence: providerEvidence(envelope),
+  };
+}
+
+function conflictResult(envelope, currentVersionValue, { idempotency_key, event_digest, reason, provider_evidence }) {
+  const stop = {
+    code: "conflict",
+    message: reason,
+  };
+  return {
+    ...envelope,
+    status: "conflict",
+    before_version: currentVersionValue,
+    after_version: currentVersionValue,
+    idempotency_key,
+    event_ref: null,
+    event_digest,
+    result_digest: sha256Json(stop),
+    projection_digest: `sha256:${"0".repeat(64)}`,
+    events: [],
+    rows: [],
+    redactions: [],
+    stop_conditions: [stop],
+    provider_evidence,
+  };
+}
+
+function baseEnvelope(rawInputs, operation) {
+  return {
+    schema: SCHEMA,
+    data_source_ref: stringInput("data_source_ref"),
+    provider: PROVIDER,
+    operation,
+    resource: safeName(stringInput("resource"), "resource"),
+    aggregate_id: operation === "list_stream_heads"
+      ? "stream-heads"
+      : safeName(stringInput("aggregate_id"), "aggregate_id"),
+  };
+}
+
+function ensureSchema(database) {
+  fs.mkdirSync(path.dirname(database), { recursive: true });
+  execSql(database, `
+PRAGMA journal_mode = WAL;
+PRAGMA busy_timeout = 5000;
+CREATE TABLE IF NOT EXISTS runx_events (
+  data_source_ref TEXT NOT NULL DEFAULT '',
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+`);
+  migrateLegacySchema(database);
+  execSql(database, `
+CREATE TABLE IF NOT EXISTS runx_stream_heads (
+  data_source_ref TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id)
+);
+CREATE TABLE IF NOT EXISTS runx_data_store_migrations (
+  version TEXT PRIMARY KEY,
+  applied_at TEXT NOT NULL
+);
+INSERT INTO runx_stream_heads (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  event_ref,
+  event_type,
+  event_digest,
+  idempotency_key,
+  event_json,
+  committed_at
+)
+SELECT
+  events.data_source_ref,
+  events.resource,
+  events.aggregate_id,
+  events.version,
+  events.event_ref,
+  events.event_type,
+  events.event_digest,
+  events.idempotency_key,
+  events.event_json,
+  events.committed_at
+FROM runx_events AS events
+WHERE NOT EXISTS (
+  SELECT 1 FROM runx_data_store_migrations WHERE version = 'stream-heads-v1'
+)
+AND events.version = (
+  SELECT MAX(candidate.version)
+  FROM runx_events AS candidate
+  WHERE candidate.data_source_ref = events.data_source_ref
+    AND candidate.resource = events.resource
+    AND candidate.aggregate_id = events.aggregate_id
+)
+ON CONFLICT (data_source_ref, resource, aggregate_id) DO UPDATE SET
+  version = excluded.version,
+  event_ref = excluded.event_ref,
+  event_type = excluded.event_type,
+  event_digest = excluded.event_digest,
+  idempotency_key = excluded.idempotency_key,
+  event_json = excluded.event_json,
+  committed_at = excluded.committed_at
+WHERE excluded.version > runx_stream_heads.version;
+INSERT OR IGNORE INTO runx_data_store_migrations (version, applied_at)
+VALUES ('stream-heads-v1', '1970-01-01T00:00:00.000Z');
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+CREATE INDEX IF NOT EXISTS runx_stream_heads_recent_v1
+  ON runx_stream_heads (data_source_ref, resource, committed_at DESC, aggregate_id ASC);
+CREATE INDEX IF NOT EXISTS runx_stream_heads_type_recent_v1
+  ON runx_stream_heads (data_source_ref, resource, event_type, committed_at DESC, aggregate_id ASC);
+`);
+}
+
+function migrateLegacySchema(database) {
+  const columns = queryJson(database, "PRAGMA table_info(runx_events);").map((column) => column.name);
+  if (columns.includes("data_source_ref")) return;
+
+  execSql(database, `
+BEGIN IMMEDIATE;
+ALTER TABLE runx_events RENAME TO runx_events_legacy_unscoped;
+CREATE TABLE runx_events (
+  data_source_ref TEXT NOT NULL,
+  resource TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  event_ref TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_digest TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (data_source_ref, resource, aggregate_id, version),
+  UNIQUE (data_source_ref, resource, aggregate_id, idempotency_key)
+);
+INSERT INTO runx_events (
+  data_source_ref,
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+)
+SELECT
+  '',
+  resource,
+  aggregate_id,
+  version,
+  idempotency_key,
+  event_ref,
+  event_type,
+  event_digest,
+  event_json,
+  committed_at
+FROM runx_events_legacy_unscoped;
+DROP TABLE runx_events_legacy_unscoped;
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_version_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, version);
+CREATE UNIQUE INDEX IF NOT EXISTS runx_events_stream_idempotency_v1
+  ON runx_events (data_source_ref, resource, aggregate_id, idempotency_key);
+COMMIT;
+`);
+}
+
+function currentVersion(database, envelope) {
+  const rows = queryJson(database, `
+SELECT COALESCE(MAX(version), 0) AS version
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)};
+`);
+  return Number(rows[0]?.version ?? 0);
+}
+
+function existingEvent(database, envelope, idempotencyKey) {
+  const rows = queryJson(database, `
+SELECT event_ref, version, event_type, event_digest, idempotency_key, committed_at, event_json
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+  AND idempotency_key = ${sqlString(idempotencyKey)}
+LIMIT 1;
+`);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    event_ref: row.event_ref,
+    version: Number(row.version),
+    event_type: row.event_type,
+    event: JSON.parse(row.event_json),
+    event_digest: row.event_digest,
+    idempotency_key: row.idempotency_key,
+    committed_at: row.committed_at,
+  };
+}
+
+function projectionDigest(database, envelope) {
+  const rows = queryJson(database, `
+SELECT version, event_digest
+FROM runx_events
+WHERE data_source_ref = ${sqlString(envelope.data_source_ref)}
+  AND resource = ${sqlString(envelope.resource)}
+  AND aggregate_id = ${sqlString(envelope.aggregate_id)}
+ORDER BY version ASC;
+`);
+  return sha256Json({
+    version: rows.length,
+    event_digests: rows.map((entry) => entry.event_digest),
+  });
+}
+
+function providerEvidence(envelope) {
+  return {
+    provider: PROVIDER,
+    adapter: "data.sqlite",
+    data_source_ref_digest: sha256Json(envelope.data_source_ref),
+    resource: envelope.resource,
+    aggregate_id: envelope.aggregate_id,
+    storage_class: "sqlite",
+  };
+}
+
+function databasePath(rawInputs) {
+  const binding = rawInputs.data_source_binding && typeof rawInputs.data_source_binding === "object" && !Array.isArray(rawInputs.data_source_binding)
+    ? rawInputs.data_source_binding
+    : {};
+  const rawPath = typeof binding.database_path === "string" && binding.database_path.trim().length > 0
+    ? binding.database_path.trim()
+    : typeof rawInputs.database_path === "string" && rawInputs.database_path.trim().length > 0
+      ? rawInputs.database_path.trim()
+      : null;
+  if (!rawPath) {
+    throw new Error("data.sqlite requires data_source_binding.database_path or database_path");
+  }
+  const root = path.resolve(process.env.RUNX_CWD || process.env.INIT_CWD || process.cwd());
+  const allowAbsolute = binding.allow_absolute_path === true || rawInputs.allow_absolute_path === true;
+  const resolved = path.isAbsolute(rawPath) ? path.resolve(rawPath) : path.resolve(root, rawPath);
+  if (path.isAbsolute(rawPath) && !allowAbsolute) {
+    throw new Error("data.sqlite absolute database_path requires allow_absolute_path=true in the operator-owned binding");
+  }
+  if (!allowAbsolute && !isInside(root, resolved)) {
+    throw new Error("data.sqlite database_path must stay inside RUNX_CWD unless allow_absolute_path=true");
+  }
+  return resolved;
+}
+
+function execSql(database, sql) {
+  const result = spawnSync(SQLITE_BIN, ["-cmd", ".timeout 5000", database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+}
+
+function queryJson(database, sql) {
+  const result = spawnSync(SQLITE_BIN, ["-cmd", ".timeout 5000", "-json", database], {
+    input: sql,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `sqlite3 exited ${result.status}`).trim());
+  }
+  const text = result.stdout.trim();
+  return text ? JSON.parse(text) : [];
+}
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function readValue(name) {
+  return inputs[name];
+}
+
+function stringInput(name) {
+  const value = readValue(name);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function numberInput(name) {
+  const value = readValue(name);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function objectInput(name) {
+  const value = readValue(name);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value;
+}
+
+function eventType(event) {
+  const explicit = safeEventToken(event.type) ?? safeEventToken(event.event_type);
+  if (explicit) return explicit;
+  const family = safeEventToken(event.effect_family);
+  const operation = safeEventToken(event.operation);
+  if (family && operation) return `${family}.${operation}`;
+  if (operation) return operation;
+  return "data.event";
+}
+
+function safeEventToken(value) {
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(text) ? text : undefined;
+}
+
+function boundedLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("limit must be an integer from 1 to 500");
+  }
+  return value;
+}
+
+function boundedHeadLimit(value) {
+  if (value === undefined || value === null) return 50;
+  if (!Number.isInteger(value) || value < 1 || value > 100) {
+    throw new Error("list_stream_heads limit must be an integer from 1 to 100");
+  }
+  return value;
+}
+
+function optionalEventTypes(value) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value) || value.length > 20) {
+    throw new Error("event_types must be an array of at most 20 exact event types");
+  }
+  return Array.from(new Set(value.map((entry) => {
+    const token = safeEventToken(entry);
+    if (!token) throw new Error("event_types contains an invalid event type");
+    return token;
+  })));
+}
+
+function streamHeadRecord(row) {
+  return {
+    aggregate_id: row.aggregate_id,
+    version: Number(row.version),
+    event_ref: row.event_ref,
+    event_type: row.event_type,
+    event: JSON.parse(row.event_json),
+    event_digest: row.event_digest,
+    idempotency_key: row.idempotency_key,
+    committed_at: row.committed_at,
+  };
+}
+
+function encodeHeadCursor(row) {
+  return Buffer.from(JSON.stringify({
+    committed_at: row.committed_at,
+    aggregate_id: row.aggregate_id,
+  }), "utf8").toString("base64url");
+}
+
+function decodeHeadCursor(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string" || value.length > 1024 || !/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw new Error("cursor must be an opaque list_stream_heads cursor");
+  }
+  try {
+    const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) throw new Error("invalid cursor");
+    const committedAt = decoded.committed_at;
+    const aggregateId = decoded.aggregate_id;
+    if (typeof committedAt !== "string" || committedAt.length > 100 || Number.isNaN(Date.parse(committedAt))) {
+      throw new Error("invalid committed_at");
+    }
+    return {
+      committed_at: committedAt,
+      aggregate_id: safeName(aggregateId, "aggregate_id"),
+    };
+  } catch {
+    throw new Error("cursor must be an opaque list_stream_heads cursor");
+  }
+}
+
+function optionalVersion(value, field) {
+  if (value === undefined || value === null) return undefined;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function committedAt(value) {
+  if (value === undefined || value === null) return "1970-01-01T00:00:00.000Z";
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+    throw new Error("observed_at must be ISO-8601");
+  }
+  return new Date(value).toISOString();
+}
+
+function safeName(value, field) {
+  const text = String(value || "").trim();
+  const pattern = field === "aggregate_id"
+    ? /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,191}$/
+    : /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+  if (!pattern.test(text)) {
+    throw new Error(`${field} must be a safe identifier`);
+  }
+  return text;
+}
+
+function sha256Json(value) {
+  return `sha256:${crypto.createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}


### PR DESCRIPTION
## Summary

- add the public `agency-health` read-only diagnostic skill
- compose `data-store.read_projection`, `data-store.read_events`, and `ledger.read` before grading
- fold ordered agency case events into four norm-backed health findings and dispatch-by-naming interventions
- include the exact inline harness cases, standalone fixtures, deterministic owner-local stages, and reproducible harness evidence

## Safety and authority

The graph has no append, effect, payment, access-grant, or dispatch step. Critical findings and any cap/authority widening route only to the named human ops lane. Ledger data is retained as id-stubs and never used as domain-keyed state.

## Validation

- `runx-cli 0.7.0`
- `runx skill inspect ./skills/agency-health --json`
- `runx harness ./skills/agency-health --json` - 2/2 cases passed
- signed harness receipts verified in production mode with zero findings
- durable-case dogfood receipt verified in production mode with zero findings
- `node --check` for every package runtime
- secret-pattern scan and `git diff --check`

The focused official catalog suite reports three pre-existing failures in `agency`, `operator-inbox`, and `data-store`; no failure names `agency-health`.