### PR TITLE
feat(skills): add governed open-skill overlay

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -221,6 +221,11 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
         digest: "e19bbe8dc5f3bf732dc265a1808819587e67759fdf3014d89bc9bf6629400b18",
     },
     OfficialSkillLockEntry {
+        skill_id: "runx/overlay-open-skill-1",
+        version: "sha-3a93e1ffea7c",
+        digest: "871bf2192651d0dbc45eafd93a2ad97054c6299139a9c2f00eb4a2630618a327",
+    },
+    OfficialSkillLockEntry {
         skill_id: "runx/policy-author",
         version: "sha-a1f056d7c7f7",
         digest: "b3bbcbda2711d78c59c572d99206c3116347e9751506301ca40a52c75e85bc84",

--- a/packages/cli/src/official-skills.lock.json
+++ b/packages/cli/src/official-skills.lock.json
@@ -294,6 +294,13 @@
     "catalog_role": "canonical"
   },
   {
+    "skill_id": "runx/overlay-open-skill-1",
+    "version": "sha-3a93e1ffea7c",
+    "digest": "871bf2192651d0dbc45eafd93a2ad97054c6299139a9c2f00eb4a2630618a327",
+    "catalog_visibility": "public",
+    "catalog_role": "context"
+  },
+  {
     "skill_id": "runx/policy-author",
     "version": "sha-a1f056d7c7f7",
     "digest": "b3bbcbda2711d78c59c572d99206c3116347e9751506301ca40a52c75e85bc84",

--- a/skills/overlay-open-skill-1/SKILL.md
+++ b/skills/overlay-open-skill-1/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: overlay-open-skill-1
+description: Govern an immutable open-ecosystem worktree skill with a pinned digest, exact one-worktree attenuation, an operator approval gate, and a receipt-bound single-effect authorization.
+---
+
+# Governed Worktree Creation Overlay
+
+Use this overlay when an open-ecosystem skill proposes creating a Git worktree
+and the operator needs more than trusted prose. The overlay pins the borrowed
+instructions, narrows one invocation to one repository and one worktree, asks
+for approval over the normalized plan, and records the approved decision in a
+sealed runx receipt.
+
+The wrapped `SKILL.md` is referenced, never copied or edited. A trusted resolver
+must compute `resolved_digest` from those public bytes. If that supplied digest
+no longer matches the pin, the graph refuses before the approval step.
+
+## Added governance
+
+The bare upstream instructions explain a good worktree workflow. This overlay
+adds authority that a caller can actually consume:
+
+1. `admit` validates the immutable digest and normalizes an exact worktree
+   creation plan.
+2. The plan is attenuated to one repository root, one `.worktrees` root, one
+   direct child path, one branch, one start commit, and one fixed argument
+   vector.
+3. `approve-create` is a native runx approval gate over that normalized plan.
+4. `record-act` recomputes the native approval decision key over the exact plan,
+   consumes that approval artifact, and emits a
+   `runx.skill_overlay.worktree_act.v1` single-effect authorization. The graph
+   receipt records the pin, attenuation, gate, decision, and closure.
+
+This package deliberately does not execute the authorization and does not claim
+that a worktree exists. A host may hand it to an existing Git execution surface,
+but the host must atomically consume its `idempotency_key` in an idempotency
+registry, execute only the exact recorded `argv`, and bind the resulting effect
+receipt and readback to that key.
+
+## Inputs
+
+- `objective`: why the isolated workspace is needed.
+- `resolved_digest`: sha256 recomputed by a trusted resolver from the immutable
+  public wrapped `SKILL.md` bytes.
+- `repo_root`: absolute root of the normal Git checkout.
+- `worktree_root`: the exact absolute `<repo_root>/.worktrees` directory.
+- `worktree_path`: one direct child of `worktree_root` for the new checkout.
+- `branch_name`: a bounded feature, fix, chore, docs, test, refactor, or codex
+  branch name.
+- `start_commit`: an immutable 40- or 64-hex Git object id.
+- `mechanism`: must be `git_fallback` for this package version.
+- `max_worktrees`: must be exactly `1`.
+
+## Exact authority
+
+When admitted, the only releasable command is represented as an argument
+vector, never a caller-provided shell string:
+
+```text
+git -C <repo_root> worktree add --no-checkout -b <branch_name> <worktree_path> <start_commit>
+```
+
+The authorization records the host tools `git.status`, `git.diff_name_only`,
+and `shell.exec` and records denials for commit, push, worktree removal,
+arbitrary filesystem writes, network access, credential access, `.gitignore`
+edits, command chaining, redirection, and more than one worktree. These are
+ticket terms for the consuming host; this non-executing graph does not itself
+enforce host-side tool dispatch.
+
+The runner-level `runx.scopes` publishes the package's non-empty required-scope
+metadata. Runtime authority remains narrowed at the executable graph steps,
+where `scopes` and `allowed_tools` are declared again for the work performed by
+each step.
+
+Admission rejects UNC and device namespaces. Its path containment check is
+lexical by design, so the consuming host has a mandatory physical-path
+preflight before execution: resolve canonical paths, confirm `repo_root` is a
+local normal Git checkout, confirm canonical `.worktrees` remains inside that
+canonical repository, and reject any symlink or junction in the worktree root,
+target, or their path components.
+
+## Refusal conditions
+
+Refuse before approval when any of these is true:
+
+- the resolved digest is missing, malformed, or differs from the pin;
+- a path is relative, escapes its parent, is not a direct child, or does not
+  use the exact `.worktrees` root;
+- a path uses a UNC or device namespace;
+- the branch is unscoped, contains traversal/reflog syntax, or ends in `.lock`;
+- the start commit is not an immutable full object id;
+- the requested mechanism is not the fixed Git fallback;
+- `max_worktrees` is not exactly one.
+
+Digest drift raises `runx.overlay.digest.stale`. Boundary failures use a
+specific `runx.overlay.attenuation.*` diagnostic. A refused admission never
+reaches the approval or ticket step.
+
+## Operator procedure
+
+1. Resolve the immutable wrapped source through a trusted resolver, recompute
+   its sha256, and retain public digest evidence.
+2. Provide the bounded inputs above and run this package.
+3. Review the normalized plan shown by the approval gate.
+4. Approve only when the repository, worktree path, branch, start commit, and
+   exact argv are correct.
+5. Inspect the sealed graph receipt and the emitted single-effect authorization.
+6. If a host consumes it, first complete the canonical local-path and
+   symlink/junction preflight, atomically register the idempotency key, verify
+   the effect with `git worktree list --porcelain`, and retain that effect
+   receipt alongside this decision receipt.
+
+## What the receipt proves
+
+The receipt proves which immutable instructions were admitted, which authority
+was requested and narrowed, which exact command was proposed, whether the
+operator approved that exact plan, and which single-effect authorization was
+issued. It does not prove host-side idempotency consumption or that a worktree
+exists; execution and readback require a separate effect receipt.

--- a/skills/overlay-open-skill-1/X.yaml
+++ b/skills/overlay-open-skill-1/X.yaml
@@ -1,0 +1,281 @@
+skill: overlay-open-skill-1
+version: "1.0.0"
+
+runx:
+  overlay:
+    wraps:
+      path: https://raw.githubusercontent.com/obra/superpowers/d884ae04edebef577e82ff7c4e143debd0bbec99/skills/using-git-worktrees/SKILL.md
+      version: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+    pinned_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: pinned-approved-one-worktree-seals
+      runner: default
+      inputs:
+        objective: Create one isolated worktree for a bounded feature change.
+        resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+        repo_root: /workspace/demo-repo
+        worktree_root: /workspace/demo-repo/.worktrees
+        worktree_path: /workspace/demo-repo/.worktrees/feature-safe-overlay
+        branch_name: feature/safe-overlay
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      caller:
+        approvals:
+          overlay-open-skill-1.worktree-create.approval: true
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: digest-stale-refuses
+      runner: default
+      inputs:
+        objective: Refuse changed worktree instructions before approval.
+        resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+        repo_root: /workspace/demo-repo
+        worktree_root: /workspace/demo-repo/.worktrees
+        worktree_path: /workspace/demo-repo/.worktrees/feature-stale
+        branch_name: feature/stale
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: path-escape-refuses
+      runner: default
+      inputs:
+        objective: Refuse a worktree path outside the attenuated root.
+        resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+        repo_root: /workspace/demo-repo
+        worktree_root: /workspace/demo-repo/.worktrees
+        worktree_path: /workspace/escaped-worktree
+        branch_name: feature/escape
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: approval-denied-refuses
+      runner: default
+      inputs:
+        objective: Refuse ticket emission when the operator denies the exact plan.
+        resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+        repo_root: /workspace/demo-repo
+        worktree_root: /workspace/demo-repo/.worktrees
+        worktree_path: /workspace/demo-repo/.worktrees/feature-denied
+        branch_name: feature/denied
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      caller:
+        approvals:
+          overlay-open-skill-1.worktree-create.approval: false
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: nested-worktree-root-refuses
+      runner: default
+      inputs:
+        objective: Refuse a nested directory merely named .worktrees.
+        resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+        repo_root: /workspace/demo-repo
+        worktree_root: /workspace/demo-repo/nested/.worktrees
+        worktree_path: /workspace/demo-repo/nested/.worktrees/feature-nested
+        branch_name: feature/nested
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: branch-lock-segment-refuses
+      runner: default
+      inputs:
+        objective: Refuse unsafe Git lock-like branch segments.
+        resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+        repo_root: /workspace/demo-repo
+        worktree_root: /workspace/demo-repo/.worktrees
+        worktree_path: /workspace/demo-repo/.worktrees/feature-lock
+        branch_name: feature/release.lock/child
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: unc-path-refuses
+      runner: default
+      inputs:
+        objective: Refuse a network namespace that contradicts local-only authority.
+        resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+        repo_root: '\\server\share\repo'
+        worktree_root: '\\server\share\repo\.worktrees'
+        worktree_path: '\\server\share\repo\.worktrees\feature-unc'
+        branch_name: feature/unc
+        start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        mechanism: git_fallback
+        max_worktrees: 1
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+runners:
+  default:
+    default: true
+    type: graph
+    runx:
+      scopes:
+        - repo.read
+        - repo.worktree.create
+      allowed_tools:
+        - git.status
+        - git.diff_name_only
+        - shell.exec
+    inputs:
+      objective:
+        type: string
+        required: true
+        description: Operator intent for the isolated worktree.
+      resolved_digest:
+        type: string
+        required: true
+        description: Sha256 recomputed by a trusted resolver from the immutable public wrapped SKILL.md bytes.
+      repo_root:
+        type: string
+        required: true
+        description: Absolute root of the normal Git checkout.
+      worktree_root:
+        type: string
+        required: true
+        description: Exact absolute <repo_root>/.worktrees directory.
+      worktree_path:
+        type: string
+        required: true
+        description: Absolute direct-child path for the new worktree.
+      branch_name:
+        type: string
+        required: true
+        description: Bounded feature/fix/chore/docs/test/refactor/codex branch.
+      start_commit:
+        type: string
+        required: true
+        description: Immutable 40- or 64-hex Git object id.
+      mechanism:
+        type: string
+        required: true
+        description: Must be git_fallback in this package version.
+      max_worktrees:
+        type: number
+        required: true
+        description: Must be exactly one.
+    graph:
+      name: overlay-open-skill-1-worktree-ticket
+      steps:
+        - id: admit
+          label: validate immutable pin and attenuate one worktree plan
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - preflight.mjs
+            outputs:
+              admission: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools:
+            - git.status
+            - git.diff_name_only
+          scopes:
+            - repo.read
+          artifacts:
+            named_emits:
+              admission: admission
+
+        - id: approve-create
+          label: approve the exact one-worktree execution plan
+          run:
+            type: approval
+          inputs:
+            gate_id: overlay-open-skill-1.worktree-create.approval
+            reason: Approve the exact repository, path, branch, start commit, and argv before issuing a receipt-bound single-effect worktree authorization.
+          context:
+            admission: admit.admission.data
+          artifacts:
+            wrap_as: approval_decision
+            packet: runx.approval.decision.v1
+
+        - id: record-act
+          label: bind approval and seal a single-effect worktree authorization
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - seal-ticket.mjs
+            outputs:
+              worktree_act: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools:
+            - git.status
+            - git.diff_name_only
+            - shell.exec
+          scopes:
+            - repo.read
+            - repo.worktree.create
+          context:
+            admission: admit.admission.data
+            approval: approve-create.approval_decision.data
+          artifacts:
+            named_emits:
+              worktree_act: worktree_act
+
+      policy:
+        guards:
+          - step: approve-create
+            field: admit.admission.data.decision
+            equals: ready_for_approval
+          - step: record-act
+            field: approve-create.approval_decision.data.approved
+            equals: true

--- a/skills/overlay-open-skill-1/evidence/local-harness.json
+++ b/skills/overlay-open-skill-1/evidence/local-harness.json
@@ -1,0 +1,82 @@
+{
+  "schema": "runx.overlay.local_harness_evidence.v1",
+  "captured_at": "2026-07-15T01:01:16.092Z",
+  "environment": {
+    "os": "Linux under WSL2",
+    "runx_version": "runx-cli 0.7.1"
+  },
+  "command": "runx harness ./skills/overlay-open-skill-1 --json",
+  "status": "passed",
+  "case_count": 7,
+  "assertion_error_count": 0,
+  "graph_case_count": 7,
+  "local_publish_rehearsal": {
+    "status": "success",
+    "mode": "local-filesystem-registry",
+    "owner": "EthanYoQ",
+    "skill_id": "ethanyoq/overlay-open-skill-1",
+    "required_scopes": [
+      "repo.read",
+      "repo.worktree.create"
+    ]
+  },
+  "clean_install_rehearsal": {
+    "status": "sealed",
+    "mode": "local-filesystem-registry",
+    "initial_status": "needs_agent",
+    "approval_gate": "overlay-open-skill-1.worktree-create.approval",
+    "resume_status": "sealed",
+    "run_id": "run_default_f0a4fe928324",
+    "receipt_id": "sha256:606e007823cb35bd39034a5a80ee43ffe5d540d73891b6627b30d4826eb02b98",
+    "verification": {
+      "valid": true,
+      "signature_mode": "local-development",
+      "receipt_count": 4,
+      "findings": []
+    }
+  },
+  "cases": [
+    {
+      "name": "pinned-approved-one-worktree-seals",
+      "expected_status": "sealed",
+      "receipt_id": "sha256:e26289fb2b0c41439a1603673055bf32c240d1ef82954bbbe4cce54137169825"
+    },
+    {
+      "name": "digest-stale-refuses",
+      "expected_status": "policy_denied",
+      "receipt_id": "sha256:73b783459566886c249a00e59297cb3f7743965a759137c93b0150ace765ab17"
+    },
+    {
+      "name": "path-escape-refuses",
+      "expected_status": "policy_denied",
+      "receipt_id": "sha256:5fc9f397e37f2d182a1979442771f1eabb33fbd08cf7818598c804a7542405f1"
+    },
+    {
+      "name": "approval-denied-refuses",
+      "expected_status": "policy_denied",
+      "receipt_id": "sha256:fcb811eaede5e817a91ddc62ef1caa5e16608b4fdcd360085f666000561e47b4"
+    },
+    {
+      "name": "nested-worktree-root-refuses",
+      "expected_status": "policy_denied",
+      "receipt_id": "sha256:24c810bb26ee39e386b16c2241aa29f05ba42b24379ce103c133c07f78a01cef"
+    },
+    {
+      "name": "branch-lock-segment-refuses",
+      "expected_status": "policy_denied",
+      "receipt_id": "sha256:a5770a2270fb5a8a1a7d619e95d161f21cbb8efa14cb181cff129b56498de7e1"
+    },
+    {
+      "name": "unc-path-refuses",
+      "expected_status": "policy_denied",
+      "receipt_id": "sha256:b89058071d7b6096bc45325ba051d38e9c0c47d17804bec51b49fb0674b0ac23"
+    }
+  ],
+  "notes": [
+    "The positive case emits a receipt-bound single-effect authorization after the native approval key is recomputed and matched.",
+    "A clean installation was run through the native approval pause and resume flow, then its four-receipt tree verified without findings.",
+    "Dynamic registry version and package digests are intentionally excluded from this in-package file because embedding them would change the package digest; final published identifiers belong in external delivery evidence.",
+    "Refusal cases seal blocked graph receipts before any authorization is issued.",
+    "The package does not claim that the Git worktree command was executed."
+  ]
+}

--- a/skills/overlay-open-skill-1/fixtures/README.md
+++ b/skills/overlay-open-skill-1/fixtures/README.md
@@ -1,0 +1,12 @@
+# Fixture replay
+
+`pinned-approved-one-worktree-seals.yaml` is the portable standalone success
+fixture. The authoritative refusal fixtures live in `X.yaml` under
+`harness.cases`, because Runx 0.7.1 represents graph guard stops as sealed
+`policy_denied` results in the inline package harness.
+
+Run the complete contract with:
+
+```text
+runx harness ./skills/overlay-open-skill-1 --json
+```

--- a/skills/overlay-open-skill-1/fixtures/pinned-approved-one-worktree-seals.yaml
+++ b/skills/overlay-open-skill-1/fixtures/pinned-approved-one-worktree-seals.yaml
@@ -1,0 +1,26 @@
+name: pinned-approved-one-worktree-seals
+kind: skill
+target: ..
+runner: default
+inputs:
+  objective: Create one isolated worktree for a bounded feature change.
+  resolved_digest: sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794
+  repo_root: /workspace/demo-repo
+  worktree_root: /workspace/demo-repo/.worktrees
+  worktree_path: /workspace/demo-repo/.worktrees/feature-safe-overlay
+  branch_name: feature/safe-overlay
+  start_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  mechanism: git_fallback
+  max_worktrees: 1
+caller:
+  approvals:
+    overlay-open-skill-1.worktree-create.approval: true
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  source: overlay-open-skill-1
+  contract: approved-one-worktree

--- a/skills/overlay-open-skill-1/preflight.mjs
+++ b/skills/overlay-open-skill-1/preflight.mjs
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+const WRAPS_PATH =
+  "https://raw.githubusercontent.com/obra/superpowers/d884ae04edebef577e82ff7c4e143debd0bbec99/skills/using-git-worktrees/SKILL.md";
+const PINNED_DIGEST =
+  "sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794";
+const GATE_ID = "overlay-open-skill-1.worktree-create.approval";
+const ALLOWED_TOOLS = Object.freeze([
+  "git.status",
+  "git.diff_name_only",
+  "shell.exec",
+]);
+const DENIED_CAPABILITIES = Object.freeze([
+  "git.commit",
+  "git.push",
+  "git.worktree.remove",
+  "filesystem.write.outside_worktree",
+  "network.access",
+  "credentials.read",
+  "gitignore.edit",
+  "shell.chaining",
+  "shell.redirection",
+  "multiple_worktrees",
+]);
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function pathApi(value) {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\")
+    ? path.win32
+    : path.posix;
+}
+
+function normalizeAbsolute(value, field) {
+  const raw = String(value || "").trim();
+  const api = pathApi(raw);
+  if (raw.startsWith("\\\\") || raw.startsWith("//")) {
+    throw attenuationError(
+      "path.network_namespace",
+      `${field} must not use a UNC or device namespace.`,
+    );
+  }
+  if (!raw || !api.isAbsolute(raw)) {
+    throw attenuationError("path.invalid", `${field} must be absolute.`);
+  }
+  return { api, value: api.normalize(raw) };
+}
+
+function isStrictChild(api, parent, child) {
+  const relative = api.relative(parent, child);
+  return Boolean(relative) && !relative.startsWith("..") && !api.isAbsolute(relative);
+}
+
+function isDirectChild(api, parent, child) {
+  if (!isStrictChild(api, parent, child)) return false;
+  const relative = api.relative(parent, child);
+  return !relative.includes(api.sep);
+}
+
+function attenuationError(suffix, message) {
+  const error = new Error(message);
+  error.diagnosticId = `runx.overlay.attenuation.${suffix}`;
+  return error;
+}
+
+function diagnostic(id, message) {
+  return { id, severity: "error", message };
+}
+
+function refuse(inputs, id, message) {
+  const admission = {
+    schema: "runx.skill_overlay.worktree_admission.v1",
+    decision: "refused",
+    objective: String(inputs.objective || "").trim(),
+    wraps: {
+      path: WRAPS_PATH,
+      pinned_digest: PINNED_DIGEST,
+      resolved_digest: String(inputs.resolved_digest || "").trim().toLowerCase(),
+    },
+    diagnostics: [diagnostic(id, message)],
+    approval: { required: false, gate_id: GATE_ID },
+    denied_capabilities: DENIED_CAPABILITIES,
+  };
+  process.stdout.write(`${JSON.stringify({ admission })}\n`);
+  process.stderr.write(`${id}: ${message}\n`);
+}
+
+function main() {
+  const inputs = readInputs();
+  const resolvedDigest = String(inputs.resolved_digest || "").trim().toLowerCase();
+
+  if (!/^sha256:[0-9a-f]{64}$/.test(resolvedDigest)) {
+    refuse(
+      inputs,
+      "runx.overlay.digest.stale",
+      "The resolved wrapped-skill digest is missing or malformed.",
+    );
+    return;
+  }
+  if (resolvedDigest !== PINNED_DIGEST) {
+    refuse(
+      inputs,
+      "runx.overlay.digest.stale",
+      "The wrapped SKILL.md bytes do not match the pinned digest; changed instructions were not admitted.",
+    );
+    return;
+  }
+
+  try {
+    const objective = String(inputs.objective || "").trim();
+    if (!objective) {
+      throw attenuationError("objective.empty", "objective must not be empty.");
+    }
+
+    const repo = normalizeAbsolute(inputs.repo_root, "repo_root");
+    const root = normalizeAbsolute(inputs.worktree_root, "worktree_root");
+    const target = normalizeAbsolute(inputs.worktree_path, "worktree_path");
+    if (repo.api !== root.api || repo.api !== target.api) {
+      throw attenuationError("path.flavor", "All paths must use the same path flavor.");
+    }
+    const expectedRoot = repo.api.join(repo.value, ".worktrees");
+    if (repo.api.relative(expectedRoot, root.value) !== "") {
+      throw attenuationError(
+        "worktree_root.name",
+        "worktree_root must be exactly <repo_root>/.worktrees.",
+      );
+    }
+    if (!isDirectChild(repo.api, root.value, target.value)) {
+      throw attenuationError(
+        "worktree_path.escape",
+        "worktree_path must be one direct child of worktree_root.",
+      );
+    }
+
+    const branchName = String(inputs.branch_name || "").trim();
+    const safeBranch =
+      /^(feature|fix|chore|docs|test|refactor|codex)\/[a-z0-9][a-z0-9._/-]{0,78}$/;
+    const branchSegments = branchName.split("/");
+    if (
+      !safeBranch.test(branchName) ||
+      branchName.includes("..") ||
+      branchName.includes("@{") ||
+      branchSegments.some(
+        (segment) =>
+          !segment ||
+          segment.startsWith(".") ||
+          segment.endsWith(".") ||
+          segment.endsWith(".lock"),
+      )
+    ) {
+      throw attenuationError(
+        "branch.invalid",
+        "branch_name is outside the bounded branch namespace or contains unsafe Git syntax.",
+      );
+    }
+
+    const startCommit = String(inputs.start_commit || "").trim().toLowerCase();
+    if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(startCommit)) {
+      throw attenuationError(
+        "start_commit.invalid",
+        "start_commit must be a full 40- or 64-hex immutable Git object id.",
+      );
+    }
+    if (String(inputs.mechanism || "").trim() !== "git_fallback") {
+      throw attenuationError(
+        "mechanism.invalid",
+        "mechanism must be git_fallback for this package version.",
+      );
+    }
+    if (Number(inputs.max_worktrees) !== 1) {
+      throw attenuationError(
+        "worktree_count.invalid",
+        "max_worktrees must be exactly 1.",
+      );
+    }
+
+    const argv = [
+      "git",
+      "-C",
+      repo.value,
+      "worktree",
+      "add",
+      "--no-checkout",
+      "-b",
+      branchName,
+      target.value,
+      startCommit,
+    ];
+    const idempotencyKey = `sha256:${createHash("sha256")
+      .update(JSON.stringify(argv))
+      .digest("hex")}`;
+    const admission = {
+      schema: "runx.skill_overlay.worktree_admission.v1",
+      decision: "ready_for_approval",
+      objective,
+      wraps: {
+        path: WRAPS_PATH,
+        pinned_digest: PINNED_DIGEST,
+        resolved_digest: resolvedDigest,
+      },
+      attenuation: {
+        repo_root: repo.value,
+        worktree_root: root.value,
+        worktree_path: target.value,
+        branch_name: branchName,
+        start_commit: startCommit,
+        mechanism: "git_fallback",
+        max_worktrees: 1,
+        argv,
+        scopes: ["repo.read", "repo.worktree.create"],
+        allowed_tools: ALLOWED_TOOLS,
+        path_policy: {
+          unc_and_device_namespaces: "denied",
+          canonical_local_git_checkout_required: true,
+          canonical_worktree_root_containment_required: true,
+          symlink_and_junction_components: "denied",
+        },
+      },
+      approval: { required: true, gate_id: GATE_ID },
+      idempotency_key: idempotencyKey,
+      denied_capabilities: DENIED_CAPABILITIES,
+      diagnostics: [],
+    };
+    process.stdout.write(`${JSON.stringify({ admission })}\n`);
+  } catch (error) {
+    refuse(
+      inputs,
+      error.diagnosticId || "runx.overlay.attenuation.invalid",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+main();

--- a/skills/overlay-open-skill-1/seal-ticket.mjs
+++ b/skills/overlay-open-skill-1/seal-ticket.mjs
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+const EXPECTED_ADMISSION_SCHEMA = "runx.skill_overlay.worktree_admission.v1";
+const GATE_ID = "overlay-open-skill-1.worktree-create.approval";
+const GATE_REASON =
+  "Approve the exact repository, path, branch, start commit, and argv before issuing a receipt-bound single-effect worktree authorization.";
+
+function deepSort(value) {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, deepSort(value[key])]),
+  );
+}
+
+function approvalIdempotencyKey(inputs) {
+  const summary = deepSort({
+    objective: inputs.objective,
+    resolved_digest: inputs.resolved_digest,
+    repo_root: inputs.repo_root,
+    worktree_root: inputs.worktree_root,
+    worktree_path: inputs.worktree_path,
+    branch_name: inputs.branch_name,
+    start_commit: inputs.start_commit,
+    mechanism: inputs.mechanism,
+    max_worktrees: inputs.max_worktrees,
+    admission: inputs.admission,
+  });
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify({ id: GATE_ID, reason: GATE_REASON, summary }))
+    .digest("hex")}`;
+}
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function fail(id, message) {
+  process.stdout.write(
+    `${JSON.stringify({
+      worktree_act: {
+        schema: "runx.skill_overlay.worktree_act.v1",
+        decision: "refused",
+        diagnostics: [{ id, severity: "error", message }],
+      },
+    })}\n`,
+  );
+  process.stderr.write(`${id}: ${message}\n`);
+  process.exitCode = 78;
+}
+
+function main() {
+  const inputs = readInputs();
+  const admission = inputs.admission;
+  const approval = inputs.approval;
+  if (
+    !admission ||
+    admission.schema !== EXPECTED_ADMISSION_SCHEMA ||
+    admission.decision !== "ready_for_approval"
+  ) {
+    fail(
+      "runx.overlay.admission.invalid",
+      "A ready, receipt-bound worktree admission is required before ticket emission.",
+    );
+    return;
+  }
+  if (!approval || approval.approved !== true) {
+    fail(
+      "runx.overlay.approval.required",
+      "The native operator approval gate did not approve this exact plan.",
+    );
+    return;
+  }
+  const expectedApprovalKey = approvalIdempotencyKey(inputs);
+  if (
+    approval.gate_id !== GATE_ID ||
+    approval.status !== "approved" ||
+    approval.idempotency_key !== expectedApprovalKey
+  ) {
+    fail(
+      "runx.overlay.approval.binding.invalid",
+      "The approval decision is not bound to the expected gate and decision key.",
+    );
+    return;
+  }
+
+  const ticketBody = {
+    schema: "runx.skill_overlay.worktree_act.v1",
+    decision: "single_effect_authority_issued",
+    objective: admission.objective,
+    wraps: admission.wraps,
+    consumed_attenuation: admission.attenuation,
+    approval: {
+      gate_id: GATE_ID,
+      approved: true,
+      status: approval.status,
+      actor: approval.actor || null,
+      decision_idempotency_key: approval.idempotency_key,
+    },
+    idempotency_key: admission.idempotency_key,
+    denied_capabilities: admission.denied_capabilities,
+    closure: {
+      authority: "single_effect",
+      max_effects: 1,
+      execution_performed: false,
+      consumption_requirement: "host_idempotency_registry",
+      canonical_path_preflight_required: true,
+      required_readback: "git worktree list --porcelain",
+      required_effect_receipt: true,
+    },
+    diagnostics: [],
+  };
+  const ticketDigest = `sha256:${createHash("sha256")
+    .update(JSON.stringify(ticketBody))
+    .digest("hex")}`;
+  process.stdout.write(
+    `${JSON.stringify({
+      worktree_act: { ...ticketBody, ticket_digest: ticketDigest },
+    })}\n`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

- add `overlay-open-skill-1`, a governed wrapper for an immutable open-ecosystem worktree skill
- pin the upstream `SKILL.md` by commit and SHA-256 without copying or editing it
- attenuate authority to one repository, one direct-child worktree path, one branch, one immutable start commit, and one exact argv vector
- require a native Runx approval decision over that normalized plan before issuing a receipt-bound single-effect authorization
- refuse digest drift, path escape, nested roots, unsafe branch syntax, approval denial, and UNC/device namespaces

## Verification

- `runx harness ./skills/overlay-open-skill-1 --json` — 7/7 cases passed
- clean local-registry install reached the native approval pause, resumed, sealed, and verified a four-receipt tree without findings
- targeted official-skill catalog checks passed
- immutable upstream bytes replay to `sha256:e2c3ec142e52868a51af246c620cd76ab648dcf27d6900d47e6ffd07159a9794`

## Scope

This graph does not execute `git worktree add`. It issues a narrowly bounded authorization and explicitly requires a consuming host to perform canonical-path checks, atomically consume the idempotency key, execute only the recorded argv, retain an effect receipt, and verify with `git worktree list --porcelain`.

