### PR TITLE
docs: fix relative links that resolve to non-existent paths

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,7 +45,7 @@ shape. It does not claim real x402 settlement or a real Stripe charge; live
 conformance lanes require dedicated funded testnet wallets or provider test
 credentials. No-secret preflight reports use `can_run: false` and `missing_env`
 to name live blockers without printing secret values. See
-[docs/demos.md](docs/demos.md#payment-demo-gate) for the full split between
+[docs/demos.md](demos.md#payment-demo-gate) for the full split between
 local dogfood and live protocol conformance.
 
 ## Requirements
@@ -73,7 +73,7 @@ pnpm rust:check
 ```
 
 Contributor setup, test selection, and commit sign-off rules are in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+[CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Local CLI
 
@@ -196,7 +196,7 @@ generated-contract layer:
   generated contracts plus narrow process/protocol, host-presentation, and
   bridge packages over language-neutral contracts.
 
-For the generated package export index, see [docs/api-surface.md](docs/api-surface.md).
+For the generated package export index, see [docs/api-surface.md](api-surface.md).
 
 `runx-runtime` is the canonical local runtime. It owns local skill, graph,
 harness, receipt, history, policy, authority, payment, sandbox admission and
@@ -229,7 +229,7 @@ Command-surface ownership:
 | marketplace and docs projection | Rust-owned catalog/contracts | generated docs and client views |
 
 Stateful product work should use the governed data-plane shape in
-[docs/governed-data-plane.md](docs/governed-data-plane.md): domain skills own
+[docs/governed-data-plane.md](governed-data-plane.md): domain skills own
 meaning, while provider adapters execute bounded reads, append-only event
 writes, and projection reads.
 
@@ -307,7 +307,7 @@ command, and there is no privileged `runx docs ...` path inside the engine.
 
 `issue-to-pr` follows the same boundary. runx owns the generic source-thread to
 scafld to PR machinery; service repos own Slack, Sentry, owner assignment, and
-publish policy. See [docs/issue-to-pr.md](docs/issue-to-pr.md).
+publish policy. See [docs/issue-to-pr.md](issue-to-pr.md).
 
 ## Standalone Skill Packages
 

--- a/docs/rust-kernel-architecture.md
+++ b/docs/rust-kernel-architecture.md
@@ -435,7 +435,7 @@ is revisited as a follow-up spec; it does not constrain this plan.
 
 ## 10. Rust-side boundary enforcement
 
-The TypeScript boundary script ([oss/scripts/check-boundaries.mjs](../scripts/check-boundaries.mjs))
+The TypeScript boundary script ([scripts/check-boundaries.mjs](../scripts/check-boundaries.mjs))
 forbids node APIs from `policy` and `state-machine` packages. The Rust side
 needs the same discipline. Layered enforcement:
 
@@ -771,7 +771,7 @@ lints are required; style churn is not.
 
 ## References
 
-- [docs/trusted-kernel-package-truth.md](../../docs/trusted-kernel-package-truth.md)
+- [docs/trusted-kernel-package-truth.md](trusted-kernel-package-truth.md)
   (repo-root docs)
 - [oss/scripts/check-boundaries.mjs](../scripts/check-boundaries.mjs)
 - [oss/crates/runx-core/src/state_machine.rs](../crates/runx-core/src/state_machine.rs)


### PR DESCRIPTION
Fixes #361.

Several relative links in `docs/reference.md` are written as if resolved from the repository root, but Markdown resolves them relative to the file, so they 404:

- line 48: `docs/demos.md#payment-demo-gate` -> `demos.md#payment-demo-gate`
- line 76: `CONTRIBUTING.md` -> `../CONTRIBUTING.md` (file lives at repo root)
- line 199: `docs/api-surface.md` -> `api-surface.md`
- line 232: `docs/governed-data-plane.md` -> `governed-data-plane.md`
- line 310: `docs/issue-to-pr.md` -> `issue-to-pr.md`

And in `docs/rust-kernel-architecture.md` (line 774): `../../docs/trusted-kernel-package-truth.md` resolved outside the repository; the file exists at `docs/trusted-kernel-package-truth.md`, so the link now uses the same-directory path. The adjacent `oss/scripts/check-boundaries.mjs` link text is updated to match its (already working) target.

Every target file verified present in a fresh clone; every old path confirmed 404.