### PR TITLE
fix(skills): fetch bookkeeper sources at runtime

### DIFF
--- a/skills/bookkeeper/SKILL.md
+++ b/skills/bookkeeper/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: bookkeeper
+description: Reconcile sourced transaction batches against an existing chart of accounts with deterministic account binding, anomaly evidence, and a read-only consumer-verified artifact.
+---
+
+# Bookkeeper — read-only reconciliation
+
+Use `bookkeeper` to turn a sourced transaction batch into a reviewable,
+read-only accounting artifact. The skill validates every source line, binds each
+line to exactly one account that already exists in the supplied chart, and then
+passes those bindings to an independent reconciliation step. It never posts to
+a ledger, invents an account, or resolves an ambiguous line by guessing.
+
+## Inputs
+
+- `transactions[]`: statement lines with `id`, `date`, `description`, signed
+  integer `amount_minor`, `currency`, `counterparty`, and `source_ref`.
+- `chart_of_accounts`: existing accounts with `code`, `name`, `type`, and a
+  `match` policy. A policy declares `direction` plus bounded
+  `description_contains` and/or `counterparty_exact` evidence.
+- `prior_period`: the statement currency, opening balance, expected ending
+  balance, prior transaction IDs, known counterparties, and an optional prior
+  average absolute amount.
+
+Positive amounts are inflows and negative amounts are outflows. Amounts are
+integers in minor currency units so reconciliation does not depend on floating
+point arithmetic.
+
+## Runtime pipeline
+
+1. `admit-source` validates source provenance, input shape, account rules,
+   transaction uniqueness, prior-period bindings, and unique account matches.
+2. `categorize-lines` recomputes the input digests and materializes every
+   proposed binding against the existing chart. Each line carries confidence,
+   reason, matched evidence, and its source reference.
+3. `reconcile-readonly` is a real downstream consumer. It independently checks
+   account membership and line coverage, recomputes the statement movement and
+   ending balance, and emits `reconciliation{matched,unmatched}`.
+4. `emit-readonly-artifact` runs only when the consumer found no unmatched
+   evidence. It emits the typed `categorized[]`, `anomalies[]`, and
+   `reconciliation` result plus a digest of the consumed reconciliation.
+
+Graph guards stop downstream work when admission returns `needs_review` or the
+consumer finds a balance mismatch. A refused run emits no final bookkeeping
+artifact.
+
+## Matching contract
+
+An account is eligible only when its declared direction matches the signed
+transaction amount and at least one declared evidence item matches. Exact
+counterparty evidence scores higher than a bounded description phrase. The top
+score must be unique. A tie or no match returns `needs_review`, including the
+candidate account codes and reason.
+
+Every categorized entry contains:
+
+- the original transaction ID, date, description, amount, currency, and
+  `source_ref`;
+- an `account_code` and `account_name` copied from `chart_of_accounts`;
+- a numeric confidence score and a human-readable reason;
+- the exact matched counterparty or description evidence; and
+- `read_only: true`.
+
+## Anomalies and reconciliation
+
+The skill flags prior-period duplicate IDs, unfamiliar counterparties, currency
+conflicts, and amount outliers. A duplicate, malformed line, unsupported
+currency, ambiguous match, or ending-balance mismatch prevents the final
+artifact. Informational anomalies such as a new counterparty or a large but
+otherwise well-bound amount remain visible for human review.
+
+`reconciliation.matched` lists every accepted statement line and its existing
+account binding. `reconciliation.unmatched` lists consumer-level failures such
+as missing line coverage or a statement-balance difference. The consumer also
+records the opening balance, net movement, calculated ending balance, expected
+ending balance, and the digest of the categorized batch it consumed.
+
+## Non-authority
+
+This skill has no credential input, network permission, or ledger-write tool.
+It produces evidence for a bookkeeper; it does not create journal entries,
+change a chart of accounts, approve a close, or send data anywhere. A separate
+governed workflow must review and post any resulting entry.

--- a/skills/bookkeeper/SKILL.md
+++ b/skills/bookkeeper/SKILL.md
@@ -1,26 +1,35 @@
 ---
 name: bookkeeper
-description: Reconcile sourced transaction batches against an existing chart of accounts with deterministic account binding, anomaly evidence, and a read-only consumer-verified artifact.
+description: Fetch an allowlisted JSON statement and reconcile its transaction rows against an existing chart of accounts with deterministic bindings and a read-only consumer-verified artifact.
 ---
 
-# Bookkeeper — read-only reconciliation
+# Bookkeeper — allowlisted source reconciliation
 
-Use `bookkeeper` to turn a sourced transaction batch into a reviewable,
-read-only accounting artifact. The skill validates every source line, binds each
-line to exactly one account that already exists in the supplied chart, and then
-passes those bindings to an independent reconciliation step. It never posts to
-a ledger, invents an account, or resolves an ambiguous line by guessing.
+Use `bookkeeper` to fetch a public JSON statement from an explicitly allowed
+host and turn its transaction rows into a reviewable, read-only accounting
+artifact. The skill validates every fetched source line, binds each line to
+exactly one account that already exists in the supplied chart, and passes those
+bindings to an independent reconciliation step. It never posts to a ledger,
+invents an account, or resolves an ambiguous line by guessing.
 
 ## Inputs
 
-- `transactions[]`: statement lines with `id`, `date`, `description`, signed
-  integer `amount_minor`, `currency`, `counterparty`, and `source_ref`.
+- `source_url`: public HTTP(S) JSON statement fetched during the governed run.
+  The document contains `currency`, `opening_balance_minor`,
+  `expected_ending_balance_minor`, and `transactions[]`.
+- `source_allowlist`: exact hosts that the canonical `web-fetch` step may
+  contact, including any permitted redirect host. Wildcards, trailing dots,
+  credentials, and hosts absent from this list are refused before network
+  access.
 - `chart_of_accounts`: existing accounts with `code`, `name`, `type`, and a
   `match` policy. A policy declares `direction` plus bounded
   `description_contains` and/or `counterparty_exact` evidence.
 - `prior_period`: the statement currency, opening balance, expected ending
   balance, prior transaction IDs, known counterparties, and an optional prior
   average absolute amount.
+- `transactions` remains declared as an optional typed contract field for the
+  bounty interface, but production admission refuses it. Rows must come from
+  the fetched `source_url`, not from caller-pasted JSON.
 
 Positive amounts are inflows and negative amounts are outflows. Amounts are
 integers in minor currency units so reconciliation does not depend on floating
@@ -28,21 +37,57 @@ point arithmetic.
 
 ## Runtime pipeline
 
-1. `admit-source` validates source provenance, input shape, account rules,
-   transaction uniqueness, prior-period bindings, and unique account matches.
-2. `categorize-lines` recomputes the input digests and materializes every
-   proposed binding against the existing chart. Each line carries confidence,
-   reason, matched evidence, and its source reference.
-3. `reconcile-readonly` is a real downstream consumer. It independently checks
-   account membership and line coverage, recomputes the statement movement and
-   ending balance, and emits `reconciliation{matched,unmatched}`.
-4. `emit-readonly-artifact` runs only when the consumer found no unmatched
+1. `validate-source-request` rejects direct transaction rows and validates an
+   exact-host source authority before any network step can run.
+2. `fetch-source` composes the canonical `web-fetch` skill. It fetches exactly
+   one URL within `source_allowlist` and emits final URL, HTTP status, byte
+   count, content digest, redirects, and extracted text in the run receipt.
+3. `admit-source` first requires the UTF-8 bytes of `extracted` to reproduce the
+   fetch receipt's byte count and SHA-256 digest exactly. It then parses those
+   exact bytes as JSON, verifies source statement currency and balances against
+   `prior_period`, derives each line's `source_ref` from the fetched final URL,
+   and prepares unique existing-account bindings.
+4. `categorize-lines` consumes only the normalized rows and chart carried by
+   the admission packet. It recomputes their digests and materializes every
+   proposed binding. Each line carries confidence, reason, matched evidence,
+   and its fetched source reference.
+5. `reconcile-readonly` consumes the categorized batch and admission-owned
+   prior-period controls. It independently checks account membership and line
+   coverage, recomputes the statement movement and ending balance, and emits
+   `reconciliation{matched,unmatched}`.
+6. `emit-readonly-artifact` runs only when the consumer found no unmatched
    evidence. It emits the typed `categorized[]`, `anomalies[]`, and
-   `reconciliation` result plus a digest of the consumed reconciliation.
+   `reconciliation` result plus fetched-source evidence and a digest of the
+   consumed reconciliation.
 
-Graph guards stop downstream work when admission returns `needs_review` or the
-consumer finds a balance mismatch. A refused run emits no final bookkeeping
-artifact.
+The emitted `source` evidence includes the validated HTTP status, exact host
+allowlist, final URL, fetched byte count, body digest, and
+`exact_bytes_verified:true`. Final controls carry both
+`source_fetch_performed:true` and `source_bytes_verified:true`.
+
+Graph guards stop downstream work when the fetch is not ready, admission
+returns `needs_review`, or the consumer finds a balance mismatch. A refused run
+emits no final bookkeeping artifact.
+
+## Source contract
+
+The fetched document must be a JSON object with:
+
+- `currency`: a three-letter currency matching `prior_period.currency`;
+- `opening_balance_minor` and `expected_ending_balance_minor`: safe integers
+  matching the supplied statement controls; and
+- `transactions[]`: one to one hundred rows with `id`, `date`, `description`,
+  signed integer `amount_minor`, and `counterparty`.
+
+`web-fetch` must report a ready 2xx response, an allowlist decision of
+`allowed`, a non-truncated text extraction, a final URL, and a SHA-256 content
+digest. Because canonical `web-fetch` text extraction is intentionally
+human-readable, the source document must be compact UTF-8 JSON whose extracted
+string has the same byte count and SHA-256 digest as the fetched body. Pretty
+printed JSON or content changed by text extraction is refused rather than
+silently reconciled. Admission derives `source_ref` as
+`<final_url>#transactions[<index>]`; the caller cannot substitute a different
+source label.
 
 ## Matching contract
 
@@ -54,8 +99,8 @@ candidate account codes and reason.
 
 Every categorized entry contains:
 
-- the original transaction ID, date, description, amount, currency, and
-  `source_ref`;
+- the fetched transaction ID, date, description, amount, currency, and a
+  `source_ref` bound to the final fetched URL and array index;
 - an `account_code` and `account_name` copied from `chart_of_accounts`;
 - a numeric confidence score and a human-readable reason;
 - the exact matched counterparty or description evidence; and
@@ -65,9 +110,9 @@ Every categorized entry contains:
 
 The skill flags prior-period duplicate IDs, unfamiliar counterparties, currency
 conflicts, and amount outliers. A duplicate, malformed line, unsupported
-currency, ambiguous match, or ending-balance mismatch prevents the final
-artifact. Informational anomalies such as a new counterparty or a large but
-otherwise well-bound amount remain visible for human review.
+currency, ambiguous match, truncated fetch, or ending-balance mismatch prevents
+the final artifact. Informational anomalies such as a new counterparty or a
+large but otherwise well-bound amount remain visible for human review.
 
 `reconciliation.matched` lists every accepted statement line and its existing
 account binding. `reconciliation.unmatched` lists consumer-level failures such
@@ -77,7 +122,9 @@ ending balance, and the digest of the categorized batch it consumed.
 
 ## Non-authority
 
-This skill has no credential input, network permission, or ledger-write tool.
-It produces evidence for a bookkeeper; it does not create journal entries,
-change a chart of accounts, approve a close, or send data anywhere. A separate
-governed workflow must review and post any resulting entry.
+This skill has one bounded network authority: the canonical `web-fetch` child
+may read one URL whose host is in `source_allowlist`. It has no credential
+input, provider-write permission, or ledger-write tool. It produces evidence
+for a bookkeeper; it does not create journal entries, change a chart of
+accounts, approve a close, or send data anywhere. A separate governed workflow
+must review and post any resulting entry.

--- a/skills/bookkeeper/X.yaml
+++ b/skills/bookkeeper/X.yaml
@@ -1,6 +1,6 @@
 # Deterministic, read-only bookkeeping graph.
 skill: bookkeeper
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   kind: graph
@@ -13,28 +13,8 @@ harness:
     - name: sourced-clean-batch-reconciles
       runner: default
       inputs:
-        transactions:
-          - id: stmt-2026-07-001
-            date: "2026-07-01"
-            description: Stripe payout invoice 1042
-            amount_minor: 125000
-            currency: USD
-            counterparty: Stripe
-            source_ref: fixture://bookkeeper/clean-statement#line-1
-          - id: stmt-2026-07-002
-            date: "2026-07-02"
-            description: AWS cloud hosting July
-            amount_minor: -18432
-            currency: USD
-            counterparty: Amazon Web Services
-            source_ref: fixture://bookkeeper/clean-statement#line-2
-          - id: stmt-2026-07-003
-            date: "2026-07-03"
-            description: GitHub Actions usage
-            amount_minor: -4210
-            currency: USD
-            counterparty: GitHub
-            source_ref: fixture://bookkeeper/clean-statement#line-3
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/68f80cada883babee91177f5c85b080f14c61ac9/clean-statement.json
+        source_allowlist: [gist.githubusercontent.com]
         chart_of_accounts:
           - code: "4000"
             name: Software revenue
@@ -74,14 +54,8 @@ harness:
     - name: ambiguous-account-binding-needs-review
       runner: default
       inputs:
-        transactions:
-          - id: ambiguous-001
-            date: "2026-07-04"
-            description: Cloud platform services
-            amount_minor: -7500
-            currency: USD
-            counterparty: Unknown Platform
-            source_ref: fixture://bookkeeper/ambiguous-statement#line-1
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/68f80cada883babee91177f5c85b080f14c61ac9/ambiguous-statement.json
+        source_allowlist: [gist.githubusercontent.com]
         chart_of_accounts:
           - code: "6100"
             name: Cloud hosting
@@ -112,14 +86,8 @@ harness:
     - name: statement-balance-mismatch-needs-review
       runner: default
       inputs:
-        transactions:
-          - id: mismatch-001
-            date: "2026-07-05"
-            description: Stripe payout invoice 2001
-            amount_minor: 50000
-            currency: USD
-            counterparty: Stripe
-            source_ref: fixture://bookkeeper/mismatch-statement#line-1
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/68f80cada883babee91177f5c85b080f14c61ac9/mismatch-statement.json
+        source_allowlist: [gist.githubusercontent.com]
         chart_of_accounts:
           - code: "4000"
             name: Software revenue
@@ -142,15 +110,167 @@ harness:
           state: sealed
           disposition: blocked
 
+    - name: direct-transaction-input-is-refused
+      runner: default
+      inputs:
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/68f80cada883babee91177f5c85b080f14c61ac9/clean-statement.json
+        source_allowlist: [gist.githubusercontent.com]
+        transactions:
+          - id: caller-injected-001
+            date: "2026-07-01"
+            description: Caller supplied row
+            amount_minor: 1
+            currency: USD
+            counterparty: Caller
+            source_ref: https://example.invalid/caller-row
+        chart_of_accounts:
+          - code: "4000"
+            name: Software revenue
+            type: income
+            match:
+              direction: inflow
+              description_contains: [stripe payout, invoice]
+              counterparty_exact: [Stripe]
+          - code: "6100"
+            name: Cloud hosting
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [aws, cloud hosting]
+              counterparty_exact: [Amazon Web Services]
+          - code: "6200"
+            name: Developer tooling
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [github actions]
+              counterparty_exact: [GitHub]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 250000
+          expected_ending_balance_minor: 352358
+          previous_transaction_ids: [stmt-2026-06-099]
+          known_counterparties: [Stripe, Amazon Web Services, GitHub]
+          average_abs_amount_minor: 30000
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: wildcard-source-allowlist-is-refused
+      runner: default
+      inputs:
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/68f80cada883babee91177f5c85b080f14c61ac9/clean-statement.json
+        source_allowlist: ["*.githubusercontent.com"]
+        chart_of_accounts:
+          - code: "4000"
+            name: Software revenue
+            type: income
+            match:
+              direction: inflow
+              description_contains: [stripe payout, invoice]
+              counterparty_exact: [Stripe]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 250000
+          expected_ending_balance_minor: 352358
+          previous_transaction_ids: []
+          known_counterparties: [Stripe]
+          average_abs_amount_minor: 30000
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: lossy-text-extraction-is-refused
+      runner: default
+      inputs:
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/c8f97e07e39f25a4a5dc7cf8a18cb1e6bde718b4/clean-statement.json
+        source_allowlist: [gist.githubusercontent.com]
+        chart_of_accounts:
+          - code: "4000"
+            name: Software revenue
+            type: income
+            match:
+              direction: inflow
+              description_contains: [stripe payout, invoice]
+              counterparty_exact: [Stripe]
+          - code: "6100"
+            name: Cloud hosting
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [aws, cloud hosting]
+              counterparty_exact: [Amazon Web Services]
+          - code: "6200"
+            name: Developer tooling
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [github actions]
+              counterparty_exact: [GitHub]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 250000
+          expected_ending_balance_minor: 352358
+          previous_transaction_ids: [stmt-2026-06-099]
+          known_counterparties: [Stripe, Amazon Web Services, GitHub]
+          average_abs_amount_minor: 30000
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: invalid-calendar-date-is-refused
+      runner: default
+      inputs:
+        source_url: https://gist.githubusercontent.com/lihonggangli123-cyber/8e6b53375f6b47a546ca07edb2761e04/raw/761e42d9d931bcf688e59644eb5c61db4709667e/invalid-date-statement.json
+        source_allowlist: [gist.githubusercontent.com]
+        chart_of_accounts:
+          - code: "4000"
+            name: Software revenue
+            type: income
+            match:
+              direction: inflow
+              description_contains: [stripe payout]
+              counterparty_exact: [Stripe]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 100000
+          expected_ending_balance_minor: 150000
+          previous_transaction_ids: []
+          known_counterparties: [Stripe]
+          average_abs_amount_minor: 50000
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
 runners:
   default:
     default: true
     type: graph
     inputs:
-      transactions:
+      source_url:
+        type: string
+        required: true
+        description: Public HTTP(S) statement URL fetched during the governed run.
+      source_allowlist:
         type: json
         required: true
-        description: Sourced transaction lines using signed integer minor-unit amounts.
+        description: Exact hosts the canonical web-fetch step may contact, including redirect hosts.
+      transactions:
+        type: json
+        required: false
+        description: Reserved typed contract field; direct transaction input is refused because rows must come from source_url.
       chart_of_accounts:
         type: json
         required: true
@@ -162,8 +282,39 @@ runners:
     graph:
       name: bookkeeper-readonly-reconciliation
       steps:
+        - id: validate-source-request
+          label: validate exact source authority before any network read
+          run:
+            type: cli-tool
+            command: node
+            args: [validate-source-request.mjs]
+            outputs:
+              source_request: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools: [shell.exec]
+          artifacts:
+            named_emits:
+              source_request: source_request
+
+        - id: fetch-source
+          label: fetch the allowlisted statement source during this run
+          skill: ../web-fetch
+          runner: web-fetch
+          scopes:
+            - runx:net:allowlist
+          inputs:
+            extract: text
+            max_bytes: 100000
+          context:
+            url: validate-source-request.source_request.data.url
+            allowlist: validate-source-request.source_request.data.allowlist
+
         - id: admit-source
-          label: validate sourced lines and prepare unique existing-account bindings
+          label: parse fetched statement bytes and prepare unique existing-account bindings
           run:
             type: cli-tool
             command: node
@@ -176,6 +327,9 @@ runners:
               network: false
               require_enforcement: false
           allowed_tools: [shell.exec]
+          context:
+            source_request: validate-source-request.source_request.data
+            fetched_source: fetch-source.fetch_result.data
           artifacts:
             named_emits:
               admission: admission
@@ -216,6 +370,7 @@ runners:
           allowed_tools: [shell.exec]
           context:
             categorized_batch: categorize-lines.categorized_batch.data
+            prior_period: admit-source.admission.data.prior_period
           artifacts:
             named_emits:
               reconciliation_packet: reconciliation_packet
@@ -243,6 +398,12 @@ runners:
 
       policy:
         guards:
+          - step: fetch-source
+            field: validate-source-request.source_request.data.decision
+            equals: ready
+          - step: admit-source
+            field: fetch-source.fetch_result.data.decision
+            equals: ready
           - step: categorize-lines
             field: admit-source.admission.data.decision
             equals: ready

--- a/skills/bookkeeper/X.yaml
+++ b/skills/bookkeeper/X.yaml
@@ -1,0 +1,254 @@
+# Deterministic, read-only bookkeeping graph.
+skill: bookkeeper
+version: "1.0.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+
+harness:
+  cases:
+    - name: sourced-clean-batch-reconciles
+      runner: default
+      inputs:
+        transactions:
+          - id: stmt-2026-07-001
+            date: "2026-07-01"
+            description: Stripe payout invoice 1042
+            amount_minor: 125000
+            currency: USD
+            counterparty: Stripe
+            source_ref: fixture://bookkeeper/clean-statement#line-1
+          - id: stmt-2026-07-002
+            date: "2026-07-02"
+            description: AWS cloud hosting July
+            amount_minor: -18432
+            currency: USD
+            counterparty: Amazon Web Services
+            source_ref: fixture://bookkeeper/clean-statement#line-2
+          - id: stmt-2026-07-003
+            date: "2026-07-03"
+            description: GitHub Actions usage
+            amount_minor: -4210
+            currency: USD
+            counterparty: GitHub
+            source_ref: fixture://bookkeeper/clean-statement#line-3
+        chart_of_accounts:
+          - code: "4000"
+            name: Software revenue
+            type: income
+            match:
+              direction: inflow
+              description_contains: [stripe payout, invoice]
+              counterparty_exact: [Stripe]
+          - code: "6100"
+            name: Cloud hosting
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [aws, cloud hosting]
+              counterparty_exact: [Amazon Web Services]
+          - code: "6200"
+            name: Developer tooling
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [github actions]
+              counterparty_exact: [GitHub]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 250000
+          expected_ending_balance_minor: 352358
+          previous_transaction_ids: [stmt-2026-06-099]
+          known_counterparties: [Stripe, Amazon Web Services, GitHub]
+          average_abs_amount_minor: 30000
+      expect:
+        status: sealed
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
+
+    - name: ambiguous-account-binding-needs-review
+      runner: default
+      inputs:
+        transactions:
+          - id: ambiguous-001
+            date: "2026-07-04"
+            description: Cloud platform services
+            amount_minor: -7500
+            currency: USD
+            counterparty: Unknown Platform
+            source_ref: fixture://bookkeeper/ambiguous-statement#line-1
+        chart_of_accounts:
+          - code: "6100"
+            name: Cloud hosting
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [cloud]
+          - code: "6200"
+            name: Developer tooling
+            type: expense
+            match:
+              direction: outflow
+              description_contains: [cloud]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 100000
+          expected_ending_balance_minor: 92500
+          previous_transaction_ids: []
+          known_counterparties: []
+          average_abs_amount_minor: 10000
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+    - name: statement-balance-mismatch-needs-review
+      runner: default
+      inputs:
+        transactions:
+          - id: mismatch-001
+            date: "2026-07-05"
+            description: Stripe payout invoice 2001
+            amount_minor: 50000
+            currency: USD
+            counterparty: Stripe
+            source_ref: fixture://bookkeeper/mismatch-statement#line-1
+        chart_of_accounts:
+          - code: "4000"
+            name: Software revenue
+            type: income
+            match:
+              direction: inflow
+              description_contains: [stripe payout]
+              counterparty_exact: [Stripe]
+        prior_period:
+          currency: USD
+          opening_balance_minor: 100000
+          expected_ending_balance_minor: 149999
+          previous_transaction_ids: []
+          known_counterparties: [Stripe]
+          average_abs_amount_minor: 50000
+      expect:
+        status: policy_denied
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: blocked
+
+runners:
+  default:
+    default: true
+    type: graph
+    inputs:
+      transactions:
+        type: json
+        required: true
+        description: Sourced transaction lines using signed integer minor-unit amounts.
+      chart_of_accounts:
+        type: json
+        required: true
+        description: Existing GL accounts and their explicit deterministic match policies.
+      prior_period:
+        type: json
+        required: true
+        description: Prior-period statement controls and expected current ending balance.
+    graph:
+      name: bookkeeper-readonly-reconciliation
+      steps:
+        - id: admit-source
+          label: validate sourced lines and prepare unique existing-account bindings
+          run:
+            type: cli-tool
+            command: node
+            args: [admit-source.mjs]
+            outputs:
+              admission: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools: [shell.exec]
+          artifacts:
+            named_emits:
+              admission: admission
+
+        - id: categorize-lines
+          label: materialize account bindings against the admitted chart
+          run:
+            type: cli-tool
+            command: node
+            args: [categorize-lines.mjs]
+            outputs:
+              categorized_batch: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools: [shell.exec]
+          context:
+            admission: admit-source.admission.data
+          artifacts:
+            named_emits:
+              categorized_batch: categorized_batch
+
+        - id: reconcile-readonly
+          label: consume categorized lines and independently reconcile the statement
+          run:
+            type: cli-tool
+            command: node
+            args: [reconcile-readonly.mjs]
+            outputs:
+              reconciliation_packet: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools: [shell.exec]
+          context:
+            categorized_batch: categorize-lines.categorized_batch.data
+          artifacts:
+            named_emits:
+              reconciliation_packet: reconciliation_packet
+
+        - id: emit-readonly-artifact
+          label: emit typed read-only bookkeeping artifact after consumer verification
+          run:
+            type: cli-tool
+            command: node
+            args: [emit-readonly-artifact.mjs]
+            outputs:
+              bookkeeper_result: object
+            sandbox:
+              profile: readonly
+              cwd_policy: skill-directory
+              network: false
+              require_enforcement: false
+          allowed_tools: [shell.exec]
+          context:
+            categorized_batch: categorize-lines.categorized_batch.data
+            reconciliation_packet: reconcile-readonly.reconciliation_packet.data
+          artifacts:
+            named_emits:
+              bookkeeper_result: bookkeeper_result
+
+      policy:
+        guards:
+          - step: categorize-lines
+            field: admit-source.admission.data.decision
+            equals: ready
+          - step: reconcile-readonly
+            field: categorize-lines.categorized_batch.data.decision
+            equals: categorized
+          - step: emit-readonly-artifact
+            field: reconcile-readonly.reconciliation_packet.data.decision
+            equals: reconciled

--- a/skills/bookkeeper/admit-source.mjs
+++ b/skills/bookkeeper/admit-source.mjs
@@ -36,8 +36,118 @@ function sourceRef(value, field) {
   return ref;
 }
 
+function contentDigest(value, field) {
+  const valueDigest = safeString(value, field, 71, 71).toLowerCase();
+  if (!/^sha256:[a-f0-9]{64}$/.test(valueDigest)) throw new Error(`${field} must be a sha256 digest.`);
+  return valueDigest;
+}
+
+function readFetchedStatement(inputs) {
+  if (inputs.transactions !== undefined) {
+    throw new Error("transactions must be fetched from source_url; direct transaction input is not accepted.");
+  }
+  const sourceRequest = inputs.source_request;
+  if (!sourceRequest || sourceRequest.decision !== "ready" || !sourceRequest.controls?.exact_hosts_only) {
+    throw new Error("a validated exact-host source_request is required.");
+  }
+  if (!Array.isArray(sourceRequest.allowlist) || sourceRequest.allowlist.length < 1) {
+    throw new Error("source_request.allowlist must contain exact hosts.");
+  }
+  const fetched = inputs.fetched_source;
+  if (!fetched || typeof fetched !== "object" || Array.isArray(fetched)) {
+    throw new Error("fetched_source from web-fetch is required.");
+  }
+  if (fetched.decision !== "ready" || !Number.isInteger(fetched.status) || fetched.status < 200 || fetched.status >= 300) {
+    throw new Error("web-fetch must return a ready 2xx source.");
+  }
+  if (fetched.extract_mode !== "text" || typeof fetched.extracted !== "string" || !fetched.extracted.trim()) {
+    throw new Error("web-fetch must return non-empty text extraction.");
+  }
+  if (fetched.policy?.allowlist_decision !== "allowed") {
+    throw new Error("web-fetch source must pass the declared host allowlist.");
+  }
+
+  const requestedUrl = sourceRef(sourceRequest.url, "source_request.url");
+  const finalUrl = sourceRef(fetched.final_url, "fetched_source.final_url");
+  const finalUrlWithoutFragment = new URL(finalUrl);
+  finalUrlWithoutFragment.hash = "";
+  const finalHost = finalUrlWithoutFragment.hostname.toLowerCase();
+  if (!sourceRequest.allowlist.includes(finalHost)) {
+    throw new Error("web-fetch final host must exactly match source_request.allowlist.");
+  }
+  const checkedHosts = Array.isArray(fetched.policy.allowlist_checked) ? fetched.policy.allowlist_checked : [];
+  if (JSON.stringify(checkedHosts) !== JSON.stringify(sourceRequest.allowlist)) {
+    throw new Error("web-fetch allowlist evidence differs from the validated source request.");
+  }
+  if (fetched.policy.attempted_host !== sourceRequest.host) {
+    throw new Error("web-fetch attempted host differs from the validated source request.");
+  }
+  const fetchedDigest = contentDigest(fetched.content_digest, "fetched_source.content_digest");
+  const extractedBytes = Buffer.from(fetched.extracted, "utf8");
+  const extractedDigest = `sha256:${createHash("sha256").update(extractedBytes).digest("hex")}`;
+  if (extractedDigest !== fetchedDigest || extractedBytes.length !== fetched.provenance?.bytes) {
+    throw new Error("web-fetch text extraction differs from the fetched bytes; source must be compact UTF-8 JSON with no extractor transformations.");
+  }
+  let document;
+  try {
+    document = JSON.parse(fetched.extracted);
+  } catch {
+    throw new Error("fetched statement must be valid JSON.");
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    throw new Error("fetched statement must be a JSON object.");
+  }
+  if (!Array.isArray(document.transactions)) {
+    throw new Error("fetched statement must contain transactions[].");
+  }
+
+  const provenance = fetched.provenance && typeof fetched.provenance === "object" && !Array.isArray(fetched.provenance)
+    ? fetched.provenance
+    : {};
+  if (!Number.isSafeInteger(provenance.bytes) || provenance.bytes < 1) {
+    throw new Error("web-fetch provenance must include a positive byte count.");
+  }
+  if (provenance.truncated === true) {
+    throw new Error("truncated fetched statements are not accepted.");
+  }
+  return {
+    document,
+    transactions: document.transactions.map((transaction, index) => ({
+      ...transaction,
+      currency: transaction?.currency ?? document.currency,
+      source_ref: `${finalUrlWithoutFragment.href}#transactions[${index}]`,
+    })),
+    evidence: {
+      requested_url: requestedUrl,
+      final_url: finalUrlWithoutFragment.href,
+      status: fetched.status,
+      content_digest: fetchedDigest,
+      fetched_at: safeString(provenance.fetched_at, "fetched_source.provenance.fetched_at", 20, 40),
+      bytes: provenance.bytes,
+      redirects: Array.isArray(provenance.redirects) ? provenance.redirects : [],
+      truncated: false,
+      allowlist: sourceRequest.allowlist,
+      exact_hosts_only: true,
+      exact_bytes_verified: true,
+      dataset: document.dataset ? safeString(document.dataset, "fetched_statement.dataset", 1, 160) : null,
+    },
+  };
+}
+
 function directionFor(amountMinor) {
   return amountMinor > 0 ? "inflow" : "outflow";
+}
+
+function realIsoDate(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() + 1 === month
+    && parsed.getUTCDate() === day;
 }
 
 function normalizedMatcherList(value, field) {
@@ -82,7 +192,8 @@ function emitNeedsReview(inputs, diagnostics, reviewItems = []) {
 function main() {
   const inputs = readInputs();
   try {
-    const transactions = inputs.transactions;
+    const fetchedStatement = readFetchedStatement(inputs);
+    const transactions = fetchedStatement.transactions;
     const chart = inputs.chart_of_accounts;
     const prior = inputs.prior_period;
     if (!Array.isArray(transactions) || transactions.length < 1 || transactions.length > 100) {
@@ -100,11 +211,35 @@ function main() {
     for (const field of ["opening_balance_minor", "expected_ending_balance_minor"]) {
       if (!Number.isSafeInteger(prior[field])) throw new Error(`prior_period.${field} must be a safe integer.`);
     }
-    const previousIds = new Set(Array.isArray(prior.previous_transaction_ids) ? prior.previous_transaction_ids.map(String) : []);
-    const knownCounterparties = new Set(Array.isArray(prior.known_counterparties) ? prior.known_counterparties.map(normalizeText) : []);
+    const previousTransactionIds = Array.isArray(prior.previous_transaction_ids)
+      ? prior.previous_transaction_ids.map((value, index) => safeString(value, `prior_period.previous_transaction_ids[${index}]`, 1, 100))
+      : [];
+    const knownCounterpartyValues = Array.isArray(prior.known_counterparties)
+      ? prior.known_counterparties.map((value, index) => safeString(value, `prior_period.known_counterparties[${index}]`, 1, 120))
+      : [];
+    const previousIds = new Set(previousTransactionIds);
+    const knownCounterparties = new Set(knownCounterpartyValues.map(normalizeText));
     const averageAbs = prior.average_abs_amount_minor;
     if (averageAbs !== undefined && (!Number.isSafeInteger(averageAbs) || averageAbs <= 0)) {
       throw new Error("prior_period.average_abs_amount_minor must be a positive safe integer when supplied.");
+    }
+    const normalizedPrior = {
+      currency,
+      opening_balance_minor: prior.opening_balance_minor,
+      expected_ending_balance_minor: prior.expected_ending_balance_minor,
+      previous_transaction_ids: previousTransactionIds,
+      known_counterparties: knownCounterpartyValues,
+      ...(averageAbs === undefined ? {} : { average_abs_amount_minor: averageAbs }),
+    };
+    const sourceCurrency = safeString(fetchedStatement.document.currency, "fetched_statement.currency", 3, 3).toUpperCase();
+    if (sourceCurrency !== currency) throw new Error("fetched statement currency differs from prior_period.currency.");
+    for (const field of ["opening_balance_minor", "expected_ending_balance_minor"]) {
+      if (!Number.isSafeInteger(fetchedStatement.document[field])) {
+        throw new Error(`fetched_statement.${field} must be a safe integer.`);
+      }
+      if (fetchedStatement.document[field] !== normalizedPrior[field]) {
+        throw new Error(`fetched_statement.${field} differs from prior_period.${field}.`);
+      }
     }
 
     const codes = new Set();
@@ -142,7 +277,7 @@ function main() {
       ids.add(id);
       if (previousIds.has(id)) throw new Error(`transaction ${id} already appears in prior_period.previous_transaction_ids.`);
       const date = safeString(raw.date, `transactions[${index}].date`, 10, 10);
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(`${date}T00:00:00Z`))) {
+      if (!realIsoDate(date)) {
         throw new Error(`transactions[${index}].date must be a real YYYY-MM-DD date.`);
       }
       const description = safeString(raw.description, `transactions[${index}].description`, 2, 240);
@@ -202,8 +337,12 @@ function main() {
       decision: "ready",
       transaction_digest: digest(normalizedTransactions),
       chart_digest: digest(normalizedChart),
-      prior_period_digest: digest(prior),
+      prior_period_digest: digest(normalizedPrior),
       currency,
+      transactions: normalizedTransactions,
+      chart_of_accounts: normalizedChart,
+      prior_period: normalizedPrior,
+      source: fetchedStatement.evidence,
       assignments,
       source_refs: normalizedTransactions.map((item) => item.source_ref),
       anomaly_inputs: {
@@ -215,6 +354,8 @@ function main() {
         ledger_mutation_performed: false,
         invented_accounts: false,
         unique_binding_required: true,
+        source_fetch_performed: true,
+        source_bytes_verified: true,
       },
       diagnostics: [],
     };

--- a/skills/bookkeeper/admit-source.mjs
+++ b/skills/bookkeeper/admit-source.mjs
@@ -1,0 +1,227 @@
+// Admit only sourced lines with unique existing-account bindings.
+import { createHash } from "node:crypto";
+
+const ACCOUNT_TYPES = new Set(["asset", "liability", "equity", "income", "expense"]);
+const DIRECTIONS = new Set(["inflow", "outflow", "any"]);
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function deepSort(value) {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, deepSort(value[key])]));
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(JSON.stringify(deepSort(value))).digest("hex")}`;
+}
+
+function normalizeText(value) {
+  return String(value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+}
+
+function safeString(value, field, min = 1, max = 160) {
+  const text = String(value || "").trim();
+  if (text.length < min || text.length > max || /[\u0000-\u001f]/.test(text)) {
+    throw new Error(`${field} must contain ${min}-${max} printable characters.`);
+  }
+  return text;
+}
+
+function sourceRef(value, field) {
+  const ref = safeString(value, field, 8, 500);
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(ref)) throw new Error(`${field} must be an absolute source URI.`);
+  return ref;
+}
+
+function directionFor(amountMinor) {
+  return amountMinor > 0 ? "inflow" : "outflow";
+}
+
+function normalizedMatcherList(value, field) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 12) throw new Error(`${field} must be an array with at most 12 items.`);
+  return value.map((item, index) => normalizeText(safeString(item, `${field}[${index}]`, 2, 64)));
+}
+
+function accountCandidate(transaction, account) {
+  const direction = directionFor(transaction.amount_minor);
+  if (account.match.direction !== "any" && account.match.direction !== direction) return null;
+  const description = normalizeText(transaction.description);
+  const counterparty = normalizeText(transaction.counterparty);
+  const descriptionEvidence = account.match.description_contains.filter((phrase) => description.includes(phrase));
+  const counterpartyEvidence = account.match.counterparty_exact.filter((name) => counterparty === name);
+  const score = descriptionEvidence.length * 2 + counterpartyEvidence.length * 3;
+  if (score === 0) return null;
+  return {
+    account_code: account.code,
+    score,
+    description_evidence: descriptionEvidence,
+    counterparty_evidence: counterpartyEvidence,
+  };
+}
+
+function emitNeedsReview(inputs, diagnostics, reviewItems = []) {
+  const admission = {
+    schema: "runx.bookkeeper.admission.v1",
+    decision: "needs_review",
+    diagnostics,
+    needs_review: reviewItems,
+    controls: {
+      read_only: true,
+      ledger_mutation_performed: false,
+      invented_accounts: false,
+    },
+  };
+  process.stdout.write(`${JSON.stringify({ admission })}\n`);
+  if (diagnostics[0]) process.stderr.write(`${diagnostics[0].id}: ${diagnostics[0].message}\n`);
+}
+
+function main() {
+  const inputs = readInputs();
+  try {
+    const transactions = inputs.transactions;
+    const chart = inputs.chart_of_accounts;
+    const prior = inputs.prior_period;
+    if (!Array.isArray(transactions) || transactions.length < 1 || transactions.length > 100) {
+      throw new Error("transactions must contain 1-100 sourced lines.");
+    }
+    if (!Array.isArray(chart) || chart.length < 1 || chart.length > 100) {
+      throw new Error("chart_of_accounts must contain 1-100 existing accounts.");
+    }
+    if (!prior || typeof prior !== "object" || Array.isArray(prior)) {
+      throw new Error("prior_period must be an object.");
+    }
+
+    const currency = safeString(prior.currency, "prior_period.currency", 3, 3).toUpperCase();
+    if (!/^[A-Z]{3}$/.test(currency)) throw new Error("prior_period.currency must be an ISO-like three-letter code.");
+    for (const field of ["opening_balance_minor", "expected_ending_balance_minor"]) {
+      if (!Number.isSafeInteger(prior[field])) throw new Error(`prior_period.${field} must be a safe integer.`);
+    }
+    const previousIds = new Set(Array.isArray(prior.previous_transaction_ids) ? prior.previous_transaction_ids.map(String) : []);
+    const knownCounterparties = new Set(Array.isArray(prior.known_counterparties) ? prior.known_counterparties.map(normalizeText) : []);
+    const averageAbs = prior.average_abs_amount_minor;
+    if (averageAbs !== undefined && (!Number.isSafeInteger(averageAbs) || averageAbs <= 0)) {
+      throw new Error("prior_period.average_abs_amount_minor must be a positive safe integer when supplied.");
+    }
+
+    const codes = new Set();
+    const normalizedChart = chart.map((raw, index) => {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error(`chart_of_accounts[${index}] must be an object.`);
+      const code = safeString(raw.code, `chart_of_accounts[${index}].code`, 1, 32);
+      if (codes.has(code)) throw new Error(`chart_of_accounts contains duplicate code ${code}.`);
+      codes.add(code);
+      const name = safeString(raw.name, `chart_of_accounts[${index}].name`, 2, 100);
+      const type = String(raw.type || "").trim().toLowerCase();
+      if (!ACCOUNT_TYPES.has(type)) throw new Error(`chart_of_accounts[${index}].type is unsupported.`);
+      if (!raw.match || typeof raw.match !== "object" || Array.isArray(raw.match)) {
+        throw new Error(`chart_of_accounts[${index}].match must be an object.`);
+      }
+      const direction = String(raw.match.direction || "").trim().toLowerCase();
+      if (!DIRECTIONS.has(direction)) throw new Error(`chart_of_accounts[${index}].match.direction is unsupported.`);
+      const descriptionContains = normalizedMatcherList(raw.match.description_contains, `chart_of_accounts[${index}].match.description_contains`);
+      const counterpartyExact = normalizedMatcherList(raw.match.counterparty_exact, `chart_of_accounts[${index}].match.counterparty_exact`);
+      if (descriptionContains.length + counterpartyExact.length === 0) {
+        throw new Error(`chart_of_accounts[${index}].match needs deterministic evidence.`);
+      }
+      return {
+        code,
+        name,
+        type,
+        match: { direction, description_contains: descriptionContains, counterparty_exact: counterpartyExact },
+      };
+    });
+
+    const ids = new Set();
+    const normalizedTransactions = transactions.map((raw, index) => {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error(`transactions[${index}] must be an object.`);
+      const id = safeString(raw.id, `transactions[${index}].id`, 1, 100);
+      if (ids.has(id)) throw new Error(`transactions contains duplicate id ${id}.`);
+      ids.add(id);
+      if (previousIds.has(id)) throw new Error(`transaction ${id} already appears in prior_period.previous_transaction_ids.`);
+      const date = safeString(raw.date, `transactions[${index}].date`, 10, 10);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(`${date}T00:00:00Z`))) {
+        throw new Error(`transactions[${index}].date must be a real YYYY-MM-DD date.`);
+      }
+      const description = safeString(raw.description, `transactions[${index}].description`, 2, 240);
+      if (!Number.isSafeInteger(raw.amount_minor) || raw.amount_minor === 0) {
+        throw new Error(`transactions[${index}].amount_minor must be a non-zero safe integer.`);
+      }
+      const lineCurrency = safeString(raw.currency, `transactions[${index}].currency`, 3, 3).toUpperCase();
+      if (lineCurrency !== currency) throw new Error(`transaction ${id} currency ${lineCurrency} differs from prior_period currency ${currency}.`);
+      const counterparty = safeString(raw.counterparty, `transactions[${index}].counterparty`, 1, 120);
+      return {
+        id,
+        date,
+        description,
+        amount_minor: raw.amount_minor,
+        currency: lineCurrency,
+        counterparty,
+        source_ref: sourceRef(raw.source_ref, `transactions[${index}].source_ref`),
+      };
+    });
+
+    const assignments = [];
+    const reviewItems = [];
+    for (const transaction of normalizedTransactions) {
+      const candidates = normalizedChart
+        .map((account) => accountCandidate(transaction, account))
+        .filter(Boolean)
+        .sort((a, b) => b.score - a.score || a.account_code.localeCompare(b.account_code));
+      if (candidates.length === 0 || (candidates[1] && candidates[0].score === candidates[1].score)) {
+        reviewItems.push({
+          transaction_id: transaction.id,
+          reason: candidates.length === 0 ? "no_existing_account_match" : "ambiguous_existing_account_match",
+          candidate_account_codes: candidates.filter((item) => !candidates[0] || item.score === candidates[0].score).map((item) => item.account_code),
+        });
+        continue;
+      }
+      const winner = candidates[0];
+      const matchedEvidence = [
+        ...winner.counterparty_evidence.map((value) => `counterparty_exact:${value}`),
+        ...winner.description_evidence.map((value) => `description_contains:${value}`),
+      ];
+      assignments.push({
+        transaction_id: transaction.id,
+        account_code: winner.account_code,
+        confidence: winner.score >= 5 ? 0.99 : winner.score >= 3 ? 0.95 : 0.9,
+        matched_evidence: matchedEvidence,
+        reason: `unique existing-account match ${winner.account_code} using ${matchedEvidence.join(", ")}`,
+      });
+    }
+
+    if (reviewItems.length > 0) {
+      emitNeedsReview(inputs, [{ id: "runx.bookkeeper.account_binding.needs_review", severity: "error", message: `${reviewItems.length} transaction(s) lack a unique existing-account binding.` }], reviewItems);
+      return;
+    }
+
+    const admission = {
+      schema: "runx.bookkeeper.admission.v1",
+      decision: "ready",
+      transaction_digest: digest(normalizedTransactions),
+      chart_digest: digest(normalizedChart),
+      prior_period_digest: digest(prior),
+      currency,
+      assignments,
+      source_refs: normalizedTransactions.map((item) => item.source_ref),
+      anomaly_inputs: {
+        known_counterparties: [...knownCounterparties],
+        average_abs_amount_minor: averageAbs ?? null,
+      },
+      controls: {
+        read_only: true,
+        ledger_mutation_performed: false,
+        invented_accounts: false,
+        unique_binding_required: true,
+      },
+      diagnostics: [],
+    };
+    process.stdout.write(`${JSON.stringify({ admission })}\n`);
+  } catch (error) {
+    emitNeedsReview(inputs, [{ id: "runx.bookkeeper.input.needs_review", severity: "error", message: error instanceof Error ? error.message : String(error) }]);
+  }
+}
+
+main();

--- a/skills/bookkeeper/categorize-lines.mjs
+++ b/skills/bookkeeper/categorize-lines.mjs
@@ -1,0 +1,131 @@
+// Materialize admitted bindings without inventing accounts.
+import { createHash } from "node:crypto";
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function deepSort(value) {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, deepSort(value[key])]));
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(JSON.stringify(deepSort(value))).digest("hex")}`;
+}
+
+function normalizeText(value) {
+  return String(value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+}
+
+function normalizeTransactions(transactions) {
+  return transactions.map((item) => ({
+    id: String(item.id).trim(),
+    date: String(item.date).trim(),
+    description: String(item.description).trim(),
+    amount_minor: item.amount_minor,
+    currency: String(item.currency).trim().toUpperCase(),
+    counterparty: String(item.counterparty).trim(),
+    source_ref: String(item.source_ref).trim(),
+  }));
+}
+
+function normalizeChart(chart) {
+  return chart.map((item) => ({
+    code: String(item.code).trim(),
+    name: String(item.name).trim(),
+    type: String(item.type).trim().toLowerCase(),
+    match: {
+      direction: String(item.match.direction).trim().toLowerCase(),
+      description_contains: (item.match.description_contains || []).map(normalizeText),
+      counterparty_exact: (item.match.counterparty_exact || []).map(normalizeText),
+    },
+  }));
+}
+
+function fail(message) {
+  process.stdout.write(`${JSON.stringify({ categorized_batch: { schema: "runx.bookkeeper.categorized_batch.v1", decision: "needs_review", reason: message } })}\n`);
+  process.stderr.write(`runx.bookkeeper.binding.invalid: ${message}\n`);
+  process.exitCode = 78;
+}
+
+function main() {
+  const inputs = readInputs();
+  const admission = inputs.admission;
+  if (!admission || admission.schema !== "runx.bookkeeper.admission.v1" || admission.decision !== "ready") {
+    fail("A ready source admission is required.");
+    return;
+  }
+  const transactions = normalizeTransactions(inputs.transactions || []);
+  const chart = normalizeChart(inputs.chart_of_accounts || []);
+  if (digest(transactions) !== admission.transaction_digest || digest(chart) !== admission.chart_digest) {
+    fail("Transaction or chart bytes changed after admission.");
+    return;
+  }
+  const transactionById = new Map(transactions.map((item) => [item.id, item]));
+  const accountByCode = new Map(chart.map((item) => [item.code, item]));
+  const categorized = [];
+  for (const assignment of admission.assignments || []) {
+    const transaction = transactionById.get(assignment.transaction_id);
+    const account = accountByCode.get(assignment.account_code);
+    if (!transaction || !account) {
+      fail(`Admitted binding ${assignment.transaction_id} -> ${assignment.account_code} does not resolve.`);
+      return;
+    }
+    categorized.push({
+      transaction_id: transaction.id,
+      date: transaction.date,
+      description: transaction.description,
+      amount_minor: transaction.amount_minor,
+      currency: transaction.currency,
+      counterparty: transaction.counterparty,
+      source_ref: transaction.source_ref,
+      account_code: account.code,
+      account_name: account.name,
+      account_type: account.type,
+      confidence: assignment.confidence,
+      reason: assignment.reason,
+      matched_evidence: assignment.matched_evidence,
+      read_only: true,
+    });
+  }
+  if (categorized.length !== transactions.length || new Set(categorized.map((item) => item.transaction_id)).size !== transactions.length) {
+    fail("Categorization did not produce exactly one binding for every source transaction.");
+    return;
+  }
+
+  const known = new Set(admission.anomaly_inputs?.known_counterparties || []);
+  const averageAbs = admission.anomaly_inputs?.average_abs_amount_minor;
+  const anomalies = [];
+  for (const line of categorized) {
+    if (known.size > 0 && !known.has(normalizeText(line.counterparty))) {
+      anomalies.push({ type: "new_counterparty", severity: "low", transaction_id: line.transaction_id, reason: `${line.counterparty} was not present in prior_period.known_counterparties` });
+    }
+    if (Number.isSafeInteger(averageAbs) && Math.abs(line.amount_minor) > averageAbs * 4) {
+      anomalies.push({ type: "amount_outlier", severity: "medium", transaction_id: line.transaction_id, reason: `absolute amount ${Math.abs(line.amount_minor)} exceeds four times prior average ${averageAbs}` });
+    }
+  }
+
+  const batchBody = {
+    schema: "runx.bookkeeper.categorized_batch.v1",
+    decision: "categorized",
+    categorized,
+    anomalies,
+    source_refs: [...new Set(categorized.map((item) => item.source_ref))],
+    account_universe: chart.map(({ code, name, type }) => ({ code, name, type })),
+    transaction_digest: admission.transaction_digest,
+    chart_digest: admission.chart_digest,
+    prior_period_digest: admission.prior_period_digest,
+    net_movement_minor: categorized.reduce((sum, item) => sum + item.amount_minor, 0),
+    controls: {
+      read_only: true,
+      ledger_mutation_performed: false,
+      invented_accounts: false,
+      one_binding_per_transaction: true,
+    },
+  };
+  process.stdout.write(`${JSON.stringify({ categorized_batch: { ...batchBody, batch_digest: digest(batchBody) } })}\n`);
+}
+
+main();

--- a/skills/bookkeeper/categorize-lines.mjs
+++ b/skills/bookkeeper/categorize-lines.mjs
@@ -57,10 +57,24 @@ function main() {
     fail("A ready source admission is required.");
     return;
   }
-  const transactions = normalizeTransactions(inputs.transactions || []);
-  const chart = normalizeChart(inputs.chart_of_accounts || []);
+  if (
+    !admission.controls?.source_fetch_performed
+    || !admission.controls?.source_bytes_verified
+    || !admission.source?.content_digest
+    || !admission.source?.final_url
+    || !Number.isInteger(admission.source?.status)
+    || admission.source.status < 200
+    || admission.source.status >= 300
+    || admission.source?.exact_bytes_verified !== true
+    || admission.source?.exact_hosts_only !== true
+  ) {
+    fail("Admission must prove an allowlisted runtime source fetch.");
+    return;
+  }
+  const transactions = normalizeTransactions(admission.transactions || []);
+  const chart = normalizeChart(admission.chart_of_accounts || []);
   if (digest(transactions) !== admission.transaction_digest || digest(chart) !== admission.chart_digest) {
-    fail("Transaction or chart bytes changed after admission.");
+    fail("Admitted transaction or chart bytes changed before categorization.");
     return;
   }
   const transactionById = new Map(transactions.map((item) => [item.id, item]));
@@ -112,6 +126,7 @@ function main() {
     decision: "categorized",
     categorized,
     anomalies,
+    source: admission.source,
     source_refs: [...new Set(categorized.map((item) => item.source_ref))],
     account_universe: chart.map(({ code, name, type }) => ({ code, name, type })),
     transaction_digest: admission.transaction_digest,
@@ -123,6 +138,8 @@ function main() {
       ledger_mutation_performed: false,
       invented_accounts: false,
       one_binding_per_transaction: true,
+      source_fetch_performed: true,
+      source_bytes_verified: true,
     },
   };
   process.stdout.write(`${JSON.stringify({ categorized_batch: { ...batchBody, batch_digest: digest(batchBody) } })}\n`);

--- a/skills/bookkeeper/emit-readonly-artifact.mjs
+++ b/skills/bookkeeper/emit-readonly-artifact.mjs
@@ -1,0 +1,52 @@
+// Emit only after the reconciliation consumer proves a complete match.
+import { createHash } from "node:crypto";
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function deepSort(value) {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, deepSort(value[key])]));
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(JSON.stringify(deepSort(value))).digest("hex")}`;
+}
+
+function main() {
+  const inputs = readInputs();
+  const batch = inputs.categorized_batch;
+  const reconciliation = inputs.reconciliation_packet;
+  if (!batch || batch.decision !== "categorized" || !reconciliation || reconciliation.decision !== "reconciled") {
+    process.stderr.write("runx.bookkeeper.emit.denied: consumer-verified reconciliation is required.\n");
+    process.exitCode = 78;
+    return;
+  }
+  if (reconciliation.consumed_batch_digest !== batch.batch_digest) {
+    process.stderr.write("runx.bookkeeper.emit.binding.invalid: reconciliation consumed a different batch.\n");
+    process.exitCode = 78;
+    return;
+  }
+  const resultBody = {
+    schema: "runx.bookkeeper.result.v1",
+    status: "reconciled",
+    categorized: batch.categorized,
+    anomalies: batch.anomalies,
+    reconciliation: reconciliation.reconciliation,
+    source_refs: batch.source_refs,
+    controls: {
+      read_only: true,
+      ledger_mutation_performed: false,
+      invented_accounts: false,
+      categorized_batch_digest: batch.batch_digest,
+      reconciliation_digest: reconciliation.reconciliation_digest,
+      consumer_step: reconciliation.consumer.step,
+      posting_authority: "none",
+    },
+  };
+  process.stdout.write(`${JSON.stringify({ bookkeeper_result: { ...resultBody, artifact_digest: digest(resultBody) } })}\n`);
+}
+
+main();

--- a/skills/bookkeeper/emit-readonly-artifact.mjs
+++ b/skills/bookkeeper/emit-readonly-artifact.mjs
@@ -35,6 +35,7 @@ function main() {
     categorized: batch.categorized,
     anomalies: batch.anomalies,
     reconciliation: reconciliation.reconciliation,
+    source: reconciliation.source,
     source_refs: batch.source_refs,
     controls: {
       read_only: true,
@@ -43,6 +44,8 @@ function main() {
       categorized_batch_digest: batch.batch_digest,
       reconciliation_digest: reconciliation.reconciliation_digest,
       consumer_step: reconciliation.consumer.step,
+      source_fetch_performed: reconciliation.consumer.source_fetch_verified === true,
+      source_bytes_verified: reconciliation.consumer.source_bytes_verified === true,
       posting_authority: "none",
     },
   };

--- a/skills/bookkeeper/evidence/local-harness.json
+++ b/skills/bookkeeper/evidence/local-harness.json
@@ -1,0 +1,47 @@
+{
+  "schema": "runx.bookkeeper.local_harness.v1",
+  "runx_cli_version": "runx-cli 0.7.1",
+  "doctor": {
+    "status": "success",
+    "errors": 0,
+    "warnings": 0
+  },
+  "harness": {
+    "status": "passed",
+    "case_count": 3,
+    "assertion_error_count": 0,
+    "case_names": [
+      "sourced-clean-batch-reconciles",
+      "ambiguous-account-binding-needs-review",
+      "statement-balance-mismatch-needs-review"
+    ],
+    "expected_statuses": [
+      "sealed",
+      "policy_denied",
+      "policy_denied"
+    ],
+    "receipt_ids": [
+      "sha256:3c174f0a4209a8613ae349137aa521482712fe128bb8649847b81a8d2ac21137",
+      "sha256:806cfb838370e7732930acee4283113c016cf87f672e2e25c5fe1387adc10c18",
+      "sha256:6fe0553dc73acea88375f0faa13bad798252785ae53c7eef60512b894206deef"
+    ]
+  },
+  "clean_case_readback": {
+    "categorized_count": 3,
+    "anomaly_count": 1,
+    "reconciliation_matched_count": 3,
+    "reconciliation_unmatched_count": 0,
+    "opening_balance_minor": 250000,
+    "net_movement_minor": 102358,
+    "calculated_ending_balance_minor": 352358,
+    "expected_ending_balance_minor": 352358,
+    "consumer_step": "reconcile-readonly",
+    "ledger_mutation_performed": false,
+    "invented_accounts": false
+  },
+  "refusal_readback": {
+    "ambiguous_reason": "ambiguous_existing_account_match",
+    "statement_mismatch_reason": "opening balance plus consumed transaction movement does not equal expected ending balance",
+    "final_artifact_emitted": false
+  }
+}

--- a/skills/bookkeeper/fixtures/README.md
+++ b/skills/bookkeeper/fixtures/README.md
@@ -1,0 +1,14 @@
+# Bookkeeper fixtures
+
+- `clean-input.json` exercises three uniquely sourced account bindings and an
+  exact statement-balance reconciliation.
+- `ambiguous-input.json` gives two existing accounts the same top score. The
+  admission step returns `needs_review`, and graph policy refuses downstream
+  categorization.
+- `statement-mismatch-input.json` reaches the independent reconciliation
+  consumer but differs from the expected ending balance by one minor unit. The
+  consumer returns `needs_review`, and policy prevents the final artifact.
+
+The post-publish dogfood input is deliberately different from every harness
+fixture. Its `source_ref` values point to a separately published, public input
+artifact, and the reconciliation step consumes the resulting categorizations.

--- a/skills/bookkeeper/fixtures/README.md
+++ b/skills/bookkeeper/fixtures/README.md
@@ -1,14 +1,35 @@
 # Bookkeeper fixtures
 
-- `clean-input.json` exercises three uniquely sourced account bindings and an
-  exact statement-balance reconciliation.
-- `ambiguous-input.json` gives two existing accounts the same top score. The
-  admission step returns `needs_review`, and graph policy refuses downstream
-  categorization.
-- `statement-mismatch-input.json` reaches the independent reconciliation
-  consumer but differs from the expected ending balance by one minor unit. The
-  consumer returns `needs_review`, and policy prevents the final artifact.
+The harness cases live in `X.yaml`. Each case uses a commit-pinned public Gist
+URL and the real canonical `web-fetch` child, so the receipt proves the same
+allowlisted network-read graph used in production:
 
-The post-publish dogfood input is deliberately different from every harness
-fixture. Its `source_ref` values point to a separately published, public input
-artifact, and the reconciliation step consumes the resulting categorizations.
+- `sourced-clean-batch-reconciles` fetches three uniquely matchable rows and
+  seals an exact statement-balance reconciliation.
+- `ambiguous-account-binding-needs-review` fetches one row for which two
+  existing accounts tie. Admission returns `needs_review`, and graph policy
+  refuses downstream categorization.
+- `statement-balance-mismatch-needs-review` fetches one uniquely matchable row
+  but differs from the source statement ending balance by one minor unit. The
+  reconciliation consumer returns `needs_review`, and policy prevents the final
+  artifact.
+- `direct-transaction-input-is-refused` fetches the clean source but also
+  supplies a caller-owned transaction row. Preflight rejects the run before
+  the network step, proving fetched statement bytes are the only accepted
+  transaction source.
+- `wildcard-source-allowlist-is-refused` proves broad wildcard network
+  authority is blocked before `web-fetch`.
+- `lossy-text-extraction-is-refused` fetches an older pretty-printed statement
+  whose readable extraction no longer matches the fetched-body digest.
+  Admission refuses it instead of parsing transformed bytes.
+- `invalid-calendar-date-is-refused` fetches a compact statement containing
+  `2026-02-31`; admission rejects the rollover date before categorization.
+
+The older `*-input.json` files are data-shape samples only; the production
+runner refuses direct `transactions` input.
+
+`dogfood-public-input.json` contains no transaction rows. It names an
+allowlisted public JSON statement, and the live `web-fetch` step retrieves those
+rows during the same run before admission, categorization, and reconciliation.
+All success-path source files are compact UTF-8 JSON so admission can prove the
+extracted bytes exactly match the fetch receipt's byte count and SHA-256 digest.

--- a/skills/bookkeeper/fixtures/ambiguous-input.json
+++ b/skills/bookkeeper/fixtures/ambiguous-input.json
@@ -1,0 +1,11 @@
+{
+  "_fixture": "ambiguous-account-binding-needs-review",
+  "transactions": [
+    {"id":"ambiguous-001","date":"2026-07-04","description":"Cloud platform services","amount_minor":-7500,"currency":"USD","counterparty":"Unknown Platform","source_ref":"fixture://bookkeeper/ambiguous-statement#line-1"}
+  ],
+  "chart_of_accounts": [
+    {"code":"6100","name":"Cloud hosting","type":"expense","match":{"direction":"outflow","description_contains":["cloud"]}},
+    {"code":"6200","name":"Developer tooling","type":"expense","match":{"direction":"outflow","description_contains":["cloud"]}}
+  ],
+  "prior_period": {"currency":"USD","opening_balance_minor":100000,"expected_ending_balance_minor":92500,"previous_transaction_ids":[],"known_counterparties":[],"average_abs_amount_minor":10000}
+}

--- a/skills/bookkeeper/fixtures/clean-input.json
+++ b/skills/bookkeeper/fixtures/clean-input.json
@@ -1,0 +1,14 @@
+{
+  "_fixture": "sourced-clean-batch-reconciles",
+  "transactions": [
+    {"id":"stmt-2026-07-001","date":"2026-07-01","description":"Stripe payout invoice 1042","amount_minor":125000,"currency":"USD","counterparty":"Stripe","source_ref":"fixture://bookkeeper/clean-statement#line-1"},
+    {"id":"stmt-2026-07-002","date":"2026-07-02","description":"AWS cloud hosting July","amount_minor":-18432,"currency":"USD","counterparty":"Amazon Web Services","source_ref":"fixture://bookkeeper/clean-statement#line-2"},
+    {"id":"stmt-2026-07-003","date":"2026-07-03","description":"GitHub Actions usage","amount_minor":-4210,"currency":"USD","counterparty":"GitHub","source_ref":"fixture://bookkeeper/clean-statement#line-3"}
+  ],
+  "chart_of_accounts": [
+    {"code":"4000","name":"Software revenue","type":"income","match":{"direction":"inflow","description_contains":["stripe payout","invoice"],"counterparty_exact":["Stripe"]}},
+    {"code":"6100","name":"Cloud hosting","type":"expense","match":{"direction":"outflow","description_contains":["aws","cloud hosting"],"counterparty_exact":["Amazon Web Services"]}},
+    {"code":"6200","name":"Developer tooling","type":"expense","match":{"direction":"outflow","description_contains":["github actions"],"counterparty_exact":["GitHub"]}}
+  ],
+  "prior_period": {"currency":"USD","opening_balance_minor":250000,"expected_ending_balance_minor":352358,"previous_transaction_ids":["stmt-2026-06-099"],"known_counterparties":["Stripe","Amazon Web Services","GitHub"],"average_abs_amount_minor":30000}
+}

--- a/skills/bookkeeper/fixtures/dogfood-public-input.json
+++ b/skills/bookkeeper/fixtures/dogfood-public-input.json
@@ -1,0 +1,90 @@
+{
+  "transactions": [
+    {
+      "id": "dog-001",
+      "date": "2026-07-08",
+      "description": "Paddle payout subscription batch 775",
+      "amount_minor": 84500,
+      "currency": "USD",
+      "counterparty": "Paddle",
+      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[0]"
+    },
+    {
+      "id": "dog-002",
+      "date": "2026-07-09",
+      "description": "DigitalOcean hosting July",
+      "amount_minor": -12900,
+      "currency": "USD",
+      "counterparty": "DigitalOcean",
+      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[1]"
+    },
+    {
+      "id": "dog-003",
+      "date": "2026-07-10",
+      "description": "Linear collaboration subscription",
+      "amount_minor": -8000,
+      "currency": "USD",
+      "counterparty": "Linear",
+      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[2]"
+    },
+    {
+      "id": "dog-004",
+      "date": "2026-07-11",
+      "description": "Bank interest credit",
+      "amount_minor": 123,
+      "currency": "USD",
+      "counterparty": "Example Bank",
+      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[3]"
+    }
+  ],
+  "chart_of_accounts": [
+    {
+      "code": "4000",
+      "name": "Software revenue",
+      "type": "income",
+      "match": {
+        "direction": "inflow",
+        "description_contains": ["paddle payout"],
+        "counterparty_exact": ["Paddle"]
+      }
+    },
+    {
+      "code": "6100",
+      "name": "Infrastructure",
+      "type": "expense",
+      "match": {
+        "direction": "outflow",
+        "description_contains": ["digitalocean", "hosting"],
+        "counterparty_exact": ["DigitalOcean"]
+      }
+    },
+    {
+      "code": "6200",
+      "name": "Collaboration software",
+      "type": "expense",
+      "match": {
+        "direction": "outflow",
+        "description_contains": ["linear", "collaboration"],
+        "counterparty_exact": ["Linear"]
+      }
+    },
+    {
+      "code": "4200",
+      "name": "Interest income",
+      "type": "income",
+      "match": {
+        "direction": "inflow",
+        "description_contains": ["bank interest"],
+        "counterparty_exact": ["Example Bank"]
+      }
+    }
+  ],
+  "prior_period": {
+    "currency": "USD",
+    "opening_balance_minor": 500000,
+    "expected_ending_balance_minor": 563723,
+    "previous_transaction_ids": [],
+    "known_counterparties": ["Paddle", "DigitalOcean", "Linear"],
+    "average_abs_amount_minor": 20000
+  }
+}

--- a/skills/bookkeeper/fixtures/dogfood-public-input.json
+++ b/skills/bookkeeper/fixtures/dogfood-public-input.json
@@ -1,42 +1,6 @@
 {
-  "transactions": [
-    {
-      "id": "dog-001",
-      "date": "2026-07-08",
-      "description": "Paddle payout subscription batch 775",
-      "amount_minor": 84500,
-      "currency": "USD",
-      "counterparty": "Paddle",
-      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[0]"
-    },
-    {
-      "id": "dog-002",
-      "date": "2026-07-09",
-      "description": "DigitalOcean hosting July",
-      "amount_minor": -12900,
-      "currency": "USD",
-      "counterparty": "DigitalOcean",
-      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[1]"
-    },
-    {
-      "id": "dog-003",
-      "date": "2026-07-10",
-      "description": "Linear collaboration subscription",
-      "amount_minor": -8000,
-      "currency": "USD",
-      "counterparty": "Linear",
-      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[2]"
-    },
-    {
-      "id": "dog-004",
-      "date": "2026-07-11",
-      "description": "Bank interest credit",
-      "amount_minor": 123,
-      "currency": "USD",
-      "counterparty": "Example Bank",
-      "source_ref": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/35a991df549c7cf927ec17be4d0c922904327f4c/bookkeeper-dogfood-source.json#transactions[3]"
-    }
-  ],
+  "source_url": "https://gist.githubusercontent.com/lihonggangli123-cyber/0ca95bb6775c383dc60e1404f097ef50/raw/351c6985a140445fc092b788f22c27b47e5ef551/bookkeeper-dogfood-source.json",
+  "source_allowlist": ["gist.githubusercontent.com"],
   "chart_of_accounts": [
     {
       "code": "4000",

--- a/skills/bookkeeper/fixtures/statement-mismatch-input.json
+++ b/skills/bookkeeper/fixtures/statement-mismatch-input.json
@@ -1,0 +1,10 @@
+{
+  "_fixture": "statement-balance-mismatch-needs-review",
+  "transactions": [
+    {"id":"mismatch-001","date":"2026-07-05","description":"Stripe payout invoice 2001","amount_minor":50000,"currency":"USD","counterparty":"Stripe","source_ref":"fixture://bookkeeper/mismatch-statement#line-1"}
+  ],
+  "chart_of_accounts": [
+    {"code":"4000","name":"Software revenue","type":"income","match":{"direction":"inflow","description_contains":["stripe payout"],"counterparty_exact":["Stripe"]}}
+  ],
+  "prior_period": {"currency":"USD","opening_balance_minor":100000,"expected_ending_balance_minor":149999,"previous_transaction_ids":[],"known_counterparties":["Stripe"],"average_abs_amount_minor":50000}
+}

--- a/skills/bookkeeper/reconcile-readonly.mjs
+++ b/skills/bookkeeper/reconcile-readonly.mjs
@@ -1,0 +1,99 @@
+// Consume categorized lines and independently recompute statement controls.
+import { createHash } from "node:crypto";
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function deepSort(value) {
+  if (Array.isArray(value)) return value.map(deepSort);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, deepSort(value[key])]));
+}
+
+function digest(value) {
+  return `sha256:${createHash("sha256").update(JSON.stringify(deepSort(value))).digest("hex")}`;
+}
+
+function main() {
+  const inputs = readInputs();
+  const batch = inputs.categorized_batch;
+  const prior = inputs.prior_period;
+  if (!batch || batch.schema !== "runx.bookkeeper.categorized_batch.v1" || batch.decision !== "categorized") {
+    process.stderr.write("runx.bookkeeper.reconciliation.invalid: categorized batch is missing.\n");
+    process.exitCode = 78;
+    return;
+  }
+  const accountCodes = new Set((batch.account_universe || []).map((item) => item.code));
+  const matched = [];
+  const unmatched = [];
+  const seen = new Set();
+  let netMovementMinor = 0;
+  for (const line of batch.categorized || []) {
+    if (seen.has(line.transaction_id)) {
+      unmatched.push({ kind: "duplicate_consumer_line", transaction_id: line.transaction_id, reason: "consumer received the same source transaction more than once" });
+      continue;
+    }
+    seen.add(line.transaction_id);
+    if (!accountCodes.has(line.account_code)) {
+      unmatched.push({ kind: "invented_account", transaction_id: line.transaction_id, account_code: line.account_code, reason: "account code is absent from the admitted chart" });
+      continue;
+    }
+    if (!Number.isSafeInteger(line.amount_minor)) {
+      unmatched.push({ kind: "invalid_amount", transaction_id: line.transaction_id, reason: "amount_minor is not a safe integer" });
+      continue;
+    }
+    netMovementMinor += line.amount_minor;
+    matched.push({
+      transaction_id: line.transaction_id,
+      source_ref: line.source_ref,
+      account_code: line.account_code,
+      amount_minor: line.amount_minor,
+      evidence: "existing_account_binding_consumed",
+    });
+  }
+
+  if (matched.length + unmatched.filter((item) => item.transaction_id).length !== (batch.categorized || []).length) {
+    unmatched.push({ kind: "line_coverage", reason: "consumer line coverage differs from categorized batch length" });
+  }
+  const openingBalanceMinor = prior.opening_balance_minor;
+  const expectedEndingBalanceMinor = prior.expected_ending_balance_minor;
+  const calculatedEndingBalanceMinor = openingBalanceMinor + netMovementMinor;
+  if (calculatedEndingBalanceMinor !== expectedEndingBalanceMinor) {
+    unmatched.push({
+      kind: "statement_balance",
+      reason: "opening balance plus consumed transaction movement does not equal expected ending balance",
+      expected_ending_balance_minor: expectedEndingBalanceMinor,
+      calculated_ending_balance_minor: calculatedEndingBalanceMinor,
+      difference_minor: calculatedEndingBalanceMinor - expectedEndingBalanceMinor,
+    });
+  }
+
+  const decision = unmatched.length === 0 ? "reconciled" : "needs_review";
+  const packetBody = {
+    schema: "runx.bookkeeper.reconciliation_packet.v1",
+    decision,
+    reconciliation: {
+      matched,
+      unmatched,
+      totals: {
+        currency: String(prior.currency).toUpperCase(),
+        opening_balance_minor: openingBalanceMinor,
+        net_movement_minor: netMovementMinor,
+        calculated_ending_balance_minor: calculatedEndingBalanceMinor,
+        expected_ending_balance_minor: expectedEndingBalanceMinor,
+      },
+    },
+    consumed_batch_digest: batch.batch_digest,
+    consumer: {
+      step: "reconcile-readonly",
+      recomputed_net_movement: true,
+      verified_account_membership: true,
+      verified_line_coverage: true,
+      ledger_mutation_performed: false,
+    },
+  };
+  process.stdout.write(`${JSON.stringify({ reconciliation_packet: { ...packetBody, reconciliation_digest: digest(packetBody) } })}\n`);
+}
+
+main();

--- a/skills/bookkeeper/reconcile-readonly.mjs
+++ b/skills/bookkeeper/reconcile-readonly.mjs
@@ -24,6 +24,26 @@ function main() {
     process.exitCode = 78;
     return;
   }
+  if (!prior || typeof prior !== "object" || Array.isArray(prior)) {
+    process.stderr.write("runx.bookkeeper.reconciliation.invalid: admitted prior-period controls are missing.\n");
+    process.exitCode = 78;
+    return;
+  }
+  if (
+    !batch.controls?.source_fetch_performed
+    || !batch.controls?.source_bytes_verified
+    || !batch.source?.content_digest
+    || !batch.source?.final_url
+    || !Number.isInteger(batch.source?.status)
+    || batch.source.status < 200
+    || batch.source.status >= 300
+    || batch.source?.exact_bytes_verified !== true
+    || batch.source?.exact_hosts_only !== true
+  ) {
+    process.stderr.write("runx.bookkeeper.reconciliation.invalid: runtime source-fetch evidence is missing.\n");
+    process.exitCode = 78;
+    return;
+  }
   const accountCodes = new Set((batch.account_universe || []).map((item) => item.code));
   const matched = [];
   const unmatched = [];
@@ -84,12 +104,15 @@ function main() {
         expected_ending_balance_minor: expectedEndingBalanceMinor,
       },
     },
+    source: batch.source,
     consumed_batch_digest: batch.batch_digest,
     consumer: {
       step: "reconcile-readonly",
       recomputed_net_movement: true,
       verified_account_membership: true,
       verified_line_coverage: true,
+      source_fetch_verified: true,
+      source_bytes_verified: true,
       ledger_mutation_performed: false,
     },
   };

--- a/skills/bookkeeper/validate-source-request.mjs
+++ b/skills/bookkeeper/validate-source-request.mjs
@@ -1,0 +1,77 @@
+// Validate the exact network authority before the composed web-fetch step runs.
+
+function readInputs() {
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function printableString(value, field, min = 1, max = 500) {
+  const text = String(value || "").trim();
+  if (text.length < min || text.length > max || /[\u0000-\u001f]/u.test(text)) {
+    throw new Error(`${field} must contain ${min}-${max} printable characters.`);
+  }
+  return text;
+}
+
+function exactHost(value, field) {
+  const host = printableString(value, field, 1, 253).toLowerCase();
+  if (host.endsWith(".") || host.includes("*") || !/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(host)) {
+    throw new Error(`${field} must be an exact DNS host without wildcards or a trailing dot.`);
+  }
+  return host;
+}
+
+function emit(sourceRequest) {
+  process.stdout.write(`${JSON.stringify({ source_request: sourceRequest })}\n`);
+}
+
+function main() {
+  const inputs = readInputs();
+  try {
+    if (inputs.transactions !== undefined) {
+      throw new Error("transactions must be fetched from source_url; direct transaction input is not accepted.");
+    }
+    if (!Array.isArray(inputs.source_allowlist) || inputs.source_allowlist.length < 1 || inputs.source_allowlist.length > 10) {
+      throw new Error("source_allowlist must contain 1-10 exact hosts.");
+    }
+    const allowlist = [...new Set(inputs.source_allowlist.map((value, index) => exactHost(value, `source_allowlist[${index}]`)))];
+    const url = new URL(printableString(inputs.source_url, "source_url"));
+    if (!new Set(["http:", "https:"]).has(url.protocol)) {
+      throw new Error("source_url must use http or https.");
+    }
+    if (url.username || url.password) {
+      throw new Error("source_url must not contain credentials.");
+    }
+    url.hash = "";
+    const host = exactHost(url.hostname, "source_url host");
+    if (!allowlist.includes(host)) {
+      throw new Error("source_url host must appear exactly in source_allowlist.");
+    }
+    emit({
+      schema: "runx.bookkeeper.source_request.v1",
+      decision: "ready",
+      url: url.href,
+      host,
+      allowlist,
+      controls: {
+        exact_hosts_only: true,
+        credentials_present: false,
+        direct_transactions_present: false,
+      },
+    });
+  } catch (error) {
+    emit({
+      schema: "runx.bookkeeper.source_request.v1",
+      decision: "needs_review",
+      diagnostics: [{
+        id: "runx.bookkeeper.source_request.needs_review",
+        severity: "error",
+        message: error instanceof Error ? error.message : String(error),
+      }],
+      controls: {
+        exact_hosts_only: false,
+      },
+    });
+  }
+}
+
+main();


### PR DESCRIPTION
## What changed

- compose the canonical `web-fetch` skill and fetch statement rows during the governed run;
- validate exact-host network authority before any network access;
- bind final URL, HTTP status, byte count, SHA-256 digest, and redirects into the bookkeeping evidence chain;
- reject direct caller-supplied transactions, wildcard hosts, transformed source bytes, ambiguous bindings, balance mismatches, and invalid calendar dates;
- make categorization and reconciliation consume only admission-owned fetched data.

## Why

The original implementation accepted pre-parsed `transactions[]` and treated source URLs as labels. That made the source read inert: receipts could not prove that categorized rows came from the referenced statement.

This revision performs the allowlisted source read in the same run and requires the extracted UTF-8 bytes to reproduce the fetch receipt's byte count and content digest before parsing.

## Validation

- `@runxhq/cli@0.7.1 doctor ./skills/bookkeeper`
- seven-case Linux harness with zero assertion errors:
  - clean reconciliation;
  - ambiguous account refusal;
  - statement-balance refusal;
  - direct transaction refusal;
  - wildcard allowlist refusal;
  - lossy extraction refusal;
  - invalid calendar-date refusal.
- independent deep adversarial review passed after four findings were repaired.

Signed-off-by: LI HONGGANG <lihonggangli123@gmail.com>
