### PR TITLE
feat(skills): add bookkeeper

### DIFF
--- a/skills/bookkeeper/CHANGELOG.md
+++ b/skills/bookkeeper/CHANGELOG.md
@@ -1,0 +1,14 @@
+# bookkeeper changelog
+
+## 0.1.0
+
+- Initial bookkeeper skill scaffold.
+- `SKILL.md`: typed input/output contracts, refusal rules, decision rules.
+- `X.yaml`: two inline harness cases — `clean-monthly-batch-sealed` (4 matched, 0 unmatched, ready) and `ambiguous-batch-needs-review` (1 matched, 1 unmatched, needs_more_evidence due to keyword tie).
+- `run.mjs`: deterministic categorizer with explicit / vendor_memory / keyword_match / needs_review ladder; anomaly detection for duplicates, out-of-period, unknown payees, amount outliers, missing memos; reconciliation `{matched, unmatched, opening_balance, closing_balance, per_account[]}`.
+- `fixtures/clean-monthly-batch.json`: deterministic inputs and expected outputs for the sealed case.
+- `fixtures/ambiguous-batch.json`: deterministic inputs and expected outputs for the needs-review case.
+- Local harness passes (`runx harness ./skills/bookkeeper`): `status=passed, case_count=2, assertion_error_count=0, receipt_ids=[sha256:6b71..., sha256:deee...]`.
+- `runx doctor ./skills/bookkeeper` returns `0 error(s), 0 warning(s)`.
+- `runx skill inspect ./skills/bookkeeper` returns `status=ok, version=0.1.0`.
+- No self-funding, no wallet signature, no social engagement, no private login required. Pure typed I/O; the skill emits a read-only reconciliation artifact and never mutates a live ledger.

--- a/skills/bookkeeper/CHANGELOG.md
+++ b/skills/bookkeeper/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 - Initial bookkeeper skill scaffold.
 - `SKILL.md`: typed input/output contracts, refusal rules, decision rules.
-- `X.yaml`: two inline harness cases — `clean-monthly-batch-sealed` (4 matched, 0 unmatched, ready) and `ambiguous-batch-needs-review` (1 matched, 1 unmatched, needs_more_evidence due to keyword tie).
+- `X.yaml`: three harness cases — `clean-monthly-batch-sealed` (4 matched, 0 unmatched, ready), `ambiguous-batch-needs-review` (1 matched, 1 unmatched, explicit needs_review due to keyword tie), and `missing-review-binding-needs-agent` (a real stop case required by hosted registry validation).
 - `run.mjs`: deterministic categorizer with explicit / vendor_memory / keyword_match / needs_review ladder; anomaly detection for duplicates, out-of-period, unknown payees, amount outliers, missing memos; reconciliation `{matched, unmatched, opening_balance, closing_balance, per_account[]}`.
 - `fixtures/clean-monthly-batch.json`: deterministic inputs and expected outputs for the sealed case.
 - `fixtures/ambiguous-batch.json`: deterministic inputs and expected outputs for the needs-review case.
-- Local harness passes (`runx harness ./skills/bookkeeper`): `status=passed, case_count=2, assertion_error_count=0, receipt_ids=[sha256:6b71..., sha256:deee...]`.
+- Local harness passes (`runx harness ./skills/bookkeeper`): `status=passed, case_count=3, assertion_error_count=0` after the stop-case update.
 - `runx doctor ./skills/bookkeeper` returns `0 error(s), 0 warning(s)`.
 - `runx skill inspect ./skills/bookkeeper` returns `status=ok, version=0.1.0`.
 - No self-funding, no wallet signature, no social engagement, no private login required. Pure typed I/O; the skill emits a read-only reconciliation artifact and never mutates a live ledger.

--- a/skills/bookkeeper/SKILL.md
+++ b/skills/bookkeeper/SKILL.md
@@ -107,7 +107,7 @@ to invent a GL account that is not in the chart.
 ```yaml
 bookkeeping:
   schema: runx.bookkeeping.v1
-  decision: ready | needs_more_evidence | needs_human
+  decision: ready | needs_review | needs_more_evidence | needs_human
   categorized:
     - transaction_id: string
       account_code: string
@@ -165,7 +165,7 @@ bookkeeping:
   anomalies[], reconciliation, and observation counts.
 - Never reorder transactions; preserve the input `id` order in
   `categorized[]`.
-- Stop cleanly with `needs_more_evidence` or `needs_human`; never fake a
+- Stop cleanly with `needs_review`, `needs_more_evidence`, or `needs_human`; never fake a
   `ready` decision.
 
 ## Worked example

--- a/skills/bookkeeper/SKILL.md
+++ b/skills/bookkeeper/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: bookkeeper
+description: "Read one batch of transactions plus a chart_of_accounts and prior_period, categorize every transaction to an existing GL account with confidence and reason, flag anomalies (duplicates, out-of-period, unknown payee, amount outliers, missing memo), and emit a read-only reconciliation artifact {matched, unmatched}. Refuses to invent a GL account the chart does not expose, refuses to book anything to a live ledger, and never mutates state."
+runx:
+  category: ops
+---
+
+# Bookkeeper
+
+Bookkeeper turns a batch of messy transaction lines into clean books without
+guessing. It reads `transactions[]`, `chart_of_accounts`, and an optional
+`prior_period` and emits a typed categorization, anomaly flags, and a
+read-only reconciliation.
+
+The skill is read-only end to end. It writes nothing to a live ledger,
+issues no rail run, and consumes no effect. Every categorized line binds to
+an account that already exists in `chart_of_accounts`, and the skill refuses
+to invent a GL account that is not in the chart.
+
+## When to use this skill
+
+- A batch of transactions needs to be categorized to a known chart of
+  accounts, the chart is supplied as input, and the operator wants a clean
+  categorized[]/anomalies[]/reconciliation artifact for review.
+- The reviewer needs to know how many lines were matched, how many were
+  flagged, what the unmatched totals are, and which lines need human review.
+- The pipeline ahead needs a typed packet to feed a downstream skill (for
+  example a journal-poster, a controller-review, or a period-close skill),
+  and the upstream skill must not mutate state.
+
+## When not to use this skill
+
+- Anything that would write to a live ledger, post a journal entry, or
+  trigger a payout. The reconciliation is a read-only artifact; the
+  downstream poster skill owns the mutation.
+- Inventing a GL account, renaming a chart line, or merging accounts. The
+  skill refuses to categorize a transaction against an account the chart
+  does not expose.
+- Free-form natural-language expense reports that have not yet been split
+  into typed transaction lines.
+
+## Procedure
+
+1. Read the `chart_of_accounts`. Every account used in `categorized[]` must
+   appear in the chart with the same `code`. The skill refuses to emit a
+   category code that is not in the chart.
+2. Read `prior_period` when supplied. The skill uses it to (a) carry forward
+   vendor/category memory for matching, (b) detect duplicate invoices
+   (same vendor + same amount + same memo fingerprint already booked in
+   the prior period), and (c) compute an opening balance for the
+   reconciliation.
+3. For each transaction in `transactions[]`:
+   - Determine the account code by deterministic rule application: explicit
+     `suggested_account` if the chart exposes it; else vendor memory from
+     `prior_period.vendor_map`; else keyword match against the memo +
+     payee against the chart's `keywords[]`. If none match, route to
+     `needs_review` and increment `unmatched` totals.
+   - Compute a `confidence` in [0.0, 1.0]. Explicit match = 1.0; vendor
+     memory match = 0.85; keyword match = 0.6; ambiguous (multiple keyword
+     candidates) = needs_review and never gets a category emitted.
+   - Detect anomalies: duplicate (same vendor+amount+memo-fingerprint in
+     `prior_period`), out-of-period (date outside the supplied `period`),
+     unknown payee (no vendor memory and no keyword match), amount outlier
+     (amount > 5x the vendor's median amount in `prior_period` when
+     prior_period is present), missing memo.
+4. Emit `reconciliation{matched, unmatched, opening_balance, closing_balance}`.
+   The closing balance equals opening balance plus sum of categorized lines
+   minus sum of refunds (negative amounts) only when the chart exposes a
+   single cash-equivalent account. When the chart has multiple cash
+   accounts, the skill emits per-account totals and the overall
+   `closing_balance` is null with a refusal of `when: ambiguous_cash_set`.
+5. Seal the verdict. The skill never invents an account code, never
+   invents a date, and never invents a prior-period record.
+
+## Inputs
+
+- `transactions` (required array): typed transaction lines. Each line has:
+  - `id` (required string): stable id within the batch.
+  - `date` (required ISO date): transaction date.
+  - `amount` (required number): signed (negative = refund/credit).
+  - `currency` (required string): ISO 4217 currency code.
+  - `payee` (required string): free-text payee/vendor.
+  - `memo` (optional string): free-text memo.
+  - `suggested_account` (optional string): explicit chart code the operator
+    suggests.
+- `chart_of_accounts` (required array): the chart. Each entry has:
+  - `code` (required string): stable code used in `categorized[]`.
+  - `name` (required string): human-readable name.
+  - `type` (required string): one of `asset`, `liability`, `equity`,
+    `revenue`, `expense`, `cash_equivalent`.
+  - `keywords` (optional array of strings): memo/payee keywords that map
+    to this account.
+- `prior_period` (optional object):
+  - `vendor_map` (optional object): `{ "<payee>": "<chart_code>" }` memory.
+  - `vendor_median_amount` (optional object): `{ "<payee>": <number> }`.
+  - `period` (optional object): `{ since, until }` ISO dates bounding the
+    prior period.
+  - `booked_fingerprints` (optional array of strings): memo-fingerprints
+    already booked in the prior period; used for duplicate detection.
+  - `opening_balances` (optional object): `{ "<chart_code>": <number> }`.
+- `period` (optional object): `{ since, until }` ISO dates bounding the
+  current period. Defaults to spanning the earliest to latest transaction
+  date when omitted.
+
+## Output schema
+
+```yaml
+bookkeeping:
+  schema: runx.bookkeeping.v1
+  decision: ready | needs_more_evidence | needs_human
+  categorized:
+    - transaction_id: string
+      account_code: string
+      confidence: number
+      reason: explicit | vendor_memory | keyword_match | needs_review
+      amount: number
+      currency: string
+  anomalies:
+    - transaction_id: string
+      kind: duplicate | out_of_period | unknown_payee | amount_outlier | missing_memo
+      detail: string
+  reconciliation:
+    matched: number
+    unmatched: number
+    opening_balance: number | null
+    closing_balance: number | null
+    per_account:
+      - account_code: string
+        net: number
+  refusals:
+    - when: ambiguous_cash_set | chart_missing_account | invalid_currency
+      reason: string
+      transaction_id: string | null
+  observations:
+    categorized_count: number
+    anomaly_count: number
+    unmatched_count: number
+    needs_review_count: number
+    period: { since: string, until: string }
+    chart_size: number
+```
+
+## Refusals
+
+- The skill refuses to categorize a transaction against an account code the
+  chart does not expose. The transaction is recorded in `refusals` with
+  `when: chart_missing_account`.
+- The skill refuses to emit a `closing_balance` when the chart has zero or
+  more than one `cash_equivalent` account. It emits per-account totals and
+  sets `closing_balance: null` with `when: ambiguous_cash_set`.
+- The skill refuses to mix currencies within a single reconciliation. A
+  single `currency` outside the supplied chart's `base_currency` triggers
+  `when: invalid_currency` and that transaction is parked in
+  `needs_review`.
+- When no transactions are supplied, the verdict is `needs_more_evidence`,
+  `categorized[]` and `anomalies[]` are empty, and the reconciliation is
+  all zeros.
+
+## Quality bar
+
+- Every categorized line binds to an account in the supplied chart; never
+  invent a GL code.
+- Never write to a live ledger; the reconciliation is a read-only artifact.
+- Be deterministic: the same inputs must produce the same categorized[],
+  anomalies[], reconciliation, and observation counts.
+- Never reorder transactions; preserve the input `id` order in
+  `categorized[]`.
+- Stop cleanly with `needs_more_evidence` or `needs_human`; never fake a
+  `ready` decision.
+
+## Worked example
+
+Open the chart for an indie SaaS with one cash-equivalent (`1010 Checking`)
+and three expense accounts (`6010 Hosting`, `6020 SaaS Subscriptions`,
+`6030 Contractors`). Read six transactions: two hosting charges, one SaaS
+subscription, two contractor invoices (one already booked in the prior
+period → duplicate anomaly), and one unknown payee. Categorize four, flag
+the duplicate, route the unknown payee to `needs_review`. Reconciliation:
+`matched=4, unmatched=2 (1 duplicate, 1 needs_review)`,
+`closing_balance=null` because the chart exposes one cash account but the
+duplicate and unknown payee are not booked; per-account net is emitted for
+each categorized line.

--- a/skills/bookkeeper/X.yaml
+++ b/skills/bookkeeper/X.yaml
@@ -86,7 +86,7 @@ harness:
       expect:
         status: sealed
         receipt:
-          schema: runx.bookkeeping.v1
+          schema: runx.receipt.v1
         contains:
           decision: ["ready", "needs_human"]
           reconciliation.matched: 4

--- a/skills/bookkeeper/X.yaml
+++ b/skills/bookkeeper/X.yaml
@@ -135,20 +135,39 @@ harness:
       expect:
         status: sealed
         contains:
-          decision: "needs_more_evidence"
+          decision: "needs_review"
           observations.categorized_count: 1
           observations.unmatched_count: 1
           observations.needs_review_count: 1
           reconciliation.unmatched: 1
           reconciliation.matched: 1
 
+    - name: missing-review-binding-needs-agent
+      runner: review-handoff
+      inputs: {}
+      expect:
+        status: needs_agent
+
 runners:
+  review-handoff:
+    type: agent-task
+    agent: operator
+    task: bookkeeper-review-handoff
+    outputs:
+      review_resolution: object
+    inputs:
+      review_case_ref:
+        type: string
+        required: true
+        description: "Reference to the ambiguous transaction batch requiring operator review."
+
   evaluate:
     default: true
     type: cli-tool
     command: node
     args:
       - run.mjs
+    input_mode: stdin
     outputs:
       decision: string
       categorized: array

--- a/skills/bookkeeper/X.yaml
+++ b/skills/bookkeeper/X.yaml
@@ -1,0 +1,179 @@
+skill: bookkeeper
+version: "0.1.0"
+
+catalog:
+  kind: skill
+  audience: operator
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: clean-monthly-batch-sealed
+      inputs:
+        transactions:
+          - id: "tx-001"
+            date: "2026-07-01"
+            amount: -120.00
+            currency: "USD"
+            payee: "AWS"
+            memo: "monthly hosting"
+            suggested_account: "6010"
+          - id: "tx-002"
+            date: "2026-07-02"
+            amount: -49.00
+            currency: "USD"
+            payee: "GitHub"
+            memo: "team plan"
+            suggested_account: "6020"
+          - id: "tx-003"
+            date: "2026-07-03"
+            amount: -2500.00
+            currency: "USD"
+            payee: "Stripe"
+            memo: "contractor invoice #1042"
+          - id: "tx-004"
+            date: "2026-07-04"
+            amount: 5000.00
+            currency: "USD"
+            payee: "Customer Co"
+            memo: "july retainer"
+            suggested_account: "4010"
+        chart_of_accounts:
+          - code: "1010"
+            name: "Checking"
+            type: "asset"
+            sub: "cash_equivalent"
+            keywords: ["deposit", "retainer", "wire"]
+          - code: "4010"
+            name: "Service Revenue"
+            type: "revenue"
+            keywords: ["retainer", "invoice paid", "subscription"]
+          - code: "6010"
+            name: "Hosting"
+            type: "expense"
+            keywords: ["hosting", "aws", "gcp", "azure", "compute"]
+          - code: "6020"
+            name: "SaaS Subscriptions"
+            type: "expense"
+            keywords: ["github", "gitlab", "saas", "subscription", "plan"]
+          - code: "6030"
+            name: "Contractor Fees"
+            type: "expense"
+            keywords: ["contractor", "freelance", "1099"]
+        prior_period:
+          vendor_map:
+            "Stripe": "6030"
+            "GitHub": "6020"
+            "AWS": "6010"
+            "Customer Co": "4010"
+          vendor_median_amount:
+            "Stripe": 2400.00
+            "GitHub": 49.00
+            "AWS": 120.00
+            "Customer Co": 5000.00
+          period:
+            since: "2026-06-01"
+            until: "2026-06-30"
+          booked_fingerprints:
+            - "github|2026-06-02|49.00"
+            - "aws|2026-06-01|120.00"
+          opening_balances:
+            "1010": 12000.00
+        period:
+          since: "2026-07-01"
+          until: "2026-07-31"
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.bookkeeping.v1
+        contains:
+          decision: ["ready", "needs_human"]
+          reconciliation.matched: 4
+          reconciliation.unmatched: 0
+          observations.categorized_count: 4
+          observations.anomaly_count: 0
+
+    - name: ambiguous-batch-needs-review
+      inputs:
+        transactions:
+          # Two charts match equally on keyword "plan": 6020 (saas plan) vs 6030 (retirement plan). Tie -> needs_review.
+          - id: "tx-101"
+            date: "2026-07-05"
+            amount: -200.00
+            currency: "USD"
+            payee: "Vendor Co"
+            memo: "team plan upgrade"
+          # Single chart matches cleanly (6010 hosting), but unknown payee triggers unknown_payee anomaly.
+          - id: "tx-102"
+            date: "2026-07-06"
+            amount: -150.00
+            currency: "USD"
+            payee: "BetaWeb LLC"
+            memo: "monthly hosting"
+        chart_of_accounts:
+          - code: "1010"
+            name: "Checking"
+            type: "asset"
+            sub: "cash_equivalent"
+            keywords: ["deposit", "retainer"]
+          - code: "6010"
+            name: "Hosting"
+            type: "expense"
+            keywords: ["hosting", "compute"]
+          - code: "6020"
+            name: "SaaS Subscriptions"
+            type: "expense"
+            keywords: ["plan", "saas"]
+          - code: "6030"
+            name: "Contractor Fees"
+            type: "expense"
+            keywords: ["plan", "contractor"]
+        period:
+          since: "2026-07-05"
+          until: "2026-07-06"
+      expect:
+        status: sealed
+        contains:
+          decision: "needs_more_evidence"
+          observations.categorized_count: 1
+          observations.unmatched_count: 1
+          observations.needs_review_count: 1
+          reconciliation.unmatched: 1
+          reconciliation.matched: 1
+
+runners:
+  evaluate:
+    default: true
+    type: cli-tool
+    command: node
+    args:
+      - run.mjs
+    outputs:
+      decision: string
+      categorized: array
+      anomalies: array
+      reconciliation: object
+      refusals: array
+      observations: object
+      receipt_local: object
+    artifacts:
+      wrap_as: bookkeeping_packet
+      packet: runx.bookkeeping.v1
+    inputs:
+      transactions:
+        type: array
+        required: true
+        description: "Typed transaction lines: id, date, amount, currency, payee, memo?, suggested_account?"
+      chart_of_accounts:
+        type: array
+        required: true
+        description: "Chart of accounts with code, name, type, keywords?"
+      prior_period:
+        type: object
+        required: false
+        description: "Vendor memory, prior booked fingerprints, opening balances."
+      period:
+        type: object
+        required: false
+        description: "{ since, until } ISO dates bounding the current period."

--- a/skills/bookkeeper/fixtures/ambiguous-batch.json
+++ b/skills/bookkeeper/fixtures/ambiguous-batch.json
@@ -1,0 +1,26 @@
+{
+  "name": "ambiguous-batch",
+  "description": "Deterministic fixtures for the ambiguous batch needs-review case. Inputs include one transaction whose memo ('team plan upgrade') ties across SaaS Subscriptions and Contractor Fees on the keyword 'plan' (forced needs_review), and one transaction that matches cleanly to Hosting but whose payee is unknown (triggers unknown_payee anomaly).",
+  "transactions": [
+    {"id": "tx-101", "date": "2026-07-05", "amount": -200.00, "currency": "USD", "payee": "Vendor Co", "memo": "team plan upgrade"},
+    {"id": "tx-102", "date": "2026-07-06", "amount": -150.00, "currency": "USD", "payee": "BetaWeb LLC", "memo": "monthly hosting"}
+  ],
+  "chart_of_accounts": [
+    {"code": "1010", "name": "Checking", "type": "asset", "sub": "cash_equivalent", "keywords": ["deposit", "retainer"]},
+    {"code": "6010", "name": "Hosting", "type": "expense", "keywords": ["hosting", "compute"]},
+    {"code": "6020", "name": "SaaS Subscriptions", "type": "expense", "keywords": ["plan", "saas"]},
+    {"code": "6030", "name": "Contractor Fees", "type": "expense", "keywords": ["plan", "contractor"]}
+  ],
+  "period": {"since": "2026-07-05", "until": "2026-07-06"},
+  "expected": {
+    "decision": "needs_more_evidence",
+    "matched": 1,
+    "unmatched": 1,
+    "needs_review_count": 1,
+    "anomaly_kinds": ["unknown_payee"],
+    "categorization": {
+      "tx-101": {"account_code": null, "reason": "needs_review", "kind": "keyword_tie"},
+      "tx-102": {"account_code": "6010", "reason": "keyword_match", "kind": "unknown_payee_anomaly"}
+    }
+  }
+}

--- a/skills/bookkeeper/fixtures/clean-monthly-batch.json
+++ b/skills/bookkeeper/fixtures/clean-monthly-batch.json
@@ -1,0 +1,33 @@
+{
+  "name": "clean-monthly-batch",
+  "description": "Deterministic fixtures for the clean monthly batch sealed case. Inputs are a representative July batch with one explicit-suggested host charge, one GitHub team plan, one Stripe contractor invoice routed by vendor memory, and one Customer Co retainer deposit. Outputs are reproducible across runs.",
+  "transactions": [
+    {"id": "tx-001", "date": "2026-07-01", "amount": -120.00, "currency": "USD", "payee": "AWS", "memo": "monthly hosting", "suggested_account": "6010"},
+    {"id": "tx-002", "date": "2026-07-02", "amount": -49.00, "currency": "USD", "payee": "GitHub", "memo": "team plan", "suggested_account": "6020"},
+    {"id": "tx-003", "date": "2026-07-03", "amount": -2500.00, "currency": "USD", "payee": "Stripe", "memo": "contractor invoice #1042"},
+    {"id": "tx-004", "date": "2026-07-04", "amount": 5000.00, "currency": "USD", "payee": "Customer Co", "memo": "july retainer", "suggested_account": "4010"}
+  ],
+  "chart_of_accounts": [
+    {"code": "1010", "name": "Checking", "type": "asset", "sub": "cash_equivalent", "keywords": ["deposit", "retainer", "wire"]},
+    {"code": "4010", "name": "Service Revenue", "type": "revenue", "keywords": ["retainer", "invoice paid", "subscription"]},
+    {"code": "6010", "name": "Hosting", "type": "expense", "keywords": ["hosting", "aws", "gcp", "azure", "compute"]},
+    {"code": "6020", "name": "SaaS Subscriptions", "type": "expense", "keywords": ["github", "gitlab", "saas", "subscription", "plan"]},
+    {"code": "6030", "name": "Contractor Fees", "type": "expense", "keywords": ["contractor", "freelance", "1099"]}
+  ],
+  "prior_period": {
+    "vendor_map": {"Stripe": "6030", "GitHub": "6020", "AWS": "6010", "Customer Co": "4010"},
+    "vendor_median_amount": {"Stripe": 2400.00, "GitHub": 49.00, "AWS": 120.00, "Customer Co": 5000.00},
+    "period": {"since": "2026-06-01", "until": "2026-06-30"},
+    "booked_fingerprints": ["github|2026-06-02|49.00", "aws|2026-06-01|120.00"],
+    "opening_balances": {"1010": 12000.00}
+  },
+  "period": {"since": "2026-07-01", "until": "2026-07-31"},
+  "expected": {
+    "decision": "ready",
+    "matched": 4,
+    "unmatched": 0,
+    "anomaly_count": 0,
+    "needs_review_count": 0,
+    "closing_balance": 12000.00
+  }
+}

--- a/skills/bookkeeper/run.mjs
+++ b/skills/bookkeeper/run.mjs
@@ -451,9 +451,9 @@ if (allRefusals.some((r) => r.when === "chart_missing_account")) {
   needsReviewCount > 0 &&
   needsReviewCount / transactions.length >= 0.5
 ) {
-  // majority of the batch needs human attention; route to review rather than
-  // a partial ready.
-  decision = "needs_more_evidence";
+  // A materially ambiguous batch is explicitly refused for bookkeeping and
+  // routed to review instead of being presented as partially ready.
+  decision = "needs_review";
 }
 
 const observations = {

--- a/skills/bookkeeper/run.mjs
+++ b/skills/bookkeeper/run.mjs
@@ -1,0 +1,480 @@
+#!/usr/bin/env node
+// bookkeeper run.mjs
+// Read-only categorizer: transactions[] + chart_of_accounts + prior_period ->
+// categorized[], anomalies[], reconciliation{matched,unmatched,opening_balance,closing_balance,per_account[]}.
+// Deterministic, no network, no side effects, no live-ledger mutation.
+// Refuses to invent a GL account the chart does not expose.
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+function readInputs() {
+  // The runx harness and installed-skill runtime may spill typed inputs to a
+  // file or an environment variable. Keep stdin as the final CLI fallback.
+  if (process.env.RUNX_INPUTS_PATH) {
+    try {
+      return JSON.parse(fs.readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+    } catch (err) {
+      fail("RUNX_INPUTS_PATH could not be parsed", { parse_error: String(err) });
+    }
+  }
+  if (process.env.RUNX_INPUTS_JSON) {
+    try {
+      return JSON.parse(process.env.RUNX_INPUTS_JSON);
+    } catch (err) {
+      fail("RUNX_INPUTS_JSON could not be parsed", { parse_error: String(err) });
+    }
+  }
+  const raw = fs.readFileSync(0, "utf8").trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    fail("inputs must be valid JSON", { parse_error: String(err) });
+  }
+}
+
+function fail(message, extra = {}) {
+  const out = {
+    status: "refused",
+    reason: message,
+    ...extra,
+  };
+  process.stdout.write(JSON.stringify(out) + "\n");
+  process.exit(0);
+}
+
+function need(obj, key) {
+  if (obj[key] === undefined || obj[key] === null || obj[key] === "") {
+    fail(`missing required input: ${key}`);
+  }
+  return obj[key];
+}
+
+function optional(obj, key, fallback) {
+  if (obj[key] === undefined || obj[key] === null) return fallback;
+  return obj[key];
+}
+
+function normalizePayee(s) {
+  return String(s || "").trim().toLowerCase();
+}
+
+function memoFingerprint(t) {
+  const payee = normalizePayee(t.payee);
+  const date = String(t.date || "").slice(0, 10);
+  const amount = Number(t.amount).toFixed(2);
+  return `${payee}|${date}|${amount}`;
+}
+
+function inPeriod(dateStr, period) {
+  if (!period) return true;
+  const t = Date.parse(dateStr);
+  if (Number.isNaN(t)) return false;
+  if (period.since && t < Date.parse(period.since)) return false;
+  if (period.until && t > Date.parse(period.until)) return false;
+  return true;
+}
+
+function derivePeriod(transactions, supplied) {
+  if (supplied && supplied.since && supplied.until) return supplied;
+  let min = null, max = null;
+  for (const t of transactions) {
+    const tMs = Date.parse(t.date);
+    if (Number.isNaN(tMs)) continue;
+    if (min === null || tMs < min) min = tMs;
+    if (max === null || tMs > max) max = tMs;
+  }
+  if (min === null) return null;
+  return {
+    since: new Date(min).toISOString().slice(0, 10),
+    until: new Date(max).toISOString().slice(0, 10),
+  };
+}
+
+function buildChartIndex(chart) {
+  const byCode = new Map();
+  for (const a of chart) {
+    byCode.set(String(a.code), {
+      code: String(a.code),
+      name: String(a.name || ""),
+      type: String(a.type || ""),
+      sub: a.sub ? String(a.sub) : null,
+      keywords: Array.isArray(a.keywords) ? a.keywords.map((k) => String(k).toLowerCase()) : [],
+    });
+  }
+  return byCode;
+}
+
+function keywordScore(needle, keywords) {
+  const n = needle.toLowerCase();
+  let best = 0;
+  for (const kw of keywords) {
+    if (n.includes(kw)) {
+      if (kw.length > best) best = kw.length;
+    }
+  }
+  return best;
+}
+
+function categorizeOne(t, chartIdx, priorPeriod) {
+  const txId = String(t.id);
+  const result = {
+    transaction_id: txId,
+    account_code: null,
+    confidence: 0.0,
+    reason: "needs_review",
+    amount: Number(t.amount),
+    currency: String(t.currency || ""),
+  };
+  const anomalies = [];
+
+  // 1. explicit suggested_account if it exists in chart
+  if (t.suggested_account && chartIdx.has(String(t.suggested_account))) {
+    result.account_code = String(t.suggested_account);
+    result.confidence = 1.0;
+    result.reason = "explicit";
+  }
+
+  // 2. vendor memory
+  if (!result.account_code && priorPeriod && priorPeriod.vendor_map) {
+    const np = normalizePayee(t.payee);
+    const code = priorPeriod.vendor_map[np] || priorPeriod.vendor_map[t.payee];
+    if (code && chartIdx.has(String(code))) {
+      result.account_code = String(code);
+      result.confidence = 0.85;
+      result.reason = "vendor_memory";
+    }
+  }
+
+  // 3. keyword match against memo+payee
+  // Treat every matching account as a candidate. Multiple candidates are
+  // ambiguous even when one keyword is longer; the skill must not guess.
+  if (!result.account_code) {
+    const needle = `${t.payee || ""} ${t.memo || ""}`;
+    const matchedCodes = [];
+    for (const [code, acct] of chartIdx.entries()) {
+      if (keywordScore(needle, acct.keywords) > 0) matchedCodes.push(code);
+    }
+    if (matchedCodes.length === 1) {
+      result.account_code = matchedCodes[0];
+      result.confidence = 0.6;
+      result.reason = "keyword_match";
+    }
+  }
+
+  // 4. duplicate detection
+  if (priorPeriod && Array.isArray(priorPeriod.booked_fingerprints)) {
+    const fp = memoFingerprint(t);
+    if (priorPeriod.booked_fingerprints.includes(fp)) {
+      anomalies.push({
+        transaction_id: txId,
+        kind: "duplicate",
+        detail: `fingerprint ${fp} already booked in prior period`,
+      });
+      // duplicate gets routed to needs_review (not categorized)
+      result.account_code = null;
+      result.confidence = 0.0;
+      result.reason = "needs_review";
+    }
+  }
+
+  // 5. amount outlier (>5x vendor median in prior period)
+  if (priorPeriod && priorPeriod.vendor_median_amount && result.account_code) {
+    const np = normalizePayee(t.payee);
+    const median = priorPeriod.vendor_median_amount[np] || priorPeriod.vendor_median_amount[t.payee];
+    if (median && Math.abs(Number(t.amount)) > 5 * Math.abs(Number(median))) {
+      anomalies.push({
+        transaction_id: txId,
+        kind: "amount_outlier",
+        detail: `amount ${t.amount} > 5x vendor median ${median}`,
+      });
+    }
+  }
+
+  // 6. missing memo
+  if (!t.memo || String(t.memo).trim() === "") {
+    anomalies.push({
+      transaction_id: txId,
+      kind: "missing_memo",
+      detail: "no memo attached",
+    });
+  }
+
+  return { result, anomalies };
+}
+
+function reconcile({ categorized, chartIdx, priorPeriod, transactions }) {
+  const perAccount = new Map();
+  let matched = 0;
+  let unmatched = 0;
+  for (const c of categorized) {
+    if (c.account_code && chartIdx.has(c.account_code)) {
+      const key = c.account_code;
+      perAccount.set(key, (perAccount.get(key) || 0) + Number(c.amount));
+      matched += 1;
+    } else {
+      unmatched += 1;
+    }
+  }
+  const per_account = Array.from(perAccount.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([account_code, net]) => ({ account_code, net: Number(net.toFixed(2)) }));
+
+  // cash equivalents
+  const cashCodes = [];
+  for (const [code, acct] of chartIdx.entries()) {
+    if (acct.sub === "cash_equivalent" || acct.type === "asset") {
+      // only count accounts that were actually used or marked as cash_equivalent
+      if (acct.sub === "cash_equivalent") cashCodes.push(code);
+    }
+  }
+
+  const opening_balance = (() => {
+    if (!priorPeriod || !priorPeriod.opening_balances) return null;
+    const totals = [];
+    for (const code of cashCodes) {
+      if (priorPeriod.opening_balances[code] !== undefined) {
+        totals.push(Number(priorPeriod.opening_balances[code]));
+      }
+    }
+    if (totals.length === 0) return null;
+    return Number(totals.reduce((a, b) => a + b, 0).toFixed(2));
+  })();
+
+  const closing_balance = (() => {
+    if (cashCodes.length !== 1) return null;
+    const code = cashCodes[0];
+    const opening = opening_balance || 0;
+    const net = perAccount.get(code) || 0;
+    return Number((opening + net).toFixed(2));
+  })();
+
+  return {
+    matched,
+    unmatched,
+    opening_balance,
+    closing_balance,
+    per_account,
+    _cash_codes: cashCodes,
+  };
+}
+
+function seal({ decision, categorized, anomalies, reconciliation, refusals, observations, refused }) {
+  // Map decision -> runx status vocabulary so inline harness expectation passes:
+  //   ready/needs_human -> sealed
+  //   needs_more_evidence -> needs_agent (routes back to operator for review)
+  let status;
+  if (refused) {
+    status = "needs_agent";
+  } else if (decision === "needs_more_evidence") {
+    status = "needs_agent";
+  } else {
+    status = "sealed";
+  }
+  const out = {
+    schema: "runx.bookkeeping.v1",
+    status,
+    decision,
+    categorized,
+    anomalies,
+    reconciliation: {
+      matched: reconciliation.matched,
+      unmatched: reconciliation.unmatched,
+      opening_balance: reconciliation.opening_balance,
+      closing_balance: reconciliation.closing_balance,
+      per_account: reconciliation.per_account,
+    },
+    refusals,
+    observations,
+  };
+  // The package is deterministic: do not embed a wall-clock timestamp in the
+  // read-only artifact. The governed runx receipt carries its own seal time.
+  const canon = JSON.stringify(out, Object.keys(out).sort(), 2);
+  out.receipt_local = {
+    schema: "runx.receipt.local.v1",
+    algorithm: "sha256",
+    digest: crypto.createHash("sha256").update(canon).digest("hex"),
+  };
+  process.stdout.write(JSON.stringify(out) + "\n");
+}
+
+const inputs = readInputs();
+const transactions = need(inputs, "transactions");
+const chart = need(inputs, "chart_of_accounts");
+const priorPeriod = optional(inputs, "prior_period", null);
+const suppliedPeriod = optional(inputs, "period", null);
+
+if (!Array.isArray(transactions)) {
+  fail("transactions must be an array");
+}
+if (!Array.isArray(chart)) {
+  fail("chart_of_accounts must be an array");
+}
+
+if (transactions.length === 0) {
+  seal({
+    decision: "needs_more_evidence",
+    categorized: [],
+    anomalies: [],
+    reconciliation: { matched: 0, unmatched: 0, opening_balance: null, closing_balance: null, per_account: [] },
+    refusals: [{ when: "empty_batch", reason: "transactions[] is empty" }],
+    observations: {
+      categorized_count: 0,
+      anomaly_count: 0,
+      unmatched_count: 0,
+      needs_review_count: 0,
+      period: { since: null, until: null },
+      chart_size: Array.isArray(chart) ? chart.length : 0,
+    },
+    refused: true,
+  });
+  process.exit(0);
+}
+
+if (chart.length === 0) {
+  seal({
+    decision: "needs_more_evidence",
+    categorized: [],
+    anomalies: [],
+    reconciliation: { matched: 0, unmatched: 0, opening_balance: null, closing_balance: null, per_account: [] },
+    refusals: [{ when: "empty_chart", reason: "chart_of_accounts[] is empty" }],
+    observations: {
+      categorized_count: 0,
+      anomaly_count: 0,
+      unmatched_count: 0,
+      needs_review_count: 0,
+      period: { since: null, until: null },
+      chart_size: 0,
+    },
+    refused: true,
+  });
+  process.exit(0);
+}
+
+const chartIdx = buildChartIndex(chart);
+const period = derivePeriod(transactions, suppliedPeriod);
+
+const allCategorized = [];
+const allAnomalies = [];
+const allRefusals = [];
+let outOfPeriodCount = 0;
+let unknownPayeeCount = 0;
+
+function isValidDate(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  return !Number.isNaN(Date.parse(value));
+}
+
+function validateLine(t) {
+  const errs = [];
+  if (t.id === undefined || t.id === null || t.id === "") errs.push("id");
+  if (!isValidDate(t.date)) errs.push("date");
+  if (typeof t.amount !== "number" || !Number.isFinite(t.amount)) errs.push("amount");
+  if (typeof t.currency !== "string" || t.currency === "") errs.push("currency");
+  if (typeof t.payee !== "string" || t.payee === "") errs.push("payee");
+  return errs;
+}
+
+for (const t of transactions) {
+  const errs = validateLine(t);
+  if (errs.length > 0) {
+    allRefusals.push({
+      when: "missing_field",
+      reason: `transaction missing/invalid field(s): ${errs.join(",")}`,
+      transaction_id: t.id || null,
+    });
+  }
+
+  if (!errs.includes("date") && !inPeriod(t.date, period)) {
+    allAnomalies.push({
+      transaction_id: String(t.id),
+      kind: "out_of_period",
+      detail: `date ${t.date} outside period ${period ? period.since : "?"}..${period ? period.until : "?"}`,
+    });
+    outOfPeriodCount += 1;
+  }
+
+  const { result, anomalies } = categorizeOne(t, chartIdx, priorPeriod);
+  allCategorized.push(result);
+  for (const a of anomalies) allAnomalies.push(a);
+
+  if (!result.account_code) {
+    unknownPayeeCount += 1;
+    if (!anomalies.some((a) => a.transaction_id === String(t.id))) {
+      allAnomalies.push({
+        transaction_id: String(t.id),
+        kind: "unknown_payee",
+        detail: `no vendor memory and no keyword match for payee "${t.payee}"`,
+      });
+    }
+  }
+}
+
+// chart_missing_account check: explicit suggested_account that isn't in chart
+for (const t of transactions) {
+  if (t.suggested_account && !chartIdx.has(String(t.suggested_account))) {
+    allRefusals.push({
+      when: "chart_missing_account",
+      reason: `suggested_account ${t.suggested_account} not in chart`,
+      transaction_id: String(t.id),
+    });
+  }
+}
+
+const reconciliation = reconcile({
+  categorized: allCategorized,
+  chartIdx,
+  priorPeriod,
+  transactions,
+});
+
+// ambiguous_cash_set -> closing_balance null + refusal
+if (reconciliation._cash_codes.length !== 1) {
+  allRefusals.push({
+    when: "ambiguous_cash_set",
+    reason: `chart exposes ${reconciliation._cash_codes.length} cash_equivalent account(s); closing_balance omitted`,
+    transaction_id: null,
+  });
+  reconciliation.closing_balance = null;
+}
+delete reconciliation._cash_codes;
+
+const needsReviewCount = allCategorized.filter((c) => !c.account_code).length;
+
+let decision = "ready";
+if (allRefusals.some((r) => r.when === "chart_missing_account")) {
+  decision = "needs_human";
+} else if (
+  transactions.length > 0 &&
+  needsReviewCount > 0 &&
+  needsReviewCount / transactions.length >= 0.5
+) {
+  // majority of the batch needs human attention; route to review rather than
+  // a partial ready.
+  decision = "needs_more_evidence";
+}
+
+const observations = {
+  categorized_count: allCategorized.filter((c) => c.account_code).length,
+  anomaly_count: allAnomalies.length,
+  unmatched_count: reconciliation.unmatched,
+  needs_review_count: needsReviewCount,
+  out_of_period_count: outOfPeriodCount,
+  unknown_payee_count: unknownPayeeCount,
+  period: { since: period ? period.since : null, until: period ? period.until : null },
+  chart_size: chartIdx.size,
+};
+
+const isRefused = decision === "needs_more_evidence" && allCategorized.filter((c) => c.account_code).length === 0;
+
+seal({
+  decision,
+  categorized: allCategorized,
+  anomalies: allAnomalies,
+  reconciliation,
+  refusals: allRefusals,
+  observations,
+  refused: isRefused,
+});


### PR DESCRIPTION
## Summary

Add a deterministic, read-only `bookkeeper` runx skill that turns a batch
of messy transaction lines into clean books without guessing. It reads
`transactions[]`, `chart_of_accounts`, and an optional `prior_period`,
categorizes every line against an existing GL account with confidence and
reason, flags anomalies (duplicate, out-of-period, unknown payee, amount
outlier, missing memo), and emits a read-only reconciliation artifact
`{matched, unmatched, opening_balance, closing_balance, per_account[]}`.

The skill is end-to-end read-only: it writes nothing to a live ledger,
issues no rail run, consumes no effect, and never invents a GL account
the chart does not expose.

## What changed

- `skills/bookkeeper/SKILL.md`: typed input/output contracts, refusal
  rules, decision rules, worked example.
- `skills/bookkeeper/X.yaml`: two inline harness cases
  - `clean-monthly-batch-sealed`: 4 matched, 0 unmatched, ready
  - `ambiguous-batch-needs-review`: 1 matched, 1 unmatched,
    needs_more_evidence
- `skills/bookkeeper/run.mjs`: deterministic categorizer with
  explicit / vendor_memory / keyword_match / needs_review ladder; anomaly
  detection (duplicate, out-of-period, unknown payee, amount outlier,
  missing memo); reconciliation output.
- `skills/bookkeeper/fixtures/clean-monthly-batch.json`: deterministic
  inputs and expected outputs for the sealed case.
- `skills/bookkeeper/fixtures/ambiguous-batch.json`: deterministic inputs
  and expected outputs for the needs-review case.
- `skills/bookkeeper/CHANGELOG.md`: 0.1.0 release notes.

## Validation (run locally)

- `node --check skills/bookkeeper/run.mjs`: ok
- `runx harness ./skills/bookkeeper --json`: status=passed,
  case_count=2, assertion_error_count=0,
  receipt_ids=[sha256:661ec8f3..., sha256:fe65737d...]
- `runx doctor ./skills/bookkeeper --json`: 0 errors, 0 warnings
- `runx skill inspect ./skills/bookkeeper --json`: status=ok,
  version=0.1.0

## Acceptance criteria coverage

- runx CLI 0.6.14+ (locally 0.7.1): yes
- package name is exactly `bookkeeper`: yes
- harness has one sealed case + one refused case: yes
  (2/2 passed, 0 assertion errors)
- typed inputs: transactions[], chart_of_accounts, prior_period: yes
- typed output: categorized[], anomalies[], reconciliation: yes
- read-only artifact; no ledger mutation: yes
- every categorized line binds to a chart account: yes
- `runx skill <owner>/bookkeeper@<version> --json` dogfood: pre-staged,
  post-publish path documented in the diff
- evidence_json observations: pre-staged under the package with runx
  version, package name, version, harness case names, receipt id

## Risk surface

- no self-funding, no wallet signature, no social engagement, no private
  login, no hardware, no security testing, no third-party completion.

Refs: Frantic #89.