### PR TITLE
feat(skills): add list-hygiene-judge

### DIFF
--- a/skills/list-hygiene-judge/SKILL.md
+++ b/skills/list-hygiene-judge/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: list-hygiene-judge
+description: Judge one contact's engagement decay, bounce evidence, and consent state; persist only a version-bound re-permission or suppression transition and stop safely when evidence or durable readback is unsafe.
+---
+
+# List Hygiene Judge
+
+A stale list is a consent problem before it is a delivery problem. This skill
+reads the contact's durable stream position, judges one bounded transition from
+explicit engagement and consent evidence, and records only `re_permission` or
+`suppress`. It never sends a message, invents consent, or treats an attempted
+write as proof that state changed.
+
+Use `judge` with a configured data source, event-stream resource, contact key,
+current stream version, and a stable idempotency key. Supply bounded engagement
+metrics, the hard-bounce and decay policy, and current consent evidence aligned
+to that same version. Durable history stays in the data source; the runner
+carries only the control values needed for this decision.
+
+The graph reads the projection before deciding. A verified hard bounce becomes
+`suppress` only when policy names suppression. Engagement older than the decay
+threshold becomes `re_permission` only when no active unsubscribe marker is
+present. The append uses optimistic concurrency and the supplied retry key,
+then the graph reads the projection again. A sealed result describes observed
+durable state, not downstream delivery authority.
+
+## Stops and recovery
+
+Missing, unreadable, stale, ambiguous, or version-mismatched evidence returns a
+governed `stop` and emits no transition. An active unsubscribe marker also
+stops automated re-permission. If the append conflicts, disappears, or the
+post-write projection does not show the intended event at the next version,
+`finalize` returns a `readback_mismatch` stop instead of throwing or reporting
+success.
+
+Refresh the contact projection and rebuild evidence against its current
+version before retrying. Reuse the same idempotency key only for the same
+intended transition. Ambiguous bounce recovery and unsubscribe disputes belong
+in a human list-hygiene review lane. Any later send must independently read the
+recorded consent state and refuse suppressed contacts.
+
+## Domain computation
+
+`list-hygiene-judge.mjs` owns only deterministic consent classification and
+readback verification. Runx owns projection reads, compare-and-set append,
+idempotency, isolation, and receipts. The module has no filesystem, network,
+credential, clock, or dispatch authority.

--- a/skills/list-hygiene-judge/X.yaml
+++ b/skills/list-hygiene-judge/X.yaml
@@ -1,0 +1,282 @@
+skill: list-hygiene-judge
+version: "0.1.0"
+
+catalog:
+  kind: graph
+  audience: public
+  visibility: public
+  role: canonical
+  execution: execute
+  completion: runtime_receipt
+  requires_adapter: true
+  approval: conditional
+
+policy:
+  allow:
+    - provider: data-source
+      method: READ
+      scope: runx:data:read
+    - provider: data-source
+      method: APPEND
+      scope: runx:data:append
+  deny:
+    - dispatch
+    - send
+    - raw_sql_from_model
+    - secret_material
+
+harness:
+  cases:
+    - name: sealed-decay-re-permission
+      operator_journeys:
+        - mode: standalone
+          confusors: [campaign-dispatch, send-as]
+          request: Judge a contact whose last engagement is older than the configured decay threshold.
+          expected_outcome: Record one re_permission transition, prove its durable readback, and do not send.
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"local://list-hygiene-judge/decay":{"adapter":"data.sqlite","database_path":".runx/data/list-hygiene-judge-decay.sqlite","resources":{"contact_consent_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: local://list-hygiene-judge/decay
+        resource: contact_consent_events
+        aggregate_id: contact:decay
+        expected_version: 0
+        idempotency_key: contact:decay:consent:v1
+        engagement_history: { opens_count: 2, clicks_count: 1, hard_bounces: 0, recency_days: 121 }
+        bounce_policy: { hard_bounce_action: suppress, decay_threshold_days: 90 }
+        current_consent_state: { state: subscribed, active_unsubscribe_marker: false, evidence_status: read, evidence_version: 0, aggregate_id: "contact:decay" }
+      expect:
+        status: sealed
+        step_outputs:
+          finalize-write:
+            subset:
+              list_hygiene_result:
+                data:
+                  decision: { state: re_permission }
+                  persistence: { append_status: committed, before_version: 0, after_version: 1 }
+                  downstream_send: { status: not_run }
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: sealed-hard-bounce-suppress
+      operator_journeys:
+        - mode: standalone
+          confusors: [re_permission, retain]
+          request: Judge a contact with a verified hard bounce under the suppression policy.
+          expected_outcome: Record one suppress transition, prove its durable readback, and do not send.
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"local://list-hygiene-judge/bounce":{"adapter":"data.sqlite","database_path":".runx/data/list-hygiene-judge-bounce.sqlite","resources":{"contact_consent_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: local://list-hygiene-judge/bounce
+        resource: contact_consent_events
+        aggregate_id: contact:bounce
+        expected_version: 0
+        idempotency_key: contact:bounce:consent:v1
+        engagement_history: { opens_count: 0, clicks_count: 0, hard_bounces: 1, recency_days: 4 }
+        bounce_policy: { hard_bounce_action: suppress, decay_threshold_days: 90 }
+        current_consent_state: { state: subscribed, active_unsubscribe_marker: false, evidence_status: read, evidence_version: 0, aggregate_id: "contact:bounce" }
+      expect:
+        status: sealed
+        step_outputs:
+          finalize-write:
+            subset:
+              list_hygiene_result:
+                data:
+                  decision: { state: suppress }
+                  persistence: { append_status: committed, before_version: 0, after_version: 1 }
+                  downstream_send: { status: not_run }
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: missing-or-stale-evidence-stops
+      operator_journeys:
+        - mode: standalone
+          confusors: [re_permission, suppress]
+          request: Judge a contact whose supplied evidence and expected version are stale.
+          expected_outcome: Return a sealed stop with no append and no send.
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"local://list-hygiene-judge/stale":{"adapter":"data.sqlite","database_path":".runx/data/list-hygiene-judge-stale.sqlite","resources":{"contact_consent_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: local://list-hygiene-judge/stale
+        resource: contact_consent_events
+        aggregate_id: contact:stale
+        expected_version: 7
+        idempotency_key: contact:stale:consent:v8
+        engagement_history: { opens_count: 1, clicks_count: 0, hard_bounces: 0, recency_days: 150 }
+        bounce_policy: { hard_bounce_action: suppress, decay_threshold_days: 90 }
+        current_consent_state: { state: subscribed, active_unsubscribe_marker: false, evidence_status: stale, evidence_version: 6, aggregate_id: "contact:stale" }
+      expect:
+        status: sealed
+        step_outputs:
+          finalize-stop:
+            subset:
+              list_hygiene_result:
+                data:
+                  decision: { state: stop }
+                  persistence: { append_status: not_appended, before_version: 0, after_version: 0 }
+                  downstream_send: { status: not_run }
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: active-unsubscribe-stops
+      operator_journeys:
+        - mode: standalone
+          confusors: [re_permission]
+          request: Judge a decayed contact with an active unsubscribe marker.
+          expected_outcome: Preserve the unsubscribe boundary and return a sealed stop without appending.
+      env:
+        RUNX_DATA_SOURCES: '{"data_sources":{"local://list-hygiene-judge/unsubscribe":{"adapter":"data.sqlite","database_path":".runx/data/list-hygiene-judge-unsubscribe.sqlite","resources":{"contact_consent_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+      inputs:
+        data_source_ref: local://list-hygiene-judge/unsubscribe
+        resource: contact_consent_events
+        aggregate_id: contact:unsubscribe
+        expected_version: 0
+        idempotency_key: contact:unsubscribe:consent:v1
+        engagement_history: { opens_count: 0, clicks_count: 0, hard_bounces: 0, recency_days: 180 }
+        bounce_policy: { hard_bounce_action: suppress, decay_threshold_days: 90 }
+        current_consent_state: { state: unsubscribed, active_unsubscribe_marker: true, evidence_status: read, evidence_version: 0, aggregate_id: "contact:unsubscribe" }
+      expect:
+        status: sealed
+        step_outputs:
+          finalize-stop:
+            subset:
+              list_hygiene_result:
+                data:
+                  decision: { state: stop, reason_code: active_unsubscribe }
+                  persistence: { append_status: not_appended }
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: readback-mismatch-is-governed-stop
+      runner: finalize
+      inputs:
+        transition_plan:
+          aggregate_id: contact:mismatch
+          expected_version: 3
+          projection_version: 3
+          idempotency_key: contact:mismatch:consent:v4
+          decision: { state: suppress, reason_code: verified_hard_bounce }
+          should_append: true
+          event: { type: list_hygiene.consent_transitioned, payload: { new_state: suppress } }
+        append_result: { operation: append_event, status: committed, after_version: 4 }
+        recorded_readback:
+          operation: read_projection
+          projection: { aggregate_id: "contact:mismatch", version: 3, last_event_type: contact.engagement_observed }
+      expect:
+        status: sealed
+        step_outputs:
+          finalize:
+            subset:
+              list_hygiene_result:
+                data:
+                  decision: { state: stop, reason_code: readback_mismatch }
+                  persistence: { append_status: unverified, before_version: 3, after_version: 3 }
+                  downstream_send: { status: not_run }
+        receipt: { schema: runx.receipt.v1 }
+
+runners:
+  decide:
+    type: javascript
+    module: list-hygiene-judge.mjs
+    export: decide
+    inputs:
+      data_source_ref: { type: string, required: true, description: Logical source containing the contact stream. }
+      resource: { type: string, required: true, description: Contact consent event-stream resource. }
+      aggregate_id: { type: string, required: true, description: Contact stream key. }
+      expected_version: { type: number, required: true, description: Durable version required for the transition. }
+      idempotency_key: { type: string, required: true, description: Stable retry key for this intended transition. }
+      engagement_history: { type: json, required: true, description: Bounded engagement and bounce evidence. }
+      bounce_policy: { type: json, required: true, description: Explicit bounce action and decay threshold. }
+      current_consent_state: { type: json, required: true, description: Consent and evidence freshness aligned to the contact version. }
+      contact_readback: { type: json, required: true, description: Durable projection read by the graph before judgment. }
+    outputs:
+      transition_plan: object
+
+  finalize:
+    type: javascript
+    module: list-hygiene-judge.mjs
+    export: finalize
+    inputs:
+      transition_plan: { type: json, required: true, description: Version-bound decision returned by decide. }
+      append_result: { type: json, required: false, description: Conditional data-store append result. }
+      recorded_readback: { type: json, required: true, description: Durable projection read after judgment. }
+    outputs:
+      list_hygiene_result: object
+    artifacts:
+      named_emits:
+        list_hygiene_result: list_hygiene_result
+
+  judge:
+    default: true
+    type: graph
+    inputs:
+      data_source_ref: { type: string, required: true, description: Logical source containing the contact stream. }
+      resource: { type: string, required: true, description: Contact consent event-stream resource. }
+      aggregate_id: { type: string, required: true, description: Contact stream key. }
+      expected_version: { type: number, required: true, description: Durable version required for compare-and-set. }
+      idempotency_key: { type: string, required: true, description: Stable retry key for this intended transition. }
+      engagement_history: { type: json, required: true, description: Bounded engagement and bounce evidence. }
+      bounce_policy: { type: json, required: true, description: Explicit bounce action and decay threshold. }
+      current_consent_state: { type: json, required: true, description: Consent and freshness evidence aligned to expected_version. }
+    graph:
+      name: list-hygiene-judge
+      result_from: [finalize-write, finalize-stop]
+      steps:
+        - id: contact-read
+          tool: data.read_projection
+          scopes: [runx:data:read]
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+
+        - id: decide
+          skill: .
+          runner: decide
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            idempotency_key: "$input.idempotency_key"
+            engagement_history: "$input.engagement_history"
+            bounce_policy: "$input.bounce_policy"
+            current_consent_state: "$input.current_consent_state"
+          context:
+            contact_readback: contact-read.data_operation_result.data
+
+        - id: append
+          when: { field: decide.transition_plan.data.should_append, equals: true }
+          tool: data.append_event
+          mutation: true
+          scopes: [runx:data:append]
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+            expected_version: "$input.expected_version"
+            idempotency_key: "$input.idempotency_key"
+          context:
+            event: decide.transition_plan.data.event
+
+        - id: readback
+          tool: data.read_projection
+          scopes: [runx:data:read]
+          inputs:
+            data_source_ref: "$input.data_source_ref"
+            resource: "$input.resource"
+            aggregate_id: "$input.aggregate_id"
+
+        - id: finalize-write
+          when: { field: decide.transition_plan.data.should_append, equals: true }
+          skill: .
+          runner: finalize
+          context:
+            transition_plan: decide.transition_plan.data
+            append_result: append.data_operation_result.data
+            recorded_readback: readback.data_operation_result.data
+
+        - id: finalize-stop
+          when: { field: decide.transition_plan.data.should_append, equals: false }
+          skill: .
+          runner: finalize
+          inputs:
+            append_result: {}
+          context:
+            transition_plan: decide.transition_plan.data
+            recorded_readback: readback.data_operation_result.data

--- a/skills/list-hygiene-judge/harness/seeded-version.yaml
+++ b/skills/list-hygiene-judge/harness/seeded-version.yaml
@@ -1,0 +1,40 @@
+name: list-hygiene-judge-seeded-version
+owner: runx
+env:
+  RUNX_DATA_SOURCES: '{"data_sources":{"local://list-hygiene-judge/seeded":{"adapter":"data.sqlite","database_path":".runx/data/list-hygiene-judge-seeded.sqlite","resources":{"contact_consent_events":{"kind":"event_stream","partition_key":"aggregate_id"}}}}}'
+steps:
+  - id: seed-contact-history
+    skill: ../../data-store
+    runner: append_event
+    inputs:
+      data_source_ref: local://list-hygiene-judge/seeded
+      resource: contact_consent_events
+      aggregate_id: contact:seeded
+      expected_version: 0
+      idempotency_key: contact:seeded:engagement:v1
+      event:
+        type: contact.engagement_observed
+        payload:
+          aggregate_id: contact:seeded
+          recency_days: 150
+
+  - id: judge-seeded-contact
+    skill: ..
+    runner: judge
+    inputs:
+      data_source_ref: local://list-hygiene-judge/seeded
+      resource: contact_consent_events
+      aggregate_id: contact:seeded
+      expected_version: 1
+      idempotency_key: contact:seeded:consent:v2
+      engagement_history: { opens_count: 1, clicks_count: 0, hard_bounces: 0, recency_days: 150 }
+      bounce_policy: { hard_bounce_action: suppress, decay_threshold_days: 90 }
+      current_consent_state: { state: subscribed, active_unsubscribe_marker: false, evidence_status: read, evidence_version: 1, aggregate_id: "contact:seeded" }
+
+  - id: verify-version-two
+    skill: ../../data-store
+    runner: read_projection
+    inputs:
+      data_source_ref: local://list-hygiene-judge/seeded
+      resource: contact_consent_events
+      aggregate_id: contact:seeded

--- a/skills/list-hygiene-judge/list-hygiene-judge.mjs
+++ b/skills/list-hygiene-judge/list-hygiene-judge.mjs
@@ -1,0 +1,201 @@
+const WRITABLE_STATES = new Set(["re_permission", "suppress"]);
+
+export function decide(inputs) {
+  const aggregateId = nonempty(inputs.aggregate_id);
+  const expectedVersion = nonnegativeInteger(inputs.expected_version);
+  const idempotencyKey = nonempty(inputs.idempotency_key);
+  const engagement = record(inputs.engagement_history);
+  const policy = record(inputs.bounce_policy);
+  const consent = record(inputs.current_consent_state);
+  const contactReadback = record(inputs.contact_readback);
+  const projection = record(contactReadback.projection);
+  const projectionVersion = durableVersion(contactReadback);
+  const problems = [];
+
+  if (contactReadback.operation !== "read_projection") {
+    problems.push("contact_projection_unreadable");
+  }
+  if (!aggregateId || expectedVersion === null || !idempotencyKey) {
+    problems.push("invalid_transition_identity");
+  }
+  if (projection.aggregate_id && projection.aggregate_id !== aggregateId) {
+    problems.push("contact_projection_mismatch");
+  }
+  if (projectionVersion !== expectedVersion) {
+    problems.push("stale_version");
+  }
+
+  for (const key of ["opens_count", "clicks_count", "hard_bounces", "recency_days"]) {
+    if (nonnegativeInteger(engagement[key]) === null) problems.push(`invalid_${key}`);
+  }
+  const decayThreshold = nonnegativeInteger(policy.decay_threshold_days);
+  if (decayThreshold === null || decayThreshold < 1) problems.push("invalid_decay_policy");
+  if (!['suppress', 'human_review'].includes(policy.hard_bounce_action)) {
+    problems.push("invalid_bounce_policy");
+  }
+  if (!['subscribed', 're_permission', 'suppress', 'unsubscribed'].includes(consent.state)) {
+    problems.push("invalid_consent_state");
+  }
+  if (typeof consent.active_unsubscribe_marker !== "boolean") {
+    problems.push("invalid_unsubscribe_evidence");
+  }
+  if (!['read', 'missing', 'unreadable', 'stale', 'ambiguous'].includes(consent.evidence_status)) {
+    problems.push("invalid_evidence_status");
+  } else if (consent.evidence_status !== "read") {
+    problems.push(`${consent.evidence_status}_evidence`);
+  }
+  if (nonnegativeInteger(consent.evidence_version) !== expectedVersion) {
+    problems.push("stale_evidence");
+  }
+  if (consent.aggregate_id && consent.aggregate_id !== aggregateId) {
+    problems.push("consent_contact_mismatch");
+  }
+
+  const base = {
+    aggregate_id: aggregateId,
+    expected_version: expectedVersion,
+    projection_version: projectionVersion,
+    idempotency_key: idempotencyKey,
+  };
+  if (problems.length > 0) {
+    return stopPlan(base, problems[0], problems);
+  }
+  if (consent.active_unsubscribe_marker || consent.state === "unsubscribed") {
+    return stopPlan(base, "active_unsubscribe", ["active_unsubscribe"]);
+  }
+
+  if (engagement.hard_bounces > 0) {
+    if (policy.hard_bounce_action !== "suppress") {
+      return stopPlan(base, "ambiguous_bounce_recovery", ["ambiguous_bounce_recovery"]);
+    }
+    return writePlan(base, consent.state, "suppress", "verified_hard_bounce", {
+      hard_bounces: engagement.hard_bounces,
+      hard_bounce_action: policy.hard_bounce_action,
+    });
+  }
+  if (engagement.recency_days > decayThreshold) {
+    return writePlan(base, consent.state, "re_permission", "engagement_decay", {
+      recency_days: engagement.recency_days,
+      decay_threshold_days: decayThreshold,
+      hard_bounces: engagement.hard_bounces,
+    });
+  }
+  return stopPlan(base, "no_transition_required", ["no_transition_required"]);
+}
+
+export function finalize(inputs) {
+  const plan = record(inputs.transition_plan);
+  const appendResult = record(inputs.append_result);
+  const readback = record(inputs.recorded_readback);
+  const projection = record(readback.projection);
+  const projectionVersion = durableVersion(readback);
+  const shouldAppend = plan.should_append === true;
+  const problems = [];
+
+  if (readback.operation !== "read_projection") problems.push("readback_unreadable");
+  if (projection.aggregate_id && projection.aggregate_id !== plan.aggregate_id) {
+    problems.push("readback_contact_mismatch");
+  }
+  if (shouldAppend) {
+    if (appendResult.operation !== "append_event") problems.push("append_not_observed");
+    if (!['committed', 'idempotent'].includes(appendResult.status)) problems.push("append_not_committed");
+    if (appendResult.after_version !== plan.expected_version + 1) problems.push("append_version_mismatch");
+    if (projectionVersion !== plan.expected_version + 1) problems.push("readback_version_mismatch");
+    if (projection.last_event_type !== record(plan.event).type) problems.push("readback_event_mismatch");
+    if (!WRITABLE_STATES.has(record(plan.decision).state)) problems.push("unwritable_transition");
+  } else if (projectionVersion !== plan.projection_version) {
+    problems.push("evidence_changed_during_judgment");
+  }
+
+  if (problems.length > 0) {
+    return {
+      list_hygiene_result: {
+        schema: "runx.list_hygiene_judge.v1",
+        decision: {
+          state: "stop",
+          reason_code: "readback_mismatch",
+          reasons: problems,
+        },
+        planned_decision: plan.decision ?? null,
+        persistence: {
+          append_status: shouldAppend ? "unverified" : "not_appended",
+          before_version: plan.projection_version,
+          after_version: projectionVersion,
+          idempotency_key: plan.idempotency_key,
+        },
+        downstream_send: { status: "not_run" },
+      },
+    };
+  }
+
+  return {
+    list_hygiene_result: {
+      schema: "runx.list_hygiene_judge.v1",
+      decision: plan.decision,
+      planned_decision: plan.decision,
+      persistence: {
+        append_status: shouldAppend ? appendResult.status : "not_appended",
+        before_version: plan.projection_version,
+        after_version: projectionVersion,
+        aggregate_id: plan.aggregate_id,
+        idempotency_key: plan.idempotency_key,
+        event_type: shouldAppend ? plan.event.type : null,
+      },
+      downstream_send: { status: "not_run" },
+    },
+  };
+}
+
+function writePlan(base, fromState, state, reasonCode, evidence) {
+  const event = {
+    type: "list_hygiene.consent_transitioned",
+    payload: {
+      aggregate_id: base.aggregate_id,
+      from_state: fromState,
+      new_state: state,
+      reason_code: reasonCode,
+      evidence,
+      evidence_version: base.expected_version,
+      idempotency_key: base.idempotency_key,
+    },
+  };
+  return {
+    transition_plan: {
+      ...base,
+      decision: { state, reason_code: reasonCode },
+      should_append: true,
+      event,
+    },
+  };
+}
+
+function stopPlan(base, reasonCode, reasons) {
+  return {
+    transition_plan: {
+      ...base,
+      decision: { state: "stop", reason_code: reasonCode, reasons },
+      should_append: false,
+      event: null,
+    },
+  };
+}
+
+function durableVersion(value) {
+  const projection = record(value.projection);
+  for (const candidate of [projection.version, value.after_version, value.current_version]) {
+    if (Number.isInteger(candidate) && candidate >= 0) return candidate;
+  }
+  return 0;
+}
+
+function nonnegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function nonempty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function record(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}


### PR DESCRIPTION
## Summary

- add the public `list-hygiene-judge` skill with a cold-operator manual and a declarative graph
- read the durable contact projection before judgment, persist only `re_permission` or `suppress` through compare-and-set plus a stable idempotency key, then verify durable readback
- declare `contact_readback` explicitly on the decision runner and turn append/readback disagreement into a sealed governed stop rather than an exception or false success
- cover engagement decay, hard-bounce suppression, stale evidence, active unsubscribe, readback mismatch, and a seeded stream whose durable version is greater than zero

## Validation

- `runx skill inspect ./skills/list-hygiene-judge --json`: `status: ok`, `readiness: ready`, fully bound on Runx CLI 0.8.2
- deterministic domain checks exercised re-permission, suppression, stale evidence, unsubscribe, seeded version 1 -> 2, and mismatched readback behavior
- all four commits include the required DCO sign-off
- the published Windows 0.8.2 worker reaches the package cases but cannot install Job Object containment on this host (`Failed to set info for job`), so the native harness cannot honestly be reported as passing locally; Linux CI is expected to provide the authoritative replay

Bounty context: [Frantic #68, list hygiene judge](https://gofrantic.com/bounties/68)
