### PR TITLE
Add incident commander skill

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -106,6 +106,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "10e3aa69cb5fdca2202c881e3f18b7cc54b2b4b4ec9f625bec5d8335924d9b3e",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/incident-commander",
+        version: "sha-3bccff6ce22e",
+        digest: "31da69e35ee841efd09e088361b1e6ae913f89f7d76dd89c2e3681e0b6dd6fee",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/issue-intake",
         version: "sha-15369469618b",
         digest: "cc964980fe249ac3633e7b30c664648f0df9406a0254ede9bb0e3cbcdebdd603",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -133,6 +133,13 @@
     "catalog_role": "context"
   },
   {
+    "skill_id": "runx/incident-commander",
+    "version": "sha-3bccff6ce22e",
+    "digest": "31da69e35ee841efd09e088361b1e6ae913f89f7d76dd89c2e3681e0b6dd6fee",
+    "catalog_visibility": "public",
+    "catalog_role": "canonical"
+  },
+  {
     "skill_id": "runx/issue-intake",
     "version": "sha-15369469618b",
     "digest": "cc964980fe249ac3633e7b30c664648f0df9406a0254ede9bb0e3cbcdebdd603",

--- a/skills/incident-commander/SKILL.md
+++ b/skills/incident-commander/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: incident-commander
+description: Coordinate one incident agency turn from monitor-backed case state, roster approval, and dispatch-by-naming to governed outbound communications.
+runx:
+  category: ops
+---
+
+# Incident Commander
+
+Incident Commander is a thin review skill over the shipped agency spine. It
+does not reimplement durable state, mint authority, post messages, or call a
+provider. It reads the folded incident case state produced by the agency turn,
+requires that state to carry a real source alert or monitor event, checks the
+fixed incident roster, and emits one typed `incident_turn` decision.
+
+Comms are dispatch-by-naming. A status update names the governed outbound lane
+that will perform the send, with the principal, audience, channel, content
+digest, and source alert bound as data. The first comms turn stays
+`awaiting_approval`. A later advance may mark it `delivered` only when the input
+contains both a roster-matched approval and a `member_result.receipt_ref` from
+the downstream governed send run.
+
+## What This Skill Does
+
+1. **Review monitor-backed case state.** `case_state.source_alert` must name the
+   monitor or alert event that opened or updated the incident.
+2. **Check the incident roster.** Every commander, responder, comms, approval,
+   and send principal must match a role in the folded case roster.
+3. **Coordinate comms safely.** A send objective returns a named
+   `governed-outbound` or `slack-notify` run and stops at approval until a
+   matching approval arrives.
+4. **Link delivery proof.** Delivered status requires a downstream send receipt
+   in `member_result.receipt_ref`.
+5. **Refuse unsafe moves.** Missing roster owners, missing source alerts,
+   unmatched approvals, missing send receipts, and resolution without evidence
+   all stop with `needs_agent` or `awaiting_approval`.
+
+## Contract Boundaries
+
+- **Typed inputs are required.**
+  - `case_id`
+  - `driver_id`
+  - `incident_objective`: `begin`, `assign`, `send`, `resolve`, or
+    `postmortem`
+  - `case_state`: folded state from the agency turn, including
+    `source_alert`
+  - `roster`: fixed incident roster from the agency case
+- **Optional inputs.**
+  - `approval`: `{ principal, reason }`
+  - `member_result`: `{ outcome, receipt_ref }`
+- **Typed output is one incident turn.**
+  - `incident_turn`: `{ status, case_id, turn, dispatch, escalation,
+    named_run, reason }`
+- **No provider effects.** This skill never sends a Slack message, email, or
+  customer notification. It names the governed outbound lane and requires that
+  lane's receipt before delivery is acknowledged.
+- **No data-store composition in graph.** The agency spine owns fold and CAS
+  append. This skill receives the folded projection as input and records the
+  decision as a sealed review act.
+
+## Decision Rules
+
+- `send`: if approval is absent, return `awaiting_approval` with a named
+  governed outbound run. If approval matches a roster principal and
+  `member_result.receipt_ref` is present, return `delivered` and link the send
+  receipt. If approval is present but no send receipt is linked, remain
+  `awaiting_approval`.
+- `assign`: require `case_state.assign_to` or `case_state.requested_owner` to
+  match a roster role. Missing owners return `needs_agent` with no named run.
+- `resolve`: require `member_result.receipt_ref` or
+  `case_state.resolution_evidence`. Without evidence, return `needs_agent`.
+- Never invent a commander, responder, comms lead, approval, source alert,
+  receipt, or resolution.
+
+## Output Shape
+
+```yaml
+incident_turn:
+  status: awaiting_approval | advanced | delivered | resolved | needs_agent
+  case_id: string
+  turn: number
+  dispatch: object | null
+  escalation: object | null
+  named_run: object | null
+  reason: string
+  source_alert: object
+  approval: object | null
+  member_result: object | null
+```
+
+## Inputs
+
+- `case_id` (required): incident case id.
+- `driver_id` (required): agency driver id; participates in the agency
+  contention lease outside this skill.
+- `incident_objective` (required): `begin`, `assign`, `send`, `resolve`, or
+  `postmortem`.
+- `case_state` (required): folded state from the agency turn.
+- `roster` (required): fixed incident roster.
+- `approval` (optional): roster principal approval for a consequential turn.
+- `member_result` (optional): downstream lane result, including receipt refs.

--- a/skills/incident-commander/X.yaml
+++ b/skills/incident-commander/X.yaml
@@ -1,0 +1,210 @@
+skill: incident-commander
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: status-update-approval-then-delivered
+      inputs:
+        case_id: inc-checkout-20260714
+        driver_id: ryde-play-driver
+        incident_objective: send
+        case_state:
+          turn: 3
+          severity: sev2
+          source_alert:
+            ref: monitor:checkout:error-rate:2026-07-14T10:40Z
+            monitor: checkout-error-rate
+            status: firing
+          channel: "#incidents"
+          audience:
+            kind: incident-stakeholders
+            external: true
+            group: checkout-oncall-and-customer-success
+          content_digest: sha256:incident-update-checkout-20260714
+          send_class: stakeholder
+        roster:
+          - role: commander
+            principal: user:alex
+            scope:
+              - incident.command
+          - role: responder_lead
+            principal: user:mei
+            scope:
+              - incident.assign
+          - role: comms_lead
+            principal: user:sam
+            scope:
+              - incident.comms
+              - governed-outbound.plan
+        approval:
+          principal: user:sam
+          reason: comms lead approved the stakeholder status update.
+        member_result:
+          outcome: sent
+          receipt_ref: runx:receipt:sha256:governed-outbound-demo-send
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+
+    - name: assign-missing-roster-owner-needs-agent
+      runner: incident_review
+      inputs:
+        case_id: inc-checkout-20260714
+        driver_id: ryde-play-driver
+        incident_objective: assign
+        case_state:
+          turn: 4
+          severity: sev2
+          source_alert:
+            ref: monitor:checkout:error-rate:2026-07-14T10:40Z
+            monitor: checkout-error-rate
+            status: firing
+          assignment_task: own database failover validation
+        roster:
+          - role: commander
+            principal: user:alex
+            scope:
+              - incident.command
+          - role: comms_lead
+            principal: user:sam
+            scope:
+              - incident.comms
+      expect:
+        status: needs_agent
+
+runners:
+  commander:
+    default: true
+    type: graph
+    act:
+      form: review
+      purpose: Review a monitor-backed incident agency turn and record the bounded command decision.
+      legitimacy: Local operator supplied folded agency case state, source alert evidence, roster, approval, and member result for review.
+      reason_step: decide
+      reason_from: act_reason
+      decision_from: act_decision
+      target_from: act_target_ref
+    inputs:
+      case_id:
+        type: string
+        required: true
+        description: "Incident case id."
+      driver_id:
+        type: string
+        required: true
+        description: "Agency driver id for the turn."
+      incident_objective:
+        type: string
+        required: true
+        description: "One of begin, assign, send, resolve, or postmortem."
+      case_state:
+        type: object
+        required: true
+        description: "Folded agency case state, including source_alert from a monitor or alert."
+      roster:
+        type: object
+        required: true
+        description: "Fixed incident roster carried from the agency turn."
+      approval:
+        type: object
+        required: false
+        description: "Optional roster principal approval."
+      member_result:
+        type: object
+        required: false
+        description: "Optional downstream lane result, including receipt_ref."
+    graph:
+      name: incident-commander
+      steps:
+        - id: decide
+          label: decide incident command turn
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - run.mjs
+            outputs:
+              act_decision: string
+              act_reason: string
+              act_target_ref: string
+              incident_turn: object
+          inputs:
+            case_id: "$input.case_id"
+            driver_id: "$input.driver_id"
+            incident_objective: "$input.incident_objective"
+            case_state: "$input.case_state"
+            roster: "$input.roster"
+            approval: "$input.approval"
+            member_result: "$input.member_result"
+          artifacts:
+            wrap_as: incident_turn
+            packet: runx.incident_commander.turn.v1
+
+  incident_review:
+    type: agent-task
+    act:
+      form: review
+      purpose: Review a monitor-backed incident agency turn and record the bounded command decision.
+      legitimacy: Local operator supplied folded agency case state, source alert evidence, roster, approval, and member result for review.
+      reason_from: act_reason
+      decision_from: act_decision
+      target_from: act_target_ref
+    agent: reviewer
+    task: incident-commander
+    outputs:
+      act_decision: string
+      act_reason: string
+      act_target_ref: string
+      incident_turn: object
+    artifacts:
+      wrap_as: incident_turn
+      packet: runx.incident_commander.turn.v1
+    runx:
+      category: ops
+    instructions: >
+      Produce one incident_turn for the supplied case_id, driver_id,
+      incident_objective, folded case_state, roster, approval, and member_result.
+      Require case_state.source_alert to name a real monitor or alert event.
+      For send objectives, return awaiting_approval and name governed-outbound or
+      slack-notify unless approval.principal matches the roster and a
+      member_result.receipt_ref links the downstream send receipt. Only then may
+      status be delivered. For assign objectives, never invent an owner: if
+      case_state.assign_to or case_state.requested_owner is absent or not in the
+      roster, return needs_agent with named_run null. Never send messages, mint
+      authority, compose data-store, or mark resolution without linked evidence.
+    inputs:
+      case_id:
+        type: string
+        required: true
+        description: "Incident case id."
+      driver_id:
+        type: string
+        required: true
+        description: "Agency driver id for the turn."
+      incident_objective:
+        type: string
+        required: true
+        description: "One of begin, assign, send, resolve, or postmortem."
+      case_state:
+        type: object
+        required: true
+        description: "Folded agency case state, including source_alert from a monitor or alert."
+      roster:
+        type: object
+        required: true
+        description: "Fixed incident roster carried from the agency turn."
+      approval:
+        type: object
+        required: false
+        description: "Optional roster principal approval."
+      member_result:
+        type: object
+        required: false
+        description: "Optional downstream lane result, including receipt_ref."

--- a/skills/incident-commander/fixtures/assign-missing-roster-owner-needs-agent.yaml
+++ b/skills/incident-commander/fixtures/assign-missing-roster-owner-needs-agent.yaml
@@ -1,0 +1,20 @@
+case_id: inc-checkout-20260714
+driver_id: ryde-play-driver
+incident_objective: assign
+case_state:
+  turn: 4
+  severity: sev2
+  source_alert:
+    ref: monitor:checkout:error-rate:2026-07-14T10:40Z
+    monitor: checkout-error-rate
+    status: firing
+  assignment_task: own database failover validation
+roster:
+  - role: commander
+    principal: user:alex
+    scope:
+      - incident.command
+  - role: comms_lead
+    principal: user:sam
+    scope:
+      - incident.comms

--- a/skills/incident-commander/fixtures/status-update-approval-then-delivered.yaml
+++ b/skills/incident-commander/fixtures/status-update-approval-then-delivered.yaml
@@ -1,0 +1,37 @@
+case_id: inc-checkout-20260714
+driver_id: ryde-play-driver
+incident_objective: send
+case_state:
+  turn: 3
+  severity: sev2
+  source_alert:
+    ref: monitor:checkout:error-rate:2026-07-14T10:40Z
+    monitor: checkout-error-rate
+    status: firing
+  channel: "#incidents"
+  audience:
+    kind: incident-stakeholders
+    external: true
+    group: checkout-oncall-and-customer-success
+  content_digest: sha256:incident-update-checkout-20260714
+  send_class: stakeholder
+roster:
+  - role: commander
+    principal: user:alex
+    scope:
+      - incident.command
+  - role: responder_lead
+    principal: user:mei
+    scope:
+      - incident.assign
+  - role: comms_lead
+    principal: user:sam
+    scope:
+      - incident.comms
+      - governed-outbound.plan
+approval:
+  principal: user:sam
+  reason: comms lead approved the stakeholder status update.
+member_result:
+  outcome: sent
+  receipt_ref: runx:receipt:sha256:governed-outbound-demo-send

--- a/skills/incident-commander/harness-evidence.json
+++ b/skills/incident-commander/harness-evidence.json
@@ -1,0 +1,41 @@
+{
+  "schema": "runx.skill_harness_evidence.v1",
+  "skill": "incident-commander",
+  "runx_cli_version": "runx-cli 0.6.14",
+  "command": "RUNX_RECEIPT_SIGN_KID=<kid> RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=<seed> RUNX_RECEIPT_SIGN_ISSUER_TYPE=hosted runx harness ./skills/incident-commander --json",
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "assertion_errors": [],
+  "receipt_ids": [
+    "sha256:ec5d57d85b1b89e47de2432b4fa869854f5f24e645dda09540de592b32a8dda1"
+  ],
+  "case_names": [
+    "status-update-approval-then-delivered",
+    "assign-missing-roster-owner-needs-agent"
+  ],
+  "coverage": {
+    "status-update-approval-then-delivered": [
+      "folded case_state carries monitor-backed source_alert",
+      "status update names governed-outbound for stakeholder send",
+      "named_run binds audience, channel, principal, content_digest, and source_alert_ref",
+      "approval principal matches the comms_lead roster entry",
+      "delivered status is allowed only because member_result.receipt_ref links the downstream governed send receipt",
+      "prior_awaiting_approval records the approval gate before delivery"
+    ],
+    "assign-missing-roster-owner-needs-agent": [
+      "folded case_state carries monitor-backed source_alert",
+      "assign objective lacks assign_to/requested_owner",
+      "agent-mediated review runner pauses with runx status needs_agent because caller.answers are omitted",
+      "named_run is null",
+      "no roster member is invented"
+    ]
+  },
+  "failure_lessons_applied": [
+    "post-publish dogfood receipt must be distinct from harness receipts",
+    "evidence_json.dogfood must include package, input, command, receipt_ref, verify_verdict, and harness_cases",
+    "human review rejected prior work for hand-fed state, so this skill requires source_alert monitor evidence in case_state",
+    "human review rejected prior work for non-executable send-as handoff, so stakeholder sends name governed-outbound and delivered status requires a linked send receipt"
+  ],
+  "note": "This file is committed with the skill package; status is replaced with captured local and hosted harness results in delivery evidence."
+}

--- a/skills/incident-commander/run.mjs
+++ b/skills/incident-commander/run.mjs
@@ -1,0 +1,191 @@
+function readJsonInput(name, fallback = null) {
+  const raw = process.env[`RUNX_INPUT_${name}`];
+  if (raw === undefined || raw === "") return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function readStringInput(name, fallback = "") {
+  const value = readJsonInput(name, fallback);
+  return typeof value === "string" ? value : fallback;
+}
+
+const caseId = readStringInput("CASE_ID", "");
+const driverId = readStringInput("DRIVER_ID", "");
+const incidentObjective = readStringInput("INCIDENT_OBJECTIVE", "");
+const caseState = readJsonInput("CASE_STATE", {});
+const roster = readJsonInput("ROSTER", []);
+const approval = readJsonInput("APPROVAL", null);
+const memberResult = readJsonInput("MEMBER_RESULT", null);
+
+const turn = Number(caseState?.turn ?? 0) + 1;
+const sourceAlert = caseState?.source_alert ?? null;
+const severity = String(caseState?.severity ?? "unknown");
+const channel = caseState?.channel ?? "#incidents";
+const audience = caseState?.audience ?? { kind: "incident-stakeholders", incident: caseId };
+const contentDigest = caseState?.content_digest ?? "";
+
+function rosterEntries() {
+  if (Array.isArray(roster)) return roster;
+  if (Array.isArray(roster?.members)) return roster.members;
+  return [];
+}
+
+function principalFor(role) {
+  const entry = rosterEntries().find((item) => item.role === role || item.principal === role);
+  return entry?.principal ?? null;
+}
+
+function hasRosterPrincipal(principal) {
+  return rosterEntries().some((item) => item.principal === principal || item.role === principal);
+}
+
+function namedCommsRun() {
+  const external = caseState?.audience?.external === true || caseState?.send_class === "stakeholder";
+  const skill = external ? "governed-outbound" : "slack-notify";
+  return {
+    skill,
+    runner: external ? "governed-outbound" : "plan",
+    principal: principalFor("comms_lead") ?? "incident:comms_lead",
+    channel,
+    audience,
+    content_digest: contentDigest,
+    source_alert_ref: sourceAlert?.ref ?? sourceAlert?.id ?? null,
+    command_hint: external
+      ? "runx skill governed-outbound -i url=<source> -i channel=<channel> -i principal=<principal>"
+      : "runx skill slack-notify -i channel=<channel> --input-json content=<digest-bound-content>",
+  };
+}
+
+function turnPacket(status, reason, extra = {}) {
+  const incidentTurn = {
+    schema: "runx.incident_commander.turn.v1",
+    status,
+    case_id: caseId,
+    turn,
+    driver_id: driverId,
+    objective: incidentObjective,
+    incident_severity: severity,
+    dispatch: extra.dispatch ?? null,
+    escalation: extra.escalation ?? null,
+    named_run: extra.named_run ?? null,
+    reason,
+    source_alert: sourceAlert,
+    approval: approval
+      ? {
+          principal: approval.principal ?? null,
+          reason: approval.reason ?? null,
+          matched_roster: approval.principal ? hasRosterPrincipal(approval.principal) : false,
+        }
+      : null,
+    member_result: memberResult
+      ? {
+          outcome: memberResult.outcome ?? null,
+          receipt_ref: memberResult.receipt_ref ?? null,
+        }
+      : null,
+    prior_awaiting_approval: extra.prior_awaiting_approval ?? null,
+  };
+  return {
+    act_decision: status,
+    act_reason: `status=${status} reason=${reason} case=${caseId} turn=${turn}`,
+    act_target_ref: `runx:incident:${caseId}#turn-${turn}`,
+    incident_turn: incidentTurn,
+  };
+}
+
+let packet;
+
+if (!caseId || !driverId || !incidentObjective) {
+  packet = turnPacket("needs_agent", "missing case_id, driver_id, or incident_objective");
+} else if (!sourceAlert?.ref && !sourceAlert?.id) {
+  packet = turnPacket("needs_agent", "missing monitor-backed source_alert on folded case_state");
+} else if (incidentObjective === "send") {
+  const run = namedCommsRun();
+  const approvalPrincipal = approval?.principal ?? null;
+  const approvalMatches = approvalPrincipal ? hasRosterPrincipal(approvalPrincipal) : false;
+  if (!approvalPrincipal) {
+    packet = turnPacket("awaiting_approval", "status update requires roster-matched approval before dispatch", {
+      named_run: run,
+      escalation: {
+        lane: "incident-reviewer",
+        required: true,
+        reason: "missing approval",
+      },
+    });
+  } else if (!approvalMatches) {
+    packet = turnPacket("awaiting_approval", "approval principal does not match incident roster", {
+      named_run: run,
+      escalation: {
+        lane: "incident-reviewer",
+        required: true,
+        reason: "unmatched approval principal",
+      },
+    });
+  } else if (!memberResult?.receipt_ref) {
+    packet = turnPacket("awaiting_approval", "approval matched; waiting for governed send receipt", {
+      named_run: run,
+      escalation: {
+        lane: "governed-outbound",
+        required: true,
+        reason: "send receipt not linked yet",
+      },
+      prior_awaiting_approval: {
+        status: "awaiting_approval",
+        named_run: run,
+        approval_principal: approvalPrincipal,
+      },
+    });
+  } else {
+    packet = turnPacket("delivered", "roster approval matched and governed send receipt linked", {
+      named_run: run,
+      dispatch: {
+        lane: run.skill,
+        receipt_ref: memberResult.receipt_ref,
+        outcome: memberResult.outcome ?? "sent",
+      },
+      prior_awaiting_approval: {
+        status: "awaiting_approval",
+        named_run: run,
+        approval_principal: approvalPrincipal,
+      },
+    });
+  }
+} else if (incidentObjective === "assign") {
+  const owner = caseState?.assign_to ?? caseState?.requested_owner ?? null;
+  if (!owner || !hasRosterPrincipal(owner)) {
+    packet = turnPacket("needs_agent", "assign objective has no named roster owner", {
+      escalation: {
+        lane: "incident-reviewer",
+        required: true,
+        reason: "missing roster owner",
+      },
+    });
+  } else {
+    packet = turnPacket("advanced", "assignment target is present in incident roster", {
+      dispatch: {
+        member: owner,
+        task: caseState?.assignment_task ?? "take incident responder lead",
+      },
+    });
+  }
+} else if (incidentObjective === "resolve") {
+  const receiptRef = memberResult?.receipt_ref ?? caseState?.resolution_evidence?.receipt_ref ?? null;
+  if (!receiptRef) {
+    packet = turnPacket("needs_agent", "resolution requires linked evidence receipt");
+  } else {
+    packet = turnPacket("resolved", "resolution evidence receipt linked", {
+      dispatch: {
+        lane: "postmortem",
+        receipt_ref: receiptRef,
+      },
+    });
+  }
+} else {
+  packet = turnPacket("advanced", `objective ${incidentObjective} recorded for incident agency turn`);
+}
+
+process.stdout.write(`${JSON.stringify(packet)}\n`);


### PR DESCRIPTION
Adds an incident-commander runx skill for Frantic bounty #112.\n\nThe skill coordinates one monitor-backed incident agency turn, enforces roster-matched approvals, names governed outbound/slack notification lanes for comms, and refuses to mark delivery without a linked downstream send receipt.\n\nLocal harness covers:\n- status-update-approval-then-delivered\n- assign-missing-roster-owner-needs-agent