### PR TITLE
feat(skills): add governed webapp testing overlay

### DIFF
--- a/skills/overlay-open-skill-1/SKILL.md
+++ b/skills/overlay-open-skill-1/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: overlay-open-skill-1
+description: Govern an operational browser-testing skill from the open skill ecosystem under an immutable sha256 pin, one exact allowed origin, a bounded browser-action budget, an explicit tool set, and a native approval gate before any session is admitted.
+runx:
+  category: governance
+---
+
+# Governed browser-testing overlay
+
+Use a practical browser-testing skill from the open skill ecosystem without
+silently trusting future edits or granting an unbounded browser session.
+
+This package never copies or edits the wrapped instructions. `X.yaml` points to
+one immutable public file and pins its exact response bytes by sha256. Every run
+validates that pin, consumes caller-supplied origin and action limits, records a
+native approval decision, and seals a final governance packet. A downstream host
+may invoke the wrapped instructions only after the packet says `ready`.
+
+## Governance the bare skill lacks
+
+The upstream workflow explains how to start local servers, drive a browser,
+inspect UI state, capture screenshots, and review console logs. It does not
+itself constrain which origin may be reached, how many browser actions may be
+performed, or whether an operator approved the session. This overlay adds all
+three controls:
+
+1. **Exact-origin attenuation.** The caller supplies one URL origin such as
+   `http://127.0.0.1:4173`. Paths, queries, fragments, wildcard hosts, and
+   additional origins are rejected.
+2. **Browser-action budget.** `max_browser_actions` is a positive integer from
+   1 through 100 and is carried into the final packet for the host to enforce.
+3. **Native approval gate.** runx records approval of the concrete origin, mode,
+   and action budget before the overlay emits a ready decision.
+4. **Receipt-emitting admission.** The digest verdict, attenuation, tool set,
+   approval, and decision are sealed by the governed run.
+
+## Authority boundary
+
+- The wrapped instructions are admitted only when their exact sha256 matches
+  the reviewed pin in `X.yaml`.
+- The browser may navigate only within `allowed_origin`.
+- `interaction_mode=read_only` excludes `browser.act` from the effective tool
+  set; `interactive` includes it only after native approval.
+- `max_browser_actions` caps browser interactions for the admitted session.
+- The declared tool superset is explicit: `fs.read`, `process.spawn`,
+  `browser.navigate`, `browser.inspect`, `browser.screenshot`,
+  `browser.console`, and `browser.act`.
+- Filesystem writes, arbitrary shell execution, credential reads, external
+  network origins, and subagent spawning are not admitted.
+
+The most restrictive authority wins. A host or graph may narrow this envelope;
+the overlay never widens it. The final packet is an admission decision, not a
+new capability grant.
+
+## Procedure
+
+1. Resolve the immutable `runx.overlay.wraps.path` from `X.yaml`.
+2. Compute sha256 over the exact response bytes without normalizing line
+   endings or transforming text.
+3. Supply the prefixed digest, one exact origin, interaction mode, and action
+   budget to the `governed` runner.
+4. Review and approve the native gate for that concrete packet.
+5. Continue only when `governance_decision.decision` is `ready`.
+6. Enforce `effective_allowed_tools`, `allowed_origin`, and
+   `max_browser_actions` when the downstream host runs the wrapped workflow.
+
+## Refusals
+
+- `runx.overlay.digest.required`: no digest was supplied.
+- `runx.overlay.digest.stale`: the digest is malformed or differs from the pin;
+  changed instructions are refused before approval.
+- `runx.overlay.param.invalid`: origin, action budget, or interaction mode is
+  missing or malformed.
+- `runx.overlay.approval.missing`: a final decision was attempted without the
+  native approval gate.
+
+## Output
+
+The final `governance_decision` uses schema `runx.skill_overlay.v1` and includes:
+
+- immutable wrapped path and digest;
+- exact origin, interaction mode, and action budget;
+- effective scopes and tools;
+- native approval gate and approved state;
+- admission digest and `ready` decision.
+
+## Harness
+
+- `pinned-approved-seals` proves the immutable, attenuated, approved path seals.
+- `digest-stale-refuses` proves changed instructions produce
+  `runx.overlay.digest.stale` and seal a policy-denied refusal before approval.
+
+## Install, run, verify
+
+```bash
+runx add <owner>/overlay-open-skill-1@<version> --registry https://api.runx.ai
+runx skill <owner>/overlay-open-skill-1@<version> governed \
+  -i resolved_digest=sha256:<reviewed-digest> \
+  -i allowed_origin=http://127.0.0.1:4173 \
+  -i max_browser_actions=12 \
+  -i interaction_mode=interactive \
+  --json -R ./receipts
+runx verify --receipt <receipt.json> --json
+```
+
+The immutable upstream repository, file, commit, license, and digest are named
+in `fixtures/evidence/upstream-provenance.json` so reviewers can recompute the
+pin without copying the upstream instructions into this package.

--- a/skills/overlay-open-skill-1/X.yaml
+++ b/skills/overlay-open-skill-1/X.yaml
@@ -1,0 +1,168 @@
+skill: overlay-open-skill-1
+version: "0.1.0"
+
+runx:
+  overlay:
+    wraps:
+      path: https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/webapp-testing/SKILL.md
+      version: sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2
+    pinned_digest: sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: pinned-approved-seals
+      runner: governed
+      inputs:
+        objective: Verify the local checkout flow under an exact origin and bounded browser-action budget.
+        resolved_digest: sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2
+        allowed_origin: http://127.0.0.1:4173
+        max_browser_actions: 12
+        interaction_mode: interactive
+      caller:
+        approvals:
+          overlay-open-skill-1.browser-session.approval: true
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+          reason_code: graph_closed
+
+    - name: digest-stale-refuses
+      runner: governed
+      inputs:
+        objective: Refuse changed browser-testing instructions before opening a browser session.
+        resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+        allowed_origin: http://127.0.0.1:4173
+        max_browser_actions: 1
+        interaction_mode: read_only
+      caller:
+        approvals:
+          overlay-open-skill-1.browser-session.approval: true
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+          reason_code: graph_blocked
+
+runners:
+  governed:
+    default: true
+    type: graph
+    inputs:
+      objective:
+        type: string
+        required: false
+        description: Browser-testing objective recorded in the sealed governance decision.
+      resolved_digest:
+        type: string
+        required: true
+        description: Recomputed sha256 digest of the immutable wrapped SKILL.md bytes.
+      allowed_origin:
+        type: string
+        required: true
+        description: One exact HTTP(S) origin the admitted browser session may reach.
+      max_browser_actions:
+        type: number
+        required: true
+        description: Positive upper bound on browser actions in the admitted session.
+      interaction_mode:
+        type: string
+        required: false
+        default: read_only
+        description: Either read_only or interactive; interactive admits browser.act after approval.
+    runx:
+      scopes:
+        - fs.read
+        - process.spawn
+        - browser.navigate
+        - browser.inspect
+        - browser.screenshot
+        - browser.console
+        - browser.act
+      allowed_tools:
+        - fs.read
+        - process.spawn
+        - browser.navigate
+        - browser.inspect
+        - browser.screenshot
+        - browser.console
+        - browser.act
+    graph:
+      name: overlay-open-skill-1
+      steps:
+        - id: admit
+          label: validate immutable instructions and caller attenuation
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - graph/admit/run.mjs
+            timeout_seconds: 30
+            outputs:
+              admission_check: object
+            sandbox:
+              profile: read-only
+              cwd_policy: skill-directory
+              network: false
+              writable_paths: []
+              require_enforcement: false
+          artifacts:
+            named_emits:
+              admission_check: admission_check
+
+        - id: approve-browser-session
+          label: approve the attenuated browser session
+          run:
+            type: approval
+          inputs:
+            gate_id: overlay-open-skill-1.browser-session.approval
+            reason: Approve the exact origin, interaction mode, and browser-action budget before the wrapped instructions are admitted.
+          context:
+            admission_check: admit.admission_check.data
+          artifacts:
+            wrap_as: approval_decision
+            packet: runx.approval.decision.v1
+
+        - id: finalize
+          label: seal the approved overlay governance decision
+          context:
+            admission_check: admit.admission_check.data
+            approval_decision: approve-browser-session.approval_decision.data
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - graph/finalize/run.mjs
+            timeout_seconds: 30
+            outputs:
+              governance_decision: object
+            sandbox:
+              profile: read-only
+              cwd_policy: skill-directory
+              network: false
+              writable_paths: []
+              require_enforcement: false
+          artifacts:
+            named_emits:
+              governance_decision: governance_decision
+      policy:
+        guards:
+          - step: approve-browser-session
+            field: admit.admission_check.data.decision
+            equals: ready_for_approval
+          - step: finalize
+            field: admit.admission_check.data.decision
+            equals: ready_for_approval
+          - step: finalize
+            field: approve-browser-session.approval_decision.data.approved
+            equals: true

--- a/skills/overlay-open-skill-1/fixtures/evidence/upstream-provenance.json
+++ b/skills/overlay-open-skill-1/fixtures/evidence/upstream-provenance.json
@@ -1,0 +1,17 @@
+{
+  "schema": "runx.skill_overlay.upstream_provenance.v1",
+  "upstream_skill": "webapp-testing",
+  "repository": "https://github.com/anthropics/skills",
+  "path": "skills/webapp-testing/SKILL.md",
+  "pinned_commit": "9d2f1ae187231d8199c64b5b762e1bdf2244733d",
+  "immutable_url": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/webapp-testing/SKILL.md",
+  "digest": "sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2",
+  "license": "Apache-2.0",
+  "license_url": "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/webapp-testing/LICENSE.txt",
+  "actively_maintained_evidence": {
+    "default_branch": "main",
+    "repository_pushed_at": "2026-07-13T22:31:37Z"
+  },
+  "wrapped_content_copied": false,
+  "digest_method": "sha256 over exact immutable_url response bytes"
+}

--- a/skills/overlay-open-skill-1/graph/admit/run.mjs
+++ b/skills/overlay-open-skill-1/graph/admit/run.mjs
@@ -1,0 +1,133 @@
+const WRAPS_PATH =
+  "https://raw.githubusercontent.com/anthropics/skills/9d2f1ae187231d8199c64b5b762e1bdf2244733d/skills/webapp-testing/SKILL.md";
+const PINNED_DIGEST =
+  "sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2";
+const DECLARED_SCOPES = Object.freeze([
+  "fs.read",
+  "process.spawn",
+  "browser.navigate",
+  "browser.inspect",
+  "browser.screenshot",
+  "browser.console",
+  "browser.act",
+]);
+const READ_ONLY_TOOLS = Object.freeze([
+  "fs.read",
+  "process.spawn",
+  "browser.navigate",
+  "browser.inspect",
+  "browser.screenshot",
+  "browser.console",
+]);
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function exactOrigin(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value.trim());
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return null;
+    }
+    if (
+      parsed.username
+      || parsed.password
+      || parsed.pathname !== "/"
+      || parsed.search
+      || parsed.hash
+    ) {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+function refuse(packet, id, message) {
+  const admissionCheck = {
+    ...packet,
+    decision: "refused",
+    diagnostics: [{ id, severity: "error", message }],
+  };
+  process.stdout.write(`${JSON.stringify({ admission_check: admissionCheck })}\n`);
+  process.exit(0);
+}
+
+const inputs = readInputs();
+const objective = String(
+  inputs.objective || "Test one local web application under governed browser boundaries.",
+).trim();
+const resolvedDigest = typeof inputs.resolved_digest === "string"
+  ? inputs.resolved_digest.trim().toLowerCase()
+  : null;
+const allowedOrigin = exactOrigin(inputs.allowed_origin);
+const actionBudget = Number(inputs.max_browser_actions);
+const interactionMode = String(inputs.interaction_mode || "read_only").trim().toLowerCase();
+const effectiveAllowedTools = interactionMode === "interactive"
+  ? [...READ_ONLY_TOOLS, "browser.act"]
+  : [...READ_ONLY_TOOLS];
+
+const packet = {
+  schema: "runx.skill_overlay.admission.v1",
+  objective,
+  wraps: { path: WRAPS_PATH, digest: PINNED_DIGEST },
+  resolved_digest: resolvedDigest,
+  governance: {
+    allowed_origin: allowedOrigin,
+    max_browser_actions: Number.isInteger(actionBudget) ? actionBudget : null,
+    interaction_mode: interactionMode,
+    declared_scopes: [...DECLARED_SCOPES],
+    effective_allowed_tools: effectiveAllowedTools,
+    denied_tools: ["fs.write", "shell.exec", "credential.read", "network.external", "task.spawn"],
+  },
+};
+
+if (resolvedDigest === null) {
+  refuse(
+    packet,
+    "runx.overlay.digest.required",
+    "Resolve the immutable wrapped SKILL.md and provide its recomputed sha256 digest.",
+  );
+}
+if (!/^sha256:[0-9a-f]{64}$/.test(resolvedDigest) || resolvedDigest !== PINNED_DIGEST) {
+  refuse(
+    packet,
+    "runx.overlay.digest.stale",
+    "Wrapped SKILL.md bytes do not match the reviewed pin; changed instructions were not admitted.",
+  );
+}
+if (allowedOrigin === null) {
+  refuse(
+    packet,
+    "runx.overlay.param.invalid",
+    "allowed_origin must be one exact HTTP(S) origin without credentials, path, query, or fragment.",
+  );
+}
+if (!Number.isInteger(actionBudget) || actionBudget < 1 || actionBudget > 100) {
+  refuse(
+    packet,
+    "runx.overlay.param.invalid",
+    "max_browser_actions must be an integer from 1 through 100.",
+  );
+}
+if (!["read_only", "interactive"].includes(interactionMode)) {
+  refuse(
+    packet,
+    "runx.overlay.param.invalid",
+    "interaction_mode must be read_only or interactive.",
+  );
+}
+
+process.stdout.write(`${JSON.stringify({
+  admission_check: {
+    ...packet,
+    decision: "ready_for_approval",
+    diagnostics: [],
+  },
+})}\n`);

--- a/skills/overlay-open-skill-1/graph/finalize/run.mjs
+++ b/skills/overlay-open-skill-1/graph/finalize/run.mjs
@@ -1,0 +1,48 @@
+import { createHash } from "node:crypto";
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function fail(id, message) {
+  process.stderr.write(`${id}: ${message}\n`);
+  process.exit(78);
+}
+
+const {
+  admission_check: admissionCheck,
+  approval_decision: approvalDecision,
+} = readInputs();
+
+if (!admissionCheck || admissionCheck.decision !== "ready_for_approval") {
+  fail(
+    "runx.overlay.admission.invalid",
+    "A successful immutable admission check is required before finalization.",
+  );
+}
+if (!approvalDecision || approvalDecision.approved !== true) {
+  fail(
+    "runx.overlay.approval.missing",
+    "The native browser-session approval gate must be approved before finalization.",
+  );
+}
+
+const admissionDigest = `sha256:${createHash("sha256")
+  .update(JSON.stringify(admissionCheck))
+  .digest("hex")}`;
+const governanceDecision = {
+  schema: "runx.skill_overlay.v1",
+  objective: admissionCheck.objective,
+  wraps: admissionCheck.wraps,
+  resolved_digest: admissionCheck.resolved_digest,
+  governance: admissionCheck.governance,
+  approval: {
+    gate_id: "overlay-open-skill-1.browser-session.approval",
+    approved: true,
+  },
+  admission_digest: admissionDigest,
+  decision: "ready",
+  diagnostics: [],
+};
+
+process.stdout.write(`${JSON.stringify({ governance_decision: governanceDecision })}\n`);

--- a/skills/overlay-open-skill-1/references/harness-evidence.md
+++ b/skills/overlay-open-skill-1/references/harness-evidence.md
@@ -1,0 +1,63 @@
+# Harness evidence
+
+Validated on 2026-07-14 from the repository root.
+
+## Contract inspection
+
+`runx skill inspect skills/overlay-open-skill-1 governed --json` returned
+`status: ok`, selected the `governed` graph runner, and exposed all five declared
+inputs.
+
+The immutable upstream response returned HTTP 200 with 3,913 bytes. SHA-256 over
+those exact bytes recomputed to:
+
+`sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2`
+
+## Inline harness
+
+The inline harness ran both graph cases and returned:
+
+```json
+{
+  "status": "passed",
+  "case_count": 2,
+  "assertion_error_count": 0,
+  "case_names": [
+    "pinned-approved-seals",
+    "digest-stale-refuses"
+  ],
+  "graph_case_count": 2
+}
+```
+
+The approved case sealed `closed`. The stale-digest case emitted
+`runx.overlay.digest.stale`, was stopped by the native graph guard before the
+approval gate, and sealed `blocked` as required by the policy-denied
+expectation.
+
+The run produced two root receipts and four step receipts. All six receipts
+passed `runx verify` against the ephemeral public verification key used for the
+test. No signing seed or private credential was persisted.
+
+On Windows, the released CLI currently attempts POSIX-style directory `fsync`
+after writing receipts. The harness was therefore executed with a locally built
+copy of the same repository revision whose Windows-only directory-sync call was
+disabled; the patch did not change parser, graph, policy, harness, receipt, or
+package behavior and was reverted immediately after compilation. Hosted
+registry verification remains the authoritative cross-platform check for the
+published package.
+
+## Dogfood run
+
+A real governed invocation paused at
+`overlay-open-skill-1.browser-session.approval`, consumed an affirmative native
+approval, and then sealed `closed` with reason code `graph_closed`.
+
+- Receipt: `sha256:b40bc4ab5c11c12f9f99b7a6ea9993273cb03fd35eb750a8b1c2f878ad34afa3`
+- Verification: valid
+- Allowed origin: `http://127.0.0.1:4173`
+- Interaction mode: `interactive`
+- Browser-action budget: `12`
+
+The verification key was supplied only to the local verifier. The ephemeral
+private signing seed was cleared and was not written to the repository.


### PR DESCRIPTION
## What changed

- adds overlay-open-skill-1, an immutable overlay over the open webapp-testing skill
- consumes one exact allowed origin, a bounded browser-action budget, and an interaction mode
- requires a native runx approval gate before sealing a ready governance decision
- records explicit scopes, allowed tools, structured refusals, immutable provenance, and review evidence

## Why

A digest pin alone does not add operational governance. This package adds caller-consumed attenuation and a receipt-emitting approval decision while leaving the upstream instructions unmodified.

## Validation

- runx skill inspect: status ok
- inline harness: 2/2 passed (pinned-approved-seals, digest-stale-refuses)
- six local receipts verified
- dogfood run paused at the native approval gate, resumed with approval, sealed graph_closed, and verified valid
- immutable upstream bytes recomputed to sha256:51b7349e77ec63b7744a6f63647e7566a0b4d2e301121cc10e8c2113af6556a2
- deterministic seven-angle review passed
## Published verification

- Immutable package: https://runx.ai/x/ivanchitorjr/overlay-open-skill-1@sha-ac99e8b0a8db
- Hosted harness: 2/2 green with two linked sealed receipts
- Clean install: passed for ivanchitorjr/overlay-open-skill-1@sha-ac99e8b0a8db
- Post-publish dogfood: native approval pause, graph_closed seal, receipt verification valid
- Immutable evidence: https://github.com/IvanchitorJR/overlay-open-skill-1-evidence/tree/4c62b9b840406ca680930f713af03fbe4a57728d