### PR TITLE
docs: correct the minimum Rust version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The full DCO text (reproduced here for reference):
 
 ## Development setup
 
-The native Rust CLI needs Rust 1.95 or newer and stays useful without Node, pnpm, tsx, or TypeScript installed. The workspace and the npm wrapper need Node.js 20 or newer and pnpm 10 or newer.
+The native Rust CLI needs Rust 1.97 or newer and stays useful without Node, pnpm, tsx, or TypeScript installed. The workspace and the npm wrapper need Node.js 20 or newer and pnpm 10 or newer.
 
 From the OSS workspace:
 


### PR DESCRIPTION
Fixes #362.

`CONTRIBUTING.md` (line 66) states the native Rust CLI needs Rust 1.95 or newer, but the workspace enforces a higher floor: `crates/Cargo.toml` sets `rust-version = "1.97"` and `rust-toolchain.toml` pins channel `1.97.1`. A contributor on Rust 1.95 or 1.96 following CONTRIBUTING.md would be stopped by cargo's `rust-version` check.

`docs/getting-started.md` and `docs/reference.md` already say 1.97+, so this one-word change brings CONTRIBUTING.md in line with the enforced toolchain.