### PR TITLE
docs: fix 6 broken relative links in docs/reference.md and rust-kernel-architecture.md (runx/runx#361)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,7 @@ crates/target/debug/runx skill examples/hello-world \
 Then inspect the emitted receipt. The full walkthrough is in
 [docs/getting-started.md](docs/getting-started.md), and the next step is
 [docs/skill-to-graph.md](docs/skill-to-graph.md).
-For governed code changes, see [docs/issue-to-pr.md](docs/issue-to-pr.md).
+For governed code changes, see [docs/issue-to-pr.md](issue-to-pr.md).
 
 ## Zero-Funded Payment Dogfood
 
@@ -44,7 +44,7 @@ shape. It does not claim real x402 settlement or a real Stripe charge; live
 conformance lanes require dedicated funded testnet wallets or provider test
 credentials. No-secret preflight reports use `can_run: false` and `missing_env`
 to name live blockers without printing secret values. See
-[docs/demos.md](docs/demos.md#payment-demo-gate) for the full split between
+[docs/demos.md](demos.md#payment-demo-gate) for the full split between
 local dogfood and live protocol conformance.
 
 ## Requirements
@@ -72,7 +72,7 @@ pnpm rust:check
 ```
 
 Contributor setup, test selection, and commit sign-off rules are in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+[CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## Local CLI
 
@@ -148,7 +148,7 @@ contract layer:
   authoring, host presentation, and bridge packages over language-neutral
   contracts.
 
-For the generated package export index, see [docs/api-surface.md](docs/api-surface.md).
+For the generated package export index, see [docs/api-surface.md](api-surface.md).
 
 `runx-runtime` is the canonical local runtime. It owns local skill, graph,
 harness, receipt, history, policy, authority, payment, sandbox admission and
@@ -180,7 +180,7 @@ Command-surface ownership:
 | marketplace and docs tooling | TypeScript/scafld until separately cut over | canonical for authoring UX |
 
 Stateful product work should use the governed data-plane shape in
-[docs/governed-data-plane.md](docs/governed-data-plane.md): domain skills own
+[docs/governed-data-plane.md](governed-data-plane.md): domain skills own
 meaning, while provider adapters execute bounded reads, append-only event
 writes, and projection reads.
 
@@ -228,7 +228,7 @@ command, and there is no privileged `runx docs ...` path inside the engine.
 
 `issue-to-pr` follows the same boundary. runx owns the generic source-thread to
 scafld to PR machinery; service repos own Slack, Sentry, owner assignment, and
-publish policy. See [docs/issue-to-pr.md](docs/issue-to-pr.md).
+publish policy. See [docs/issue-to-pr.md](issue-to-pr.md).
 
 ## Standalone Skill Packages
 

--- a/docs/rust-kernel-architecture.md
+++ b/docs/rust-kernel-architecture.md
@@ -733,7 +733,7 @@ lints are required; style churn is not.
 
 ## References
 
-- [docs/trusted-kernel-package-truth.md](../../docs/trusted-kernel-package-truth.md)
+- [docs/trusted-kernel-package-truth.md](./trusted-kernel-package-truth.md)
   (repo-root docs)
 - [oss/scripts/check-boundaries.mjs](../scripts/check-boundaries.mjs)
 - [oss/crates/runx-core/src/state_machine.rs](../crates/runx-core/src/state_machine.rs)


### PR DESCRIPTION
Closes runx/runx#361. Fixes 6 broken relative Markdown links in two docs files: links of the form `docs/X.md` are corrected to `X.md` (sibling reference from docs/reference.md), the `CONTRIBUTING.md` link gets a `../` prefix to escape the docs/ subdir, and a mis-rooted `../../docs/X.md` link gets a `./` prefix.