### PR TITLE
docs(crates): fix public repository links

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -3,8 +3,9 @@
 This workspace contains the Rust packages that back the `runx` distribution:
 contracts, kernel decisions, parser, receipts, the native runtime, the CLI
 binary, and the blocking SDK. Architectural authority lives in
-[`oss/docs/rust-kernel-architecture.md`](../docs/rust-kernel-architecture.md);
-sequencing lives in [`plans/rust-takeover.md`](../../plans/rust-takeover.md).
+[`docs/rust-kernel-architecture.md`](../docs/rust-kernel-architecture.md);
+the current cutover boundary lives in
+[`docs/ts-interop-boundary.md`](../docs/ts-interop-boundary.md).
 
 ## Commands
 
@@ -30,9 +31,8 @@ before they may be added to `deny.toml`.
 - `runx-cli`: native `runx` binary. Hand-rolled dispatcher across `harness`,
   `connect`, `config`, `policy`, `kernel`, `doctor`, `list`, `history`, `mcp`,
   `tool`, `registry`, `skill`, plus project/router plumbing. Activation
-  versus the npm CLI is recorded by the completed
-  [`rust-cli-rust-cutover`](../.scafld/specs/archive/2026-05/rust-cli-rust-cutover.md)
-  spec.
+  versus the npm CLI is documented by the current
+  [TypeScript interop boundary](../docs/ts-interop-boundary.md).
 - `runx-contracts`: pure public contracts for JSON, host protocol, receipts,
   registry/tool records, act assignment, harness spine, generic authority and
   effect finality, target-repo runner planning, and the post-merge observer.


### PR DESCRIPTION
## What changed

- Replace the `crates/README.md` link to the private/missing `plans/rust-takeover.md` file with the public TypeScript interop boundary.
- Replace the link to the missing archived scafld spec with the same current public boundary document.
- Update the architecture link label so it matches the public repository layout.

## Why

The Rust workspace guide retained paths from the project’s earlier monorepo layout. In the public checkout, both referenced files are absent, so readers hit dead links while trying to understand the native CLI cutover.

## Impact

Contributors can now follow every local Markdown link in the Rust workspace guide to current, public documentation.

## Validation

- `git show --check`
- Repository-wide scan of local Markdown link targets: all targets resolve
