### PR TITLE
feat(skills): add governed skill discovery overlay

### DIFF
--- a/skills/overlay-open-skill-2/SKILL.md
+++ b/skills/overlay-open-skill-2/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: overlay-open-skill-2
+description: Govern an immutable open-ecosystem skill finder with a pinned digest, owner-scoped discovery, an operator approval gate, and a receipt-bound single-search authorization.
+---
+
+# Governed Skill Discovery Overlay
+
+Use this overlay when an operator wants to search the open skill ecosystem but
+does not want borrowed instructions to gain installation authority or silently
+change after adoption. The overlay pins the wrapped instructions, narrows one
+invocation to one owner-scoped search, asks for approval over the normalized
+query, and records the approved decision in a sealed runx receipt.
+
+The wrapped `SKILL.md` is referenced, never copied or edited. A trusted resolver
+must compute `resolved_digest` from the immutable public bytes. If that digest
+does not match the pin, the graph raises `runx.overlay.digest.stale` and refuses
+before the approval step.
+
+## Added governance
+
+The bare upstream skill can search, recommend, and install extensions. This
+overlay deliberately attenuates that authority to discovery only:
+
+1. `admit` verifies the immutable digest and validates a bounded query.
+2. The search is restricted to one explicit public repository owner, at most
+   six safe query tokens, and one fixed argument vector.
+3. `approve-search` is a native runx approval gate over that exact owner, query,
+   and command plan.
+4. `record-search` consumes the bound approval decision and emits a
+   `runx.skill_overlay.skill_search_act.v1` single-effect authorization.
+
+The package never installs or updates a skill, never writes to the filesystem,
+and never executes the search itself. A consuming host must atomically consume
+the authorization's idempotency key, execute only its recorded argument vector,
+retain exit status and redacted output, and bind that effect receipt to the
+authorization.
+
+## Inputs
+
+- `objective`: why discovery is needed.
+- `resolved_digest`: sha256 recomputed from the immutable wrapped `SKILL.md`.
+- `query`: one to six bounded search tokens.
+- `owner`: one explicit public repository owner to search.
+- `operation`: must be `find`.
+- `allow_install`: must be `false`.
+- `max_results`: must be an integer from 1 through 10; the consuming host must
+  retain no more than this many normalized result records.
+
+## Exact authority
+
+When admitted, the only releasable command is represented as an argument
+vector, never as a caller-provided shell string:
+
+```text
+npx --yes skills find <query tokens...> --owner <owner>
+```
+
+The authorization allows only `shell.exec` under `web.read` and
+`skill.discovery` scopes. It records explicit denials for installation,
+updates, filesystem writes, credential reads, arbitrary owners, command
+chaining, redirection, interactive prompts, and additional commands.
+
+## Refusal conditions
+
+Refuse before approval when any of these is true:
+
+- the resolved digest is missing, malformed, or differs from the pin;
+- `operation` is not exactly `find`;
+- `allow_install` is not exactly `false`;
+- the owner is missing or is not a bounded public owner name;
+- the query is empty, has more than six tokens, or contains shell syntax;
+- `max_results` is outside the integer range 1 through 10.
+
+Digest drift raises `runx.overlay.digest.stale`. Other boundary failures use a
+specific `runx.overlay.attenuation.*` diagnostic. A refusal never reaches the
+approval or authorization step.
+
+## Operator procedure
+
+1. Fetch the immutable wrapped source, recompute sha256, and retain the public
+   source URL and digest evidence.
+2. Supply the bounded inputs and run this package.
+3. Review the normalized owner, query tokens, result cap, and exact argv at the
+   native approval gate.
+4. Approve only when the outbound search is appropriate.
+5. Inspect the sealed receipt and single-effect authorization.
+6. If a host consumes it, atomically register the idempotency key, execute only
+   the exact argv without a shell interpreter, redact secrets from output, cap
+   normalized records at `max_results`, and retain an effect receipt.
+
+## What the receipt proves
+
+The receipt proves which immutable instructions were admitted, which authority
+was narrowed, which exact search was approved, and which single-effect
+authorization was issued. It does not prove that the host executed the command
+or that any result is safe to install. Installation requires a separate,
+independently governed decision.

--- a/skills/overlay-open-skill-2/X.yaml
+++ b/skills/overlay-open-skill-2/X.yaml
@@ -1,0 +1,220 @@
+skill: overlay-open-skill-2
+version: "1.0.0"
+
+runx:
+  overlay:
+    wraps:
+      path: https://raw.githubusercontent.com/vercel-labs/skills/5527c09adc367612b0bffd9c80e3bc28a6b01b6d/skills/find-skills/SKILL.md
+      version: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+    pinned_digest: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: context
+
+harness:
+  cases:
+    - name: pinned-approved-owner-search-seals
+      runner: default
+      inputs:
+        objective: Find a maintained testing skill from one reviewed owner.
+        resolved_digest: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+        query: playwright testing
+        owner: microsoft
+        operation: find
+        allow_install: false
+        max_results: 5
+      caller:
+        approvals:
+          overlay-open-skill-2.skill-search.approval: true
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: digest-stale-refuses
+      runner: default
+      inputs:
+        objective: Refuse changed discovery instructions before approval.
+        resolved_digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+        query: playwright testing
+        owner: microsoft
+        operation: find
+        allow_install: false
+        max_results: 5
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: approval-denied-refuses
+      runner: default
+      inputs:
+        objective: Refuse search authority when the operator denies the plan.
+        resolved_digest: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+        query: accessibility audit
+        owner: vercel-labs
+        operation: find
+        allow_install: false
+        max_results: 3
+      caller:
+        approvals:
+          overlay-open-skill-2.skill-search.approval: false
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: install-authority-refuses
+      runner: default
+      inputs:
+        objective: Refuse an attempt to turn discovery into installation.
+        resolved_digest: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+        query: react performance
+        owner: vercel-labs
+        operation: add
+        allow_install: true
+        max_results: 5
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: query-injection-refuses
+      runner: default
+      inputs:
+        objective: Refuse shell syntax in an ecosystem search query.
+        resolved_digest: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+        query: testing; curl example.invalid
+        owner: microsoft
+        operation: find
+        allow_install: false
+        max_results: 5
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+runners:
+  default:
+    default: true
+    type: graph
+    runx:
+      scopes:
+        - web.read
+        - skill.discovery
+      allowed_tools:
+        - shell.exec
+    inputs:
+      objective:
+        type: string
+        required: true
+        description: Operator intent for the bounded skill search.
+      resolved_digest:
+        type: string
+        required: true
+        description: Sha256 recomputed from the immutable public wrapped SKILL.md bytes.
+      query:
+        type: string
+        required: true
+        description: One to six bounded search tokens.
+      owner:
+        type: string
+        required: true
+        description: One explicit public repository owner.
+      operation:
+        type: string
+        required: true
+        description: Must be find.
+      allow_install:
+        type: boolean
+        required: true
+        description: Must be false; this overlay never installs or updates skills.
+      max_results:
+        type: number
+        required: true
+        description: Integer result cap from one through ten.
+    graph:
+      name: overlay-open-skill-2-search-ticket
+      steps:
+        - id: admit
+          label: validate immutable pin and attenuate one owner-scoped search
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - preflight.mjs
+            outputs:
+              admission: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools:
+            - shell.exec
+          scopes:
+            - web.read
+          artifacts:
+            named_emits:
+              admission: admission
+
+        - id: approve-search
+          label: approve the exact owner-scoped discovery plan
+          run:
+            type: approval
+          inputs:
+            gate_id: overlay-open-skill-2.skill-search.approval
+            reason: Approve the exact owner, query tokens, result cap, and argv before issuing a receipt-bound single-search authorization.
+          context:
+            admission: admit.admission.data
+          artifacts:
+            wrap_as: approval_decision
+            packet: runx.approval.decision.v1
+
+        - id: record-search
+          label: bind approval and seal a single-search authorization
+          run:
+            type: cli-tool
+            command: node
+            args:
+              - seal-ticket.mjs
+            outputs:
+              search_act: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools:
+            - shell.exec
+          scopes:
+            - web.read
+            - skill.discovery
+          context:
+            admission: admit.admission.data
+            approval: approve-search.approval_decision.data
+          artifacts:
+            named_emits:
+              search_act: search_act
+
+      policy:
+        guards:
+          - step: approve-search
+            field: admit.admission.data.decision
+            equals: ready_for_approval
+          - step: record-search
+            field: approve-search.approval_decision.data.approved
+            equals: true

--- a/skills/overlay-open-skill-2/evidence/local-harness.json
+++ b/skills/overlay-open-skill-2/evidence/local-harness.json
@@ -1,0 +1,48 @@
+{
+  "schema": "runx.overlay_open_skill.local_harness.v1",
+  "runx_cli_version": "runx-cli 0.7.1",
+  "doctor": {
+    "status": "success",
+    "errors": 0,
+    "warnings": 0
+  },
+  "harness": {
+    "status": "passed",
+    "case_count": 5,
+    "assertion_error_count": 0,
+    "case_names": [
+      "pinned-approved-owner-search-seals",
+      "digest-stale-refuses",
+      "approval-denied-refuses",
+      "install-authority-refuses",
+      "query-injection-refuses"
+    ],
+    "receipt_ids": [
+      "sha256:eae24aca23a99291de9cb46fbe6ae59bba2f8349a0b88c79643f494d43f05431",
+      "sha256:65d484088299844e8097268bc327d2e736b61bff9541f7d77413c0220560a8d4",
+      "sha256:9eee9b353f332121d8a174e43a6f272d546dd8dc3b19a9acd0f93995d01440c7",
+      "sha256:7d0f4a4c3a44fe2301bb4a0abd5cba0e3eab34d51935c41a78e52df40a8c0588",
+      "sha256:23e93076b2c7aa753a536001a626d10f4db9a6f564b1a32e84899a9ea68cfadc"
+    ]
+  },
+  "local_dogfood": {
+    "status": "sealed",
+    "run_id": "run_default_b8f05bea0ea8",
+    "receipt_id": "sha256:4b0eaa34f45b80525bacac347c3caa905e51e2927f30ff5c9e26b3a44b54c5ed",
+    "verify_valid": true,
+    "receipt_tree_count": 4,
+    "signature_mode": "local-development",
+    "decision": "single_search_authority_issued",
+    "ticket_digest": "sha256:7bdd6e18c5a01fe86d1f877ccd7fb56b0d53231e0a34707ff33d30688b578123"
+  },
+  "upstream": {
+    "repository": "vercel-labs/skills",
+    "commit": "5527c09adc367612b0bffd9c80e3bc28a6b01b6d",
+    "path": "skills/find-skills/SKILL.md",
+    "license": "MIT",
+    "pinned_digest": "sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f",
+    "archived": false,
+    "stars_observed": 26179,
+    "pushed_at_observed": "2026-07-14T18:17:15Z"
+  }
+}

--- a/skills/overlay-open-skill-2/fixtures/README.md
+++ b/skills/overlay-open-skill-2/fixtures/README.md
@@ -1,0 +1,6 @@
+# Fixtures
+
+- `pinned-approved-owner-search-seals.yaml` replays the happy path with the
+  immutable digest, bounded owner/query, native approval, and sealed ticket.
+- The inline harness in `X.yaml` also covers digest drift, approval denial,
+  installation escalation, and shell syntax in a query.

--- a/skills/overlay-open-skill-2/fixtures/pinned-approved-owner-search-seals.yaml
+++ b/skills/overlay-open-skill-2/fixtures/pinned-approved-owner-search-seals.yaml
@@ -1,0 +1,24 @@
+name: pinned-approved-owner-search-seals
+kind: skill
+target: ..
+runner: default
+inputs:
+  objective: Find a maintained testing skill from one reviewed owner.
+  resolved_digest: sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f
+  query: playwright testing
+  owner: microsoft
+  operation: find
+  allow_install: false
+  max_results: 5
+caller:
+  approvals:
+    overlay-open-skill-2.skill-search.approval: true
+expect:
+  status: sealed
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: closed
+metadata:
+  source: overlay-open-skill-2
+  contract: approved-owner-scoped-search

--- a/skills/overlay-open-skill-2/preflight.mjs
+++ b/skills/overlay-open-skill-2/preflight.mjs
@@ -1,0 +1,175 @@
+import { createHash } from "node:crypto";
+
+const WRAPS_PATH =
+  "https://raw.githubusercontent.com/vercel-labs/skills/5527c09adc367612b0bffd9c80e3bc28a6b01b6d/skills/find-skills/SKILL.md";
+const PINNED_DIGEST =
+  "sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f";
+const GATE_ID = "overlay-open-skill-2.skill-search.approval";
+const ALLOWED_TOOLS = Object.freeze(["shell.exec"]);
+const SCOPES = Object.freeze(["web.read", "skill.discovery"]);
+const DENIED_CAPABILITIES = Object.freeze([
+  "skills.add",
+  "skills.install",
+  "skills.update",
+  "filesystem.write",
+  "credentials.read",
+  "unbounded_owner_search",
+  "shell.chaining",
+  "shell.redirection",
+  "interactive_prompt",
+  "additional_commands",
+]);
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function attenuationError(suffix, message) {
+  const error = new Error(message);
+  error.diagnosticId = `runx.overlay.attenuation.${suffix}`;
+  return error;
+}
+
+function diagnostic(id, message) {
+  return { id, severity: "error", message };
+}
+
+function refuse(inputs, id, message) {
+  const admission = {
+    schema: "runx.skill_overlay.skill_search_admission.v1",
+    decision: "refused",
+    objective: String(inputs.objective || "").trim(),
+    wraps: {
+      path: WRAPS_PATH,
+      pinned_digest: PINNED_DIGEST,
+      resolved_digest: String(inputs.resolved_digest || "").trim().toLowerCase(),
+    },
+    diagnostics: [diagnostic(id, message)],
+    approval: { required: false, gate_id: GATE_ID },
+    denied_capabilities: DENIED_CAPABILITIES,
+  };
+  process.stdout.write(`${JSON.stringify({ admission })}\n`);
+  process.stderr.write(`${id}: ${message}\n`);
+}
+
+function main() {
+  const inputs = readInputs();
+  const resolvedDigest = String(inputs.resolved_digest || "").trim().toLowerCase();
+
+  if (!/^sha256:[0-9a-f]{64}$/.test(resolvedDigest)) {
+    refuse(
+      inputs,
+      "runx.overlay.digest.stale",
+      "The resolved wrapped-skill digest is missing or malformed.",
+    );
+    return;
+  }
+  if (resolvedDigest !== PINNED_DIGEST) {
+    refuse(
+      inputs,
+      "runx.overlay.digest.stale",
+      "The wrapped SKILL.md bytes do not match the pinned digest; changed instructions were not admitted.",
+    );
+    return;
+  }
+
+  try {
+    const objective = String(inputs.objective || "").trim();
+    if (!objective) {
+      throw attenuationError("objective.empty", "objective must not be empty.");
+    }
+    if (String(inputs.operation || "").trim() !== "find") {
+      throw attenuationError(
+        "operation.denied",
+        "operation must be find; installation and updates are outside this overlay.",
+      );
+    }
+    if (inputs.allow_install !== false) {
+      throw attenuationError(
+        "install.denied",
+        "allow_install must be false; this overlay grants discovery only.",
+      );
+    }
+
+    const owner = String(inputs.owner || "").trim().toLowerCase();
+    if (!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(owner)) {
+      throw attenuationError(
+        "owner.invalid",
+        "owner must be one bounded public repository-owner name.",
+      );
+    }
+
+    const query = String(inputs.query || "").trim();
+    const queryTokens = query ? query.split(/\s+/) : [];
+    if (
+      queryTokens.length < 1 ||
+      queryTokens.length > 6 ||
+      queryTokens.some((token) => !/^[A-Za-z0-9][A-Za-z0-9._+-]{0,31}$/.test(token))
+    ) {
+      throw attenuationError(
+        "query.invalid",
+        "query must contain one to six safe tokens without shell syntax.",
+      );
+    }
+
+    const maxResults = Number(inputs.max_results);
+    if (!Number.isInteger(maxResults) || maxResults < 1 || maxResults > 10) {
+      throw attenuationError(
+        "result_cap.invalid",
+        "max_results must be an integer from 1 through 10.",
+      );
+    }
+
+    const argv = [
+      "npx",
+      "--yes",
+      "skills",
+      "find",
+      ...queryTokens,
+      "--owner",
+      owner,
+    ];
+    const idempotencyKey = `sha256:${createHash("sha256")
+      .update(JSON.stringify(argv))
+      .digest("hex")}`;
+    const admission = {
+      schema: "runx.skill_overlay.skill_search_admission.v1",
+      decision: "ready_for_approval",
+      objective,
+      wraps: {
+        path: WRAPS_PATH,
+        pinned_digest: PINNED_DIGEST,
+        resolved_digest: resolvedDigest,
+      },
+      attenuation: {
+        operation: "find",
+        owner,
+        query_tokens: queryTokens,
+        max_results: maxResults,
+        allow_install: false,
+        argv,
+        scopes: SCOPES,
+        allowed_tools: ALLOWED_TOOLS,
+        execution_policy: {
+          shell_interpreter: "denied",
+          interactive_prompt: "denied",
+          output_redaction_required: true,
+          normalized_result_cap_required: true,
+        },
+      },
+      approval: { required: true, gate_id: GATE_ID },
+      idempotency_key: idempotencyKey,
+      denied_capabilities: DENIED_CAPABILITIES,
+      diagnostics: [],
+    };
+    process.stdout.write(`${JSON.stringify({ admission })}\n`);
+  } catch (error) {
+    refuse(
+      inputs,
+      error.diagnosticId || "runx.overlay.attenuation.invalid",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+main();

--- a/skills/overlay-open-skill-2/seal-ticket.mjs
+++ b/skills/overlay-open-skill-2/seal-ticket.mjs
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+const EXPECTED_ADMISSION_SCHEMA =
+  "runx.skill_overlay.skill_search_admission.v1";
+const GATE_ID = "overlay-open-skill-2.skill-search.approval";
+const GATE_REASON =
+  "Approve the exact owner, query tokens, result cap, and argv before issuing a receipt-bound single-search authorization.";
+
+function deepSort(value) {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, deepSort(value[key])]),
+  );
+}
+
+function approvalIdempotencyKey(inputs) {
+  const summary = deepSort({
+    objective: inputs.objective,
+    resolved_digest: inputs.resolved_digest,
+    query: inputs.query,
+    owner: inputs.owner,
+    operation: inputs.operation,
+    allow_install: inputs.allow_install,
+    max_results: inputs.max_results,
+    admission: inputs.admission,
+  });
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify({ id: GATE_ID, reason: GATE_REASON, summary }))
+    .digest("hex")}`;
+}
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function fail(id, message) {
+  process.stdout.write(
+    `${JSON.stringify({
+      search_act: {
+        schema: "runx.skill_overlay.skill_search_act.v1",
+        decision: "refused",
+        diagnostics: [{ id, severity: "error", message }],
+      },
+    })}\n`,
+  );
+  process.stderr.write(`${id}: ${message}\n`);
+  process.exitCode = 78;
+}
+
+function main() {
+  const inputs = readInputs();
+  const admission = inputs.admission;
+  const approval = inputs.approval;
+  if (
+    !admission ||
+    admission.schema !== EXPECTED_ADMISSION_SCHEMA ||
+    admission.decision !== "ready_for_approval"
+  ) {
+    fail(
+      "runx.overlay.admission.invalid",
+      "A ready, receipt-bound search admission is required before authorization.",
+    );
+    return;
+  }
+  if (!approval || approval.approved !== true) {
+    fail(
+      "runx.overlay.approval.required",
+      "The native operator approval gate did not approve this exact search.",
+    );
+    return;
+  }
+  const expectedApprovalKey = approvalIdempotencyKey(inputs);
+  if (
+    approval.gate_id !== GATE_ID ||
+    approval.status !== "approved" ||
+    approval.idempotency_key !== expectedApprovalKey
+  ) {
+    fail(
+      "runx.overlay.approval.binding.invalid",
+      "The approval decision is not bound to the expected gate and decision key.",
+    );
+    return;
+  }
+
+  const ticketBody = {
+    schema: "runx.skill_overlay.skill_search_act.v1",
+    decision: "single_search_authority_issued",
+    objective: admission.objective,
+    wraps: admission.wraps,
+    consumed_attenuation: admission.attenuation,
+    approval: {
+      gate_id: GATE_ID,
+      approved: true,
+      status: approval.status,
+      actor: approval.actor || null,
+      decision_idempotency_key: approval.idempotency_key,
+    },
+    idempotency_key: admission.idempotency_key,
+    denied_capabilities: admission.denied_capabilities,
+    closure: {
+      authority: "single_effect",
+      max_effects: 1,
+      execution_performed: false,
+      consumption_requirement: "host_idempotency_registry",
+      shell_interpreter: "denied",
+      required_readback: "exit_status_and_redacted_bounded_results",
+      required_effect_receipt: true,
+      installation_requires_separate_governance: true,
+    },
+    diagnostics: [],
+  };
+  const ticketDigest = `sha256:${createHash("sha256")
+    .update(JSON.stringify(ticketBody))
+    .digest("hex")}`;
+  process.stdout.write(
+    `${JSON.stringify({
+      search_act: { ...ticketBody, ticket_digest: ticketDigest },
+    })}\n`,
+  );
+}
+
+main();


### PR DESCRIPTION
## What changed

- adds `overlay-open-skill-2`, a governed wrapper for the immutable `find-skills` instructions in `vercel-labs/skills`
- pins the upstream bytes at `sha256:c00eeea0e13e74fe4a9d84ba0a8542205a1b736d65f13134fe1a6647eb14976f`
- attenuates the upstream search/install workflow to one owner-scoped discovery command and explicitly denies install/update/filesystem-write authority
- requires a native runx approval over the exact owner, query tokens, result cap, and argv before issuing a receipt-bound single-search authorization
- refuses digest drift, approval denial, installation escalation, unsafe owners, unsafe query syntax, and oversized result caps

## Why

A digest pin alone detects drift but does not create operational governance. This package adds caller-consumable attenuation, an approval decision, an idempotency key, and a single-effect authorization while leaving the upstream `SKILL.md` untouched.

## Impact

The wrapped discovery workflow can be adopted without granting its installation behavior. A consuming host receives one exact argv vector and must retain an effect receipt; installation requires separate governance.

## Checks

- `runx-cli 0.7.1`
- `runx doctor ./skills/overlay-open-skill-2 --json` — 0 errors, 0 warnings
- `runx harness ./skills/overlay-open-skill-2 --json` — 5/5 passed, 0 assertion errors
- local `runx skill` approval pause/resume — sealed `graph_closed`
- local receipt tree — 4 receipts, valid, no findings
- upstream repo is active and MIT-licensed; pinned bytes were recomputed from commit `5527c09adc367612b0bffd9c80e3bc28a6b01b6d`

Related bounty: Frantic #101.