### PR TITLE
fix Windows harness: Access denied on receipt directory fsync

### DIFF
--- a/crates/runx-runtime/src/receipts/store.rs
+++ b/crates/runx-runtime/src/receipts/store.rs
@@ -1,7 +1,9 @@
 // rust-style-allow: large-file -- local store read/write/index semantics stay
 // together until the receipt-store API finishes the hard-cutover review.
 use std::ffi::OsStr;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
+#[cfg(not(windows))]
+use std::fs::File;
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -759,7 +761,18 @@ fn write_temp_file(path: &Path, contents: &[u8], durable: bool) -> Result<(), st
 }
 
 fn sync_directory(path: &Path) -> Result<(), std::io::Error> {
-    File::open(path)?.sync_all()
+    // On Windows, opening a directory handle and calling sync_all fails with
+    // ERROR_ACCESS_DENIED (os error 5). Receipt bytes are already durable via
+    // file.sync_all() in write_temp_file; skip directory fsync on Windows.
+    #[cfg(windows)]
+    {
+        let _ = path;
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    {
+        File::open(path)?.sync_all()
+    }
 }
 
 fn temp_file_name(file_name: &str) -> String {


### PR DESCRIPTION
## Problem
On Windows, \unx harness\ seals receipt JSON files then fails every case with:

\\\
receipt store is unreadable: Access is denied. (os error 5)
\\\

Root cause: \sync_directory\ opens the receipt directory and calls \sync_all()\. Windows denies that directory open/fsync path after rename.

## Fix
Skip directory fsync on Windows. Receipt file durability still uses \ile.sync_all()\ in \write_temp_file\ before rename.

## Test plan
- [x] Built patched runx-cli on Windows
- [x] \unx harness ./skills/bookkeeper\ → status passed (was 3/3 failures)

Related: Frantic bookkeeper work / PR #343.
