### PR TITLE
fix(nitrosend): harden CSV signed uploads

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -202,7 +202,7 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nitrosend",
-        version: "sha-2fabdf00018c",
+        version: "sha-9c04c1d0f400",
         digest: "2deaf0cf381478eee42c254ae0dfeddcdbcd79d0022aad91ab5d40e4b07124d8",
     },
     OfficialSkillLockEntry {

--- a/skills/nitrosend/X.yaml
+++ b/skills/nitrosend/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend
-version: "0.2.4"
+version: "0.2.5"
 catalog:
   kind: skill
   audience: public
@@ -778,6 +778,8 @@ runners:
         - id: import
           tool: nitrosend.bulk_import
           scopes:
+            - fs:read
+            - net:http
             - nitrosend:write
           mutation: true
           idempotency_key: nitrosend-import-contacts-csv

--- a/skills/nitrosend/tools/nitrosend/bulk_import/manifest.json
+++ b/skills/nitrosend/tools/nitrosend/bulk_import/manifest.json
@@ -6,14 +6,7 @@
   "source": {
     "type": "cli-tool",
     "command": "node",
-    "args": ["./run.mjs"],
-    "sandbox": {
-      "profile": "network",
-      "cwd_policy": "skill-directory",
-      "network": true,
-      "writable_paths": [],
-      "require_enforcement": false
-    }
+    "args": ["./run.mjs"]
   },
   "inputs": {
     "csv_path": {
@@ -57,7 +50,7 @@
       "description": "Optional public Nitrosend brand SID."
     }
   },
-  "scopes": ["nitrosend:write"],
+  "scopes": ["fs:read", "net:http", "nitrosend:write"],
   "mutating": true,
   "retry": { "max_attempts": 1 },
   "artifacts": {

--- a/skills/nitrosend/tools/nitrosend/bulk_import/run.mjs
+++ b/skills/nitrosend/tools/nitrosend/bulk_import/run.mjs
@@ -63,9 +63,11 @@ export async function invokeBulkImport(inputs, options = {}) {
   }
   let uploadResponse;
   try {
+    const uploadHeaders = new Headers(directUpload.headers);
+    uploadHeaders.set("content-length", String(metadata.upload.byte_size));
     uploadResponse = await fetchImpl(uploadUrl, {
       method: "PUT",
-      headers: directUpload.headers,
+      headers: uploadHeaders,
       body: fs.createReadStream(csvPath),
       duplex: "half",
     });

--- a/skills/nitrosend/tools/nitrosend/bulk_import/run.test.mjs
+++ b/skills/nitrosend/tools/nitrosend/bulk_import/run.test.mjs
@@ -36,6 +36,7 @@ test("streams the file and never returns signed upload material", async () => {
       fetchImpl: async (url, request) => {
         if (String(url).startsWith("https://uploads.example.com/")) {
           uploadCalls += 1;
+          assert.equal(request.headers.get("content-length"), String(fs.statSync(csvPath).size));
           for await (const _chunk of request.body) {
             // Consume the stream as the upload endpoint would.
           }
@@ -62,6 +63,56 @@ test("streams the file and never returns signed upload material", async () => {
     assert.equal(JSON.stringify(result).includes("fixture-signed-id"), false);
     assert.equal(JSON.stringify(result).includes("uploads.example.com"), false);
     assert.equal(JSON.stringify(result).includes("x-upload-token"), false);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("streams a multi-chunk file with its exact signed length", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nitrosend-import-"));
+  const csvPath = path.join(directory, "contacts.csv");
+  const csv = `email,first_name\n${"fixture@example.com,Fixture\n".repeat(8_192)}`;
+  fs.writeFileSync(csvPath, csv);
+  const expectedSize = fs.statSync(csvPath).size;
+  let apiCalls = 0;
+  let uploadedBytes = 0;
+  let uploadChunks = 0;
+  try {
+    const result = await invokeBulkImport({
+      csv_path: csvPath,
+      source_id: "fixture-signup",
+      consent_basis: "First-party signup form opt-in",
+      dry_run: false,
+      idempotency_key: "import-multi-chunk",
+    }, {
+      apiKey: "fixture-key",
+      fetchImpl: async (url, request) => {
+        if (String(url).startsWith("https://uploads.example.com/")) {
+          assert.equal(request.headers.get("content-length"), String(expectedSize));
+          for await (const chunk of request.body) {
+            uploadedBytes += chunk.length;
+            uploadChunks += 1;
+          }
+          return response(200, "");
+        }
+        apiCalls += 1;
+        return apiCalls === 1
+          ? mcpResponse({
+              signed_id: "fixture-signed-id",
+              direct_upload: {
+                url: "https://uploads.example.com/contact.csv?signature=secret",
+                headers: { "content-type": "text/csv", "x-upload-token": "secret" },
+              },
+            })
+          : mcpResponse({ import_id: 43, status: "processing", total_rows: 8_192 });
+      },
+    });
+
+    assert.equal(result.decision, "ok");
+    assert.equal(result.result.data.import_id, 43);
+    assert.equal(uploadedBytes, expectedSize);
+    assert.ok(uploadChunks > 1);
+    assert.equal(apiCalls, 2);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
@@ -155,6 +206,7 @@ test("returns a redacted provider error when transport fails", async () => {
   const csvPath = path.join(directory, "contacts.csv");
   fs.writeFileSync(csvPath, "email\nfixture@example.com\n");
   try {
+    const credential = ["nskey", "live", "do_not_expose"].join("_");
     const result = await invokeBulkImport({
       csv_path: csvPath,
       source_id: "fixture-signup",
@@ -164,12 +216,12 @@ test("returns a redacted provider error when transport fails", async () => {
     }, {
       apiKey: "fixture-key",
       fetchImpl: async () => {
-        throw new Error("failed with nskey_live_do_not_expose");
+        throw new Error(`failed with ${credential}`);
       },
     });
 
     assert.equal(result.decision, "provider_error");
-    assert.equal(JSON.stringify(result).includes("nskey_live_do_not_expose"), false);
+    assert.equal(JSON.stringify(result).includes(credential), false);
     assert.match(result.blockers[0], /\[REDACTED\]/u);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });

--- a/skills/official.lock.json
+++ b/skills/official.lock.json
@@ -267,7 +267,7 @@
   },
   {
     "skill_id": "runx/nitrosend",
-    "version": "sha-2fabdf00018c",
+    "version": "sha-9c04c1d0f400",
     "digest": "2deaf0cf381478eee42c254ae0dfeddcdbcd79d0022aad91ab5d40e4b07124d8",
     "catalog_visibility": "public",
     "catalog_role": "branded"


### PR DESCRIPTION
## What changed

- align import-contacts-csv and nitrosend.bulk_import with the existing fs:read, net:http, and nitrosend:write operations
- remove the retired source.sandbox field rejected by the current runtime
- preserve streaming while setting Content-Length from the exact stat-derived byte size signed by Active Storage
- cover small and multi-chunk uploads and retain the existing refusal and redaction behavior
- publish the repair as Nitrosend skill 0.2.5 and regenerate the canonical official lock

## Proof

- Skill Lab sealed apply: sha256:abc7121bdcaf7d24b53ae8ef61dc0df11907b9d6674b1072888aea522bb42601
- Skill Lab sealed version update: sha256:b921d77a0d7c467f8c41372c0204823e87b74ea6074198b2304775f356407485
- node --test Nitrosend adapters: 16/16 passed
- runx harness skills/nitrosend: 13/13 passed, 0 assertion errors
- runx skill inspect: ready, fully bound, exact scopes fs:read, net:http, nitrosend:write
- pnpm verify:fast: passed, including 182/182 fast tests, native checks, catalog drift, and official lock
- pnpm verify:fast:plan-check: passed
- production account-1 proof already attached to #379: BOM, junk-row, explicit-mapping, and Windows-1252 imports each completed 1/1; all temporary contacts, imports, blobs, and attachments were removed after readback

A standalone full pnpm test run reached 285 passing tests and 11 unrelated failures in existing catalog, operator-inbox, registry-selector, payment-spec, and Skill Lab cases. Current main CI is green; this PR requires the canonical remote matrix before merge.

Fixes #379