### PR TITLE
docs: remove stale 'oss/' paths from build walkthroughs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,6 @@ checked-in `examples/hello-world` package so the commands stay tied to the repo.
 Build the native CLI from the OSS workspace:
 
 ```bash
-cd oss
 cargo build --manifest-path crates/Cargo.toml -p runx-cli
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -677,7 +677,7 @@ The package must include `dist/index.js` and `dist/index.d.ts`, and `dist/index.
 
 ## Boundary Rules
 
-- `oss/` must not import from `cloud/`.
+- `oss/` (this repository) must not import from `cloud/` (the private companion workspace, not part of this checkout).
 - State-machine and policy packages remain pure.
 - Rust owns trusted local runtime/execution, including sandbox, receipts,
   policy, authority, payment, harness, built-in adapters, and external

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,7 +12,6 @@ The npm CLI package is `@runxhq/cli` and exposes the `runx` binary.
 Start with the checked-in hello-world skill:
 
 ```bash
-cd oss
 cargo build --manifest-path crates/Cargo.toml -p runx-cli
 export RUNX_RECEIPT_DIR="$(mktemp -d)"
 crates/target/debug/runx skill examples/hello-world \
@@ -668,9 +667,9 @@ coverage.
 ## Build And Pack
 
 ```bash
-pnpm --dir oss build
-pnpm --dir oss test tests/cli-package.test.ts
-cd oss/packages/cli
+pnpm build
+pnpm test tests/cli-package.test.ts
+cd packages/cli
 npm pack --dry-run --json
 ```
 

--- a/docs/skill-to-graph.md
+++ b/docs/skill-to-graph.md
@@ -104,7 +104,6 @@ The gates are intentionally narrow:
 Use the graph harness as the executable contract:
 
 ```bash
-cd oss
 cargo build --manifest-path crates/Cargo.toml -p runx-cli
 crates/target/debug/runx harness examples/hello-graph/harness.yaml --json
 ```


### PR DESCRIPTION
Fixes #359.

The getting-started guide tells new contributors to `cd oss` before building, but there is no `oss/` directory in this repository — the checkout root is already the OSS workspace, so the first command fails on a fresh clone. The same stale layout appears in three docs:

- `docs/getting-started.md`: drop the `cd oss` step before `cargo build`
- `docs/reference.md`: drop the same `cd oss` step, and fix `pnpm --dir oss build` / `pnpm --dir oss test` / `cd oss/packages/cli` to run from the clone root (`pnpm build`, `pnpm test`, `cd packages/cli`)
- `docs/skill-to-graph.md`: drop the `cd oss` step

Each command was verified against a fresh clone: the `oss/` paths do not exist, and `crates/Cargo.toml`, `packages/cli`, and the root `package.json` all exist at the locations the fixed commands assume.