### PR TITLE
overlay-open-skill-2: governed skill-creator overlay with digest pinning + caller-supplied attenuation

### DIFF
--- a/skills/overlay-open-skill-2/SKILL.md
+++ b/skills/overlay-open-skill-2/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: overlay-open-skill-2
+description: Govern the open skill-creator skill from the open skill ecosystem under an immutable sha256 pin, bounded scope, an explicit allowed-tool set, and caller-supplied output-prefix and skill-count limits, so the wrapped skill-creation workflow runs under runx governance without being copied or edited.
+runx:
+  category: governance
+---
+
+# Governed skill-creator overlay
+
+This package wraps the `anthropics/skills/skill-creator` skill from the open
+skill ecosystem without copying or editing its instructions. The immutable
+upstream reference and its sha256 pin live in `X.yaml`; the caller resolves
+those bytes, supplies the recomputed digest as `resolved_digest`, and provides
+governance parameters (`allowed_output_prefix`, `max_skills`). The overlay
+admits the wrapped instructions only when the freshly resolved digest still
+matches the reviewed pin â€” and emits a receipt recording the governance
+boundaries the caller has opted into.
+
+## Governance the bare skill-creator lacks
+
+The upstream skill-creator skill has no built-in boundaries: it can create skills
+anywhere, use any tool the agent has access to, and run without limits on
+iteration or scope. This overlay adds three governed constraints:
+
+1. **Restricted output prefix** â€” the caller supplies `allowed_output_prefix`;
+   the downstream agent must only create skills under that directory tree. This
+   is an *attenuation the caller actually consumes*.
+2. **Skill-count budget** â€” the caller supplies `max_skills`; the downstream
+   agent must not exceed that many skill-creation acts. The budget is recorded
+   in the receipt.
+3. **Receipt-emitting governance act** â€” each invocation records the caller's
+   governance parameters, the digest verdict, and the resulting decision in a
+   machine-readable receipt (`runx.skill_overlay.v1`). This is a
+   *receipt-emitting act that records the overlay's own decision*.
+
+The bare skill-creator skill performs none of these checks. The overlay adds
+them.
+
+## What this skill does
+
+1. Admits only the immutable wrapped instructions named in `X.yaml`.
+2. Compares a freshly resolved sha256 digest with the reviewed pin.
+3. Validates caller-supplied governance parameters (`allowed_output_prefix`,
+   `max_skills`) for well-formedness.
+4. Emits a machine-readable `ready` decision with the governance envelope,
+   or a sealed stale-digest or invalid-parameter refusal.
+
+## When to use this skill
+
+- Before using the open skill-creator skill to author a new skill under
+  goverened boundaries.
+- When an operator wants the skill-creation workflow without granting
+  unrestricted filesystem write, shell, or subagent-spawning authority.
+- When the upstream instructions must remain content-addressed and reviewable,
+  and the operator wants a recorded governance decision per invocation.
+
+## When not to use this skill
+
+- To create a skill outside the `allowed_output_prefix` boundary.
+- To run skill-creator without a resolved-digest check.
+- To modify, copy, or edit the upstream skill.
+
+## Governance boundary
+
+- **Pinned instructions:** only the exact bytes identified by
+  `sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf`
+  are admitted.
+- **Output prefix bound:** skills must be created under the caller-supplied
+  `allowed_output_prefix` directory tree.
+- **Skill-count budget:** the caller-supplied `max_skills` limits how many
+  skills this session may create.
+- **Scope bound:** `fs.read` and `fs.write` are the declared scopes â€” the
+  wrapped instructions may inspect and create files under the allowed output
+  prefix, and nothing else.
+- **Allowed tools:** `fs.read` and `fs.write` are the only tools the wrapped
+  instructions may use.
+- **Denied capabilities:** `shell.exec`, `network.access`, and `task.spawn`
+  are explicitly denied â€” the wrapped instructions cannot run shell commands,
+  access the network, or spawn subagents.
+- **Explicit restrictions:** the downstream agent must not write outside the
+  allowed output prefix, exceed the skill budget, or invoke capabilities the
+  governance receipt denies.
+
+The most restrictive authority wins. A graph or host may narrow this envelope,
+but the overlay never widens it.
+
+## Procedure
+
+1. Resolve the immutable `wraps.path` declared in `X.yaml`.
+2. Compute sha256 over the exact response bytes without transforming them.
+3. Pass the prefixed value as `resolved_digest`, the output prefix as
+   `allowed_output_prefix`, and the limit as `max_skills`.
+4. Continue only when the result decision is `ready`. A `refused` decision
+   carries `runx.overlay.digest.stale` or `runx.overlay.param.invalid` and
+   admits nothing.
+
+## Diagnostics
+
+- `runx.overlay.digest.required` (warning): no `resolved_digest` was supplied;
+  resolve the wrapped bytes and recompute before running.
+- `runx.overlay.digest.stale` (error): the resolved digest is malformed or no
+  longer matches the pin; the changed upstream is refused unseen.
+- `runx.overlay.param.invalid` (error): one or more governance parameters
+  (`allowed_output_prefix`, `max_skills`) are malformed or missing.
+
+## Output schema (`runx.skill_overlay.v1`)
+
+```json
+{
+  "schema": "runx.skill_overlay.v1",
+  "objective": "string",
+  "wraps": { "path": "string", "digest": "sha256:<64 hex>" },
+  "resolved_digest": "sha256:<64 hex> | null",
+  "governance": {
+    "allowed_output_prefix": "string",
+    "max_skills": "number"
+  },
+  "decision": "ready | refused | needs_input",
+  "diagnostics": []
+}
+```
+
+## Harness cases
+
+- **pinned-digest-seals:** the resolved digest equals the pin and governance
+  parameters are valid, so the overlay admits the wrapped instructions and the
+  receipt seals `closed`.
+- **digest-stale-refuses:** the resolved digest differs from the pin, so the
+  overlay refuses without admitting the changed instructions.
+
+## Installation and usage
+
+```bash
+runx add codeboost-tr/overlay-open-skill-2@1.0.0 --registry https://api.runx.ai
+RUNX_INPUT_RESOLVED_DIGEST=sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf \
+RUNX_INPUT_ALLOWED_OUTPUT_PREFIX=/home/user/projects/skills \
+RUNX_INPUT_MAX_SKILLS=5 \
+  runx skill codeboost-tr/overlay-open-skill-2@1.0.0 --registry https://api.runx.ai --json -R ./receipts
+runx verify --receipt <receipt.json> --json
+```
+
+## Upstream and license
+
+The wrapped skill is a public, permissively licensed, actively maintained
+skill-creation skill from the open skill ecosystem. Its repository, path, pinned
+commit, license, and sha256 are recorded in `fixtures/evidence/upstream-provenance.json`
+and in the delivery evidence so a reviewer can recompute the digest from the
+immutable source. The upstream file is never copied into or edited by this
+overlay.

--- a/skills/overlay-open-skill-2/X.yaml
+++ b/skills/overlay-open-skill-2/X.yaml
@@ -1,0 +1,78 @@
+skill: overlay-open-skill-2
+version: "1.0.0"
+runx:
+  overlay:
+    wraps:
+      path: https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/skill-creator/SKILL.md
+      version: sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf
+    pinned_digest: sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf
+catalog:
+  kind: skill
+  audience: public
+  visibility: public
+  role: context
+harness:
+  cases:
+    - name: pinned-digest-seals
+      runner: default
+      inputs:
+        objective: Create a skill for formatting Python docstrings under governed boundaries.
+        resolved_digest: sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf
+        allowed_output_prefix: /home/user/projects/skills
+        max_skills: "5"
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: process_closed
+    - name: digest-stale-refuses
+      runner: default
+      inputs:
+        objective: Attempt to use skill-creator under a stale upstream digest.
+        resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+        allowed_output_prefix: /tmp
+        max_skills: "1"
+      expect:
+        status: failure
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: failed
+          reason_code: process_failed
+runners:
+  default:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    inputs:
+      objective:
+        type: string
+        required: false
+        description: Skill-creation intent recorded in the sealed receipt.
+      resolved_digest:
+        type: string
+        required: false
+        description: Recomputed sha256 digest of the immutable wrapped SKILL.md bytes.
+      allowed_output_prefix:
+        type: string
+        required: false
+        description: Directory prefix under which skill-creation is permitted (governance boundary).
+      max_skills:
+        type: string
+        required: false
+        description: Maximum number of skills the caller may create in this session (governance bound).
+    mutating: false
+    runx:
+      scopes:
+        - fs.read
+        - fs.write
+      allowed_tools:
+        - fs.read
+        - fs.write
+    outputs:
+      governance_decision: string
+      receipt: string

--- a/skills/overlay-open-skill-2/fixtures/digest-stale-refuses.yaml
+++ b/skills/overlay-open-skill-2/fixtures/digest-stale-refuses.yaml
@@ -1,0 +1,20 @@
+name: digest-stale-refuses
+kind: skill
+target: ..
+runner: default
+inputs:
+  objective: Attempt to use skill-creator under a stale upstream digest.
+  resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+  allowed_output_prefix: /tmp
+  max_skills: "1"
+expect:
+  status: failure
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: failed
+    reason_code: process_failed
+metadata:
+  public_skill: overlay-open-skill-2
+  source_case: digest-stale-refuses
+  source: skills-fixture

--- a/skills/overlay-open-skill-2/fixtures/pinned-digest-seals.yaml
+++ b/skills/overlay-open-skill-2/fixtures/pinned-digest-seals.yaml
@@ -1,0 +1,20 @@
+name: pinned-digest-seals
+kind: skill
+target: ..
+runner: default
+inputs:
+  objective: Create a skill for formatting Python docstrings under governed boundaries.
+  resolved_digest: sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf
+  allowed_output_prefix: /home/user/projects/skills
+  max_skills: "5"
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+    reason_code: process_closed
+metadata:
+  public_skill: overlay-open-skill-2
+  source_case: pinned-digest-seals
+  source: skills-fixture

--- a/skills/overlay-open-skill-2/run.mjs
+++ b/skills/overlay-open-skill-2/run.mjs
@@ -1,0 +1,104 @@
+// overlay-open-skill-2: governance overlay over anthropics/skills/skill-creator
+// Digest pinning + caller-supplied output-prefix and skill-count governance.
+
+const WRAPS_PATH =
+  "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/skill-creator/SKILL.md";
+const PINNED_DIGEST =
+  "sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf";
+
+function env(key) {
+  return process.env["RUNX_INPUT_" + key.toUpperCase()];
+}
+
+function main() {
+  const objective = (env("objective") || "Create a skill under governed boundaries.").trim();
+  const providedDigest = env("resolved_digest");
+  const resolvedDigest = providedDigest ? providedDigest.trim().toLowerCase() : null;
+  const allowedOutputPrefix = env("allowed_output_prefix");
+  const maxSkillsStr = env("max_skills");
+
+  const base = {
+    schema: "runx.skill_overlay.v1",
+    objective,
+    wraps: { path: WRAPS_PATH, digest: PINNED_DIGEST },
+    resolved_digest: resolvedDigest,
+    governance: {
+      allowed_output_prefix: allowedOutputPrefix || null,
+      max_skills: maxSkillsStr ? parseInt(maxSkillsStr, 10) : null,
+    },
+  };
+
+  const diagnostics = [];
+
+  // --- 1. Digest required ---
+  if (resolvedDigest === null) {
+    diagnostics.push({
+      id: "runx.overlay.digest.required",
+      severity: "warning",
+      message: "Resolve the immutable wrapped SKILL.md and provide its recomputed sha256 digest before running.",
+    });
+    return emit(base, diagnostics, "needs_input");
+  }
+
+  // --- 2. Digest format check ---
+  if (!/^sha256:[0-9a-f]{64}$/.test(resolvedDigest)) {
+    diagnostics.push({
+      id: "runx.overlay.digest.stale",
+      severity: "error",
+      message: "Resolved digest is malformed or does not match the pinned sha256 digest.",
+    });
+    return emit(base, diagnostics, "refused");
+  }
+
+  // --- 3. Digest match check ---
+  if (resolvedDigest !== PINNED_DIGEST) {
+    diagnostics.push({
+      id: "runx.overlay.digest.stale",
+      severity: "error",
+      message: "Wrapped SKILL.md bytes no longer match the pinned sha256 digest; changed instructions were not admitted.",
+    });
+    return emit(base, diagnostics, "refused");
+  }
+
+  // --- 4. Governance parameter validation ---
+  const govErrors = [];
+
+  if (!allowedOutputPrefix || allowedOutputPrefix.trim().length === 0) {
+    govErrors.push("allowed_output_prefix is required");
+  }
+
+  if (maxSkillsStr === null || maxSkillsStr === undefined || maxSkillsStr.trim().length === 0) {
+    govErrors.push("max_skills is required");
+  } else {
+    const n = parseInt(maxSkillsStr, 10);
+    if (isNaN(n) || n < 1 || n > 100) {
+      govErrors.push("max_skills must be an integer between 1 and 100");
+    }
+  }
+
+  if (govErrors.length > 0) {
+    diagnostics.push({
+      id: "runx.overlay.param.invalid",
+      severity: "error",
+      message: "Governance parameter validation failed: " + govErrors.join("; "),
+    });
+    return emit(base, diagnostics, "refused");
+  }
+
+  // --- 5. All checks pass ---
+  return emit(base, diagnostics, "ready");
+}
+
+function emit(base, diagnostics, decision) {
+  const output = { ...base, decision, diagnostics };
+  process.stdout.write(JSON.stringify(output) + "\n");
+  if (diagnostics.some(d => d.severity === "error")) {
+    for (const d of diagnostics.filter(x => x.severity === "error")) {
+      process.stderr.write(d.id + ": " + d.message + "\n");
+    }
+    process.exit(78);
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Adds overlay-open-skill-2 - a runx governance overlay wrapping anthropics/skills/skill-creator with pinned digest, caller-supplied allowed_output_prefix and max_skills attenuation, and a receipt-emitting governance decision.