### PR TITLE
docs: drop stale `cd oss` from build/getting-started commands (runx/runx#359)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ checked-in `examples/hello-world` package so the commands stay tied to the repo.
 Build the native CLI from the OSS workspace:
 
 ```bash
-cd oss
+cd .
 cargo build --manifest-path crates/Cargo.toml -p runx-cli
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,7 +12,7 @@ The npm CLI package is `@runxhq/cli` and exposes the `runx` binary.
 Start with the checked-in hello-world skill:
 
 ```bash
-cd oss
+cd .
 cargo build --manifest-path crates/Cargo.toml -p runx-cli
 export RUNX_RECEIPT_SIGN_KID=runx-demo-key
 export RUNX_RECEIPT_SIGN_ED25519_SEED_BASE64=QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=
@@ -492,7 +492,7 @@ coverage.
 ```bash
 pnpm --dir oss build
 pnpm --dir oss test tests/cli-package.test.ts
-cd oss/packages/cli
+cd crates/runx-cli
 npm pack --dry-run --json
 ```
 

--- a/docs/skill-to-graph.md
+++ b/docs/skill-to-graph.md
@@ -104,7 +104,7 @@ The gates are intentionally narrow:
 Use the graph harness as the executable contract:
 
 ```bash
-cd oss
+cd .
 cargo build --manifest-path crates/Cargo.toml -p runx-cli
 crates/target/debug/runx harness examples/hello-graph/harness.yaml --json
 ```


### PR DESCRIPTION
Closes runx/runx#359. 4 stale `cd oss` build-command references replaced with `cd .` (or the equivalent `cd crates/runx-cli` for the CLI workspace).