### PR TITLE
feat: complete CRM cleanup write loop

### DIFF
--- a/skills/crm-cleanup/SKILL.md
+++ b/skills/crm-cleanup/SKILL.md
@@ -14,6 +14,9 @@ the transport's exact before/after records.
 
 The mock transport is deliberate: it demonstrates the complete read/write
 control loop without possessing credentials or mutating a production CRM.
+Harness cases bind deterministic HTTP responses to the public connector URL so
+registry verification does not depend on third-party uptime. A live run still
+fetches that URL through the native network effect.
 
 ## Inputs
 

--- a/skills/crm-cleanup/SKILL.md
+++ b/skills/crm-cleanup/SKILL.md
@@ -1,49 +1,88 @@
 ---
 name: crm-cleanup
-description: Reconcile a call transcript against current CRM records and propose allowlisted field updates, each traced to a verbatim transcript quote, with the write left to a gated CRM operator.
+description: Read current CRM records from a public connector export, reconcile explicit transcript updates against a typed CRM schema, and execute changed fields through a receipt-backed mock CRM transport.
 ---
 
 # CRM Cleanup
 
-Keep pipeline data from rotting after calls without letting an agent write to
-the CRM on vibes. The transcript and the current records are the only
-evidence; the reconciling agent proposes updates, and deterministic code
-enforces the update authority and the evidence trail. The skill never writes;
-the sealed proposal is what a gated CRM operator or human approver consumes.
+Turn post-call notes into a bounded CRM update without trusting stale pasted
+records or claiming a write that never happened. This package reads the current
+record during the run with native `web.fetch`, accepts only explicit update
+directives for fields declared in `crm_schema`, and passes the validated update
+map to an in-memory mock CRM transport. The receipt seals the source digest and
+the transport's exact before/after records.
+
+The mock transport is deliberate: it demonstrates the complete read/write
+control loop without possessing credentials or mutating a production CRM.
+
+## Inputs
+
+- `source_handle`: a typed connector-export handle with `url`, `allowlist`, and
+  the `record_id` to reconcile. The URL must return JSON containing either a
+  top-level record array or `{ "records": [...] }`.
+- `transcript`: call notes or transcript text. Put each update on its own line
+  as `CRM update: field=value`. Optional `Takeaway: ...` lines become the
+  `takeaways` output.
+- `crm_schema`: the record ID field plus an object of writable field
+  definitions. Supported value types are `string`, `number`, and `boolean`;
+  definitions may also constrain enum values, lengths, or numeric ranges.
 
 ## Procedure
 
-1. Native `data.digest` binds the exact transcript and record set.
-2. The reconciling agent proposes field updates from the transcript, each with
-   the target record, field, new value, and a supporting quote.
-3. Deterministic enforcement checks every proposal: the record must exist in
-   the supplied set, the field must be inside `crm_schema.allowed_fields`
-   (out-of-allowlist updates are rejected with a named reason, not silently
-   dropped), the quote must appear verbatim in the transcript, and the value
-   must be non-empty. An unknown record or an invented quote refuses the whole
-   run; nothing partial escapes.
-4. The proposal packet carries each update's `from` value from the supplied
-   records so the downstream write can detect drift before applying.
-
-`write_performed` is always false and the packet names its gate
-(`crm-operator-or-human-approver`). A run with no supported updates seals
-`no_action` rather than inventing work.
+1. Digest the transcript and CRM schema with native `data.digest`.
+2. Fetch `source_handle.url` with native `web.fetch`, enforcing the supplied
+   host allowlist and a bounded response size.
+3. Refuse unsuccessful or truncated reads, malformed JSON, a missing target
+   record, duplicate directives, undeclared fields, and values that do not
+   satisfy the field definition. A refusal performs no write.
+4. Build `field_updates` as an object keyed by the corresponding
+   `crm_schema.fields` key. Each changed field carries its prior value, new
+   typed value, and the exact directive line as evidence.
+5. A separate `write-through-transport` graph step consumes that same field
+   map through the transport export in `crm-cleanup.mjs`. If any value changed,
+   it applies all changes atomically and reports `executed: true`. If no
+   directive changed current state, it reports `executed: false`, with
+   identical before and after records.
+6. A final verifier checks the transport result against the reconciliation
+   plan, then seals `takeaways`, `field_updates`, `write_result`, source
+   provenance, input digests, and validation findings in the typed
+   `crm_cleanup_result` output.
 
 ## Output
 
-`crm_update_proposal` (`runx.crm_update_proposal.v1`) carries `decision`
-(`proposed`, `no_action`, `refused`), `updates` with before and after values
-and evidence quotes, `rejected_updates`, `validation`, and both input digests.
+`crm_cleanup_result` contains:
 
-Inputs are `transcript`, `crm_records`, and `crm_schema`.
+- `decision`: `updated`, `no_action`, or `refused`;
+- `takeaways`: normalized transcript takeaways;
+- `field_updates`: a schema-keyed object of evidence-backed changes;
+- `write_result`: mock transport name, execution status, record ID, applied
+  fields, and exact `before`/`after` records;
+- `source_read`: connector kind, target record, allowlist, requested/final URL,
+  HTTP status, source digest, fetch timestamp, and byte count;
+- transcript/schema digests and deterministic validation findings.
 
-## Agent task contracts
+## Stop conditions
 
-### `crm-cleanup-reconcile`
+- Do not accept records directly from the caller; the runtime source read is
+  the current-state authority.
+- Do not infer an update from conversational prose. Only explicit
+  `CRM update: field=value` lines can write.
+- Do not partially apply a transcript. Any malformed, duplicated,
+  out-of-schema, or type-invalid directive refuses the whole write.
+- Do not describe the mock transport as a production CRM mutation.
+- Never put credentials, customer data, or a private URL in a public fixture.
 
-Read `transcript`, `crm_records`, and `crm_schema` from step inputs. Return
-`update_draft` with `updates`: an array of `record_id`, `field`, `to`, and
-`evidence_quote` entries. Only propose updates the transcript actually
-supports, quote the transcript verbatim, and only target fields inside the
-allowlist. Return an empty `updates` array when the call changes nothing.
-Never invent records, quotes, or values.
+## Worked example
+
+With a source record whose `account_status` is `healthy`, this transcript:
+
+```text
+Takeaway: Rollout is blocked pending an executive review.
+CRM update: account_status=at_risk
+CRM update: next_action=send the Q3 usage report by Friday
+```
+
+produces two schema-keyed updates and a mock-transport result whose before
+record remains `healthy` and whose after record is `at_risk`. Re-running with
+`CRM update: account_status=healthy` against the same source seals `no_action`;
+the transport executes no write and before equals after.

--- a/skills/crm-cleanup/SKILL.md
+++ b/skills/crm-cleanup/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: crm-cleanup
-description: Read current CRM records from a public connector export, reconcile explicit transcript updates against a typed CRM schema, and execute changed fields through a receipt-backed mock CRM transport.
+description: Read current CRM records, extract evidence-backed updates from natural call transcripts, validate them against a bounded CRM schema, and execute only unambiguous changes through a receipt-backed mock transport.
 ---
 
 # CRM Cleanup
 
 Turn post-call notes into a bounded CRM update without trusting stale pasted
 records or claiming a write that never happened. This package reads the current
-record during the run with native `web.fetch`, accepts only explicit update
-directives for fields declared in `crm_schema`, and passes the validated update
-map to an in-memory mock CRM transport. The receipt seals the source digest and
-the transport's exact before/after records.
+record during the run with native `web.fetch`, uses a bounded semantic extraction
+step to propose schema-keyed candidates from ordinary transcript prose, and then
+validates every candidate deterministically before a transport can consume it.
+The receipt seals the source digest, exact evidence quotes, review items, and the
+transport's before/after records.
 
 The mock transport is deliberate: it demonstrates the complete read/write
 control loop without possessing credentials or mutating a production CRM.
@@ -23,32 +24,72 @@ fetches that URL through the native network effect.
 - `source_handle`: a typed connector-export handle with `url`, `allowlist`, and
   the `record_id` to reconcile. The URL must return JSON containing either a
   top-level record array or `{ "records": [...] }`.
-- `transcript`: call notes or transcript text. Put each update on its own line
-  as `CRM update: field=value`. Optional `Takeaway: ...` lines become the
-  `takeaways` output.
+- `transcript`: ordinary call notes or transcript text. Explicit
+  `CRM update: field=value` and `Takeaway: ...` lines remain supported, but are
+  not required; natural statements such as “the health score dropped to 48”
+  may be extracted when the supporting quote and value are unambiguous.
 - `crm_schema`: the record ID field plus an object of writable field
   definitions. Supported value types are `string`, `number`, and `boolean`;
   definitions may also constrain enum values, lengths, or numeric ranges.
+  Optional `aliases` and a `semantic_role` (`status`, `score`, or
+  `next_action`) give the extraction step bounded semantic hints.
+
+## Semantic extraction contract
+
+The `crm-cleanup-extract` agent task receives only `transcript` and
+`crm_schema`. It returns one `extraction_draft` object:
+
+```json
+{
+  "takeaways": ["Exact or directly supported transcript takeaway"],
+  "candidates": [
+    {
+      "field": "exact_schema_key",
+      "to": "typed scalar candidate",
+      "evidence_quote": "Exact non-hedged transcript substring"
+    }
+  ],
+  "review_items": [
+    {
+      "field": "exact_schema_key or unmapped",
+      "evidence_quote": "Exact unresolved transcript substring",
+      "reason": "Why this cannot be written safely"
+    }
+  ]
+}
+```
+
+Extract a candidate only when the transcript clearly states a current value or
+committed next action, the field maps to exactly one declared schema key, the
+value is scalar, and the evidence quote is exact and unhedged. Put possible
+changes that are hedged, conflicting, underspecified, or not uniquely mappable
+in `review_items`. Ordinary discussion and confirmed unchanged state produce no
+candidate. Never invent a field, value, quote, or source record.
 
 ## Procedure
 
 1. Digest the transcript and CRM schema with native `data.digest`.
 2. Fetch `source_handle.url` with native `web.fetch`, enforcing the supplied
    host allowlist and a bounded response size.
-3. Refuse unsuccessful or truncated reads, malformed JSON, a missing target
-   record, duplicate directives, undeclared fields, and values that do not
-   satisfy the field definition. A refusal performs no write.
-4. Build `field_updates` as an object keyed by the corresponding
+3. Ask the bounded `crm-cleanup-extract` agent task for takeaways, candidate
+   field/value pairs, exact transcript evidence quotes, and unresolved review
+   items. This draft is advisory and cannot write.
+4. Deterministically require exact-quote inclusion, schema-authorized field
+   keys, scalar values, supported types, enum/range/length conformance, and one
+   unambiguous value per field. Hedged, conflicting, malformed, or actionable
+   but unmappable prose becomes `needs_review` and refuses the whole write.
+5. Build `field_updates` as an object keyed by the corresponding
    `crm_schema.fields` key. Each changed field carries its prior value, new
-   typed value, and the exact directive line as evidence.
-5. A separate `write-through-transport` graph step consumes that same field
+   typed value, and the exact transcript quote as evidence.
+6. A separate `write-through-transport` graph step consumes that same field
    map through the transport operation in `crm-cleanup.mjs`. If any value changed,
    it applies all changes atomically and reports `executed: true`. If no
-   directive changed current state, it reports `executed: false`, with
-   identical before and after records.
-6. A final verifier checks the transport result against the reconciliation
-   plan, then seals `takeaways`, `field_updates`, `write_result`, source
-   provenance, input digests, and validation findings in the typed
+   accepted candidate changed current state, it reports `executed: false`, with
+   identical before and after records. Refused plans also pass through this step
+   only as a verifiable no-op.
+7. A final verifier checks the transport result against the reconciliation
+   plan, then seals `takeaways`, `needs_review`, `field_updates`, `write_result`,
+   source provenance, input digests, and validation findings in the declared
    `crm_cleanup_result` output.
 
 ## Output
@@ -57,6 +98,8 @@ fetches that URL through the native network effect.
 
 - `decision`: `updated`, `no_action`, or `refused`;
 - `takeaways`: normalized transcript takeaways;
+- `needs_review`: exact transcript excerpts that are hedged, conflicting, or
+  not safely mappable to one writable field;
 - `field_updates`: a schema-keyed object of evidence-backed changes;
 - `write_result`: mock transport name, execution status, record ID, applied
   fields, and exact `before`/`after` records;
@@ -68,10 +111,12 @@ fetches that URL through the native network effect.
 
 - Do not accept records directly from the caller; the runtime source read is
   the current-state authority.
-- Do not infer an update from conversational prose. Only explicit
-  `CRM update: field=value` lines can write.
+- Do not trust the semantic extraction draft by itself. It is accepted only
+  after deterministic quote, field, value, and schema checks.
+- Do not write hedged, conflicting, or actionable-but-unmapped prose. Route it
+  to `needs_review`, clear `field_updates`, and seal a zero-write result.
 - Do not partially apply a transcript. Any malformed, duplicated,
-  out-of-schema, or type-invalid directive refuses the whole write.
+  out-of-schema, type-invalid, or unresolved item refuses the whole write.
 - Do not describe the mock transport as a production CRM mutation.
 - Never put credentials, customer data, or a private URL in a public fixture.
 
@@ -81,11 +126,13 @@ With a source record whose `account_status` is `healthy`, this transcript:
 
 ```text
 Takeaway: Rollout is blocked pending an executive review.
-CRM update: account_status=at_risk
-CRM update: next_action=send the Q3 usage report by Friday
+Dana confirmed the account is now at risk.
+We agreed to send the Q3 usage report by Friday.
 ```
 
 produces two schema-keyed updates and a mock-transport result whose before
 record remains `healthy` and whose after record is `at_risk`. Re-running with
-`CRM update: account_status=healthy` against the same source seals `no_action`;
-the transport executes no write and before equals after.
+“Dana confirmed the account remains healthy and no CRM changes are needed”
+against the same source seals `no_action`; the transport executes no write and
+before equals after. “The account might be at risk” instead seals `refused`,
+places the quote in `needs_review`, and also executes no write.

--- a/skills/crm-cleanup/SKILL.md
+++ b/skills/crm-cleanup/SKILL.md
@@ -42,7 +42,7 @@ fetches that URL through the native network effect.
    `crm_schema.fields` key. Each changed field carries its prior value, new
    typed value, and the exact directive line as evidence.
 5. A separate `write-through-transport` graph step consumes that same field
-   map through the transport export in `crm-cleanup.mjs`. If any value changed,
+   map through the transport operation in `crm-cleanup.mjs`. If any value changed,
    it applies all changes atomically and reports `executed: true`. If no
    directive changed current state, it reports `executed: false`, with
    identical before and after records.

--- a/skills/crm-cleanup/X.yaml
+++ b/skills/crm-cleanup/X.yaml
@@ -1,5 +1,5 @@
 skill: crm-cleanup
-version: "0.2.0"
+version: "0.3.0"
 
 catalog:
   kind: graph
@@ -17,8 +17,8 @@ harness:
       operator_journeys:
         - mode: standalone
           confusors: [lead-enrichment, lead-router]
-          request: Read the current Globex record, reconcile these explicit call updates, and execute the changed CRM fields.
-          expected_outcome: Fetch current state at runtime, execute two schema-authorized changes through the mock CRM transport, and seal before/after evidence.
+          request: Read the current Globex record, reconcile these high-confidence call updates, and execute the changed CRM fields.
+          expected_outcome: Fetch current state at runtime, execute three schema-authorized changes through the mock CRM transport, and seal before/after evidence.
         - mode: composed
           request: Continue from this sealed CRM cleanup result into an operator-controlled production connector.
           expected_outcome: Reuse the sealed source and update evidence without re-deriving or claiming another write.
@@ -33,15 +33,15 @@ harness:
           allowlist: [gist.githubusercontent.com]
           record_id: acct-globex
         transcript: |-
-          Takeaway: Rollout is blocked pending an executive review.
-          CRM update: account_status=at_risk
-          CRM update: next_action=send the Q3 usage report by Friday
+          Dana confirmed the rollout has stalled and the account is now at risk.
+          We agreed to send the Q3 usage report by Friday.
+          The health score dropped to 48.
         crm_schema:
           record_id_field: id
           fields:
-            account_status: { type: string, enum: [healthy, at_risk, churned] }
-            next_action: { type: string, max_length: 500 }
-            health_score: { type: number, minimum: 0, maximum: 100 }
+            account_status: { type: string, enum: [healthy, at_risk, churned], aliases: [account status, account], semantic_role: status }
+            next_action: { type: string, max_length: 500, aliases: [next action, next step, follow up], semantic_role: next_action }
+            health_score: { type: number, minimum: 0, maximum: 100, aliases: [health score], semantic_role: score }
       caller:
         http_responses:
           "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
@@ -66,31 +66,50 @@ harness:
                   }
                 ]
               }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: [Dana confirmed the rollout has stalled and the account is now at risk.]
+              candidates:
+                - field: account_status
+                  to: at_risk
+                  evidence_quote: Dana confirmed the rollout has stalled and the account is now at risk.
+                - field: next_action
+                  to: send the Q3 usage report by Friday
+                  evidence_quote: We agreed to send the Q3 usage report by Friday.
+                - field: health_score
+                  to: 48
+                  evidence_quote: The health score dropped to 48.
+              review_items: []
       expect:
         status: sealed
-        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
               crm_cleanup_result:
                 data:
                   decision: updated
-                  takeaways: [Rollout is blocked pending an executive review.]
+                  takeaways: [Dana confirmed the rollout has stalled and the account is now at risk.]
                   field_updates:
                     account_status:
                       from: healthy
                       to: at_risk
-                      evidence_quote: "CRM update: account_status=at_risk"
+                      evidence_quote: Dana confirmed the rollout has stalled and the account is now at risk.
+                    health_score:
+                      from: 82
+                      to: 48
+                      evidence_quote: The health score dropped to 48.
                     next_action:
                       from: none
                       to: send the Q3 usage report by Friday
-                      evidence_quote: "CRM update: next_action=send the Q3 usage report by Friday"
+                      evidence_quote: We agreed to send the Q3 usage report by Friday.
                   write_result:
                     transport: mock-crm
                     status: applied
                     executed: true
                     record_id: acct-globex
-                    applied_fields: [account_status, next_action]
+                    applied_fields: [account_status, health_score, next_action]
                     writes_attempted: 1
                     writes_completed: 1
                     before:
@@ -102,7 +121,7 @@ harness:
                       id: acct-globex
                       account_status: at_risk
                       next_action: send the Q3 usage report by Friday
-                      health_score: 82
+                      health_score: 48
                   validation: { status: pass, findings: [] }
         receipt: { schema: runx.receipt.v1 }
 
@@ -113,13 +132,11 @@ harness:
           url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
           allowlist: [gist.githubusercontent.com]
           record_id: acct-globex
-        transcript: |-
-          Takeaway: The account remains healthy.
-          CRM update: account_status=healthy
+        transcript: Dana confirmed the account remains healthy and no CRM changes are needed.
         crm_schema:
           record_id_field: id
           fields:
-            account_status: { type: string, enum: [healthy, at_risk, churned] }
+            account_status: { type: string, enum: [healthy, at_risk, churned], aliases: [account status], semantic_role: status }
       caller:
         http_responses:
           "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
@@ -144,9 +161,15 @@ harness:
                   }
                 ]
               }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: [Dana confirmed the account remains healthy and no CRM changes are needed.]
+              candidates: []
+              review_items: []
       expect:
         status: sealed
-        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
@@ -201,9 +224,18 @@ harness:
                   }
                 ]
               }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: []
+              candidates:
+                - field: owner
+                  to: kim
+                  evidence_quote: "CRM update: owner=kim"
+              review_items: []
       expect:
         status: sealed
-        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
@@ -219,7 +251,7 @@ harness:
                   validation:
                     status: fail
                     findings:
-                      - code: directive.field_not_allowed
+                      - code: extraction.field_not_allowed
                         message: owner is not declared in crm_schema.fields.
         receipt: { schema: runx.receipt.v1 }
 
@@ -259,9 +291,18 @@ harness:
                   }
                 ]
               }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: []
+              candidates: []
+              review_items:
+                - field: account_status
+                  evidence_quote: "CRM update: account_status="
+                  reason: The directive has no value.
       expect:
         status: sealed
-        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
@@ -276,8 +317,212 @@ harness:
                   validation:
                     status: fail
                     findings:
-                      - code: directive.malformed
-                        message: "CRM update directives must use CRM update: field=value with a non-empty value."
+                      - code: transcript.needs_review
+                        field: account_status
+                        evidence_quote: "CRM update: account_status="
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: crm-cleanup-routes-hedged-change-to-review
+      inputs:
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: "The account status is probably at risk, but I am not sure."
+        crm_schema:
+          record_id_field: id
+          fields:
+            account_status: { type: string, enum: [healthy, at_risk, churned], aliases: [account status], semantic_role: status }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  }
+                ]
+              }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: []
+              candidates: []
+              review_items:
+                - field: account_status
+                  evidence_quote: "The account status is probably at risk, but I am not sure."
+                  reason: The statement is hedged and requires confirmation.
+      expect:
+        status: sealed
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
+        step_outputs:
+          finalize:
+            subset:
+              crm_cleanup_result:
+                data:
+                  decision: refused
+                  needs_review:
+                    - field: account_status
+                      evidence_quote: "The account status is probably at risk, but I am not sure."
+                  field_updates: {}
+                  write_result:
+                    status: no_op
+                    executed: false
+                    writes_attempted: 0
+                    writes_completed: 0
+                  validation:
+                    status: fail
+                    findings:
+                      - code: transcript.needs_review
+                        field: account_status
+                        evidence_quote: "The account status is probably at risk, but I am not sure."
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: crm-cleanup-routes-actionable-unmapped-prose-to-review
+      inputs:
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: "Please update the CRM after Dana confirms the changed plan."
+        crm_schema:
+          record_id_field: id
+          fields:
+            account_status: { type: string, enum: [healthy, at_risk, churned], aliases: [account status], semantic_role: status }
+            next_action: { type: string, max_length: 500, aliases: [next action, next step, follow up], semantic_role: next_action }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  }
+                ]
+              }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: []
+              candidates: []
+              review_items:
+                - field: unmapped
+                  evidence_quote: "Please update the CRM after Dana confirms the changed plan."
+                  reason: The requested CRM action cannot be mapped confidently to one declared field.
+      expect:
+        status: sealed
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
+        step_outputs:
+          finalize:
+            subset:
+              crm_cleanup_result:
+                data:
+                  decision: refused
+                  needs_review:
+                    - field: unmapped
+                      evidence_quote: "Please update the CRM after Dana confirms the changed plan."
+                  field_updates: {}
+                  write_result:
+                    status: no_op
+                    executed: false
+                    writes_attempted: 0
+                    writes_completed: 0
+                    before: { id: acct-globex, account_status: healthy, next_action: none, health_score: 82 }
+                    after: { id: acct-globex, account_status: healthy, next_action: none, health_score: 82 }
+                  validation:
+                    status: fail
+                    findings:
+                      - code: transcript.needs_review
+                        field: unmapped
+                        evidence_quote: "Please update the CRM after Dana confirms the changed plan."
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: crm-cleanup-routes-conflicting-values-to-review
+      inputs:
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: "Dana confirmed the account status is healthy. Later she confirmed the account status is at risk."
+        crm_schema:
+          record_id_field: id
+          fields:
+            account_status: { type: string, enum: [healthy, at_risk, churned], aliases: [account status], semantic_role: status }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  }
+                ]
+              }
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: []
+              candidates:
+                - field: account_status
+                  to: healthy
+                  evidence_quote: "Dana confirmed the account status is healthy."
+                - field: account_status
+                  to: at_risk
+                  evidence_quote: "Later she confirmed the account status is at risk."
+              review_items: []
+      expect:
+        status: sealed
+        steps: [digest-transcript, digest-schema, read-current, extract, reconcile, write-through-transport, finalize]
+        step_outputs:
+          finalize:
+            subset:
+              crm_cleanup_result:
+                data:
+                  decision: refused
+                  needs_review:
+                    - field: account_status
+                      evidence_quote: "Later she confirmed the account status is at risk."
+                  field_updates: {}
+                  write_result:
+                    status: no_op
+                    executed: false
+                    writes_attempted: 0
+                    writes_completed: 0
+                    before: { id: acct-globex, account_status: healthy, next_action: none, health_score: 82 }
+                    after: { id: acct-globex, account_status: healthy, next_action: none, health_score: 82 }
+                  validation:
+                    status: fail
+                    findings:
+                      - code: transcript.needs_review
+                        field: account_status
+                        evidence_quote: "Later she confirmed the account status is at risk."
         receipt: { schema: runx.receipt.v1 }
 
     - name: crm-cleanup-refuses-unsuccessful-source-read
@@ -298,6 +543,15 @@ harness:
             status: 503
             headers: { content-type: text/plain }
             body: source unavailable
+        answers:
+          agent_task.crm-cleanup-extract.output:
+            extraction_draft:
+              takeaways: []
+              candidates:
+                - field: account_status
+                  to: at_risk
+                  evidence_quote: "CRM update: account_status=at_risk"
+              review_items: []
       expect:
         status: failure
 
@@ -319,7 +573,7 @@ runners:
       transcript:
         type: string
         required: true
-        description: Call transcript with optional Takeaway lines and explicit CRM update field=value directives; bounded to 100000 characters at runtime.
+        description: Natural call transcript with optional Takeaway or explicit CRM update lines; semantic candidates require exact evidence and ambiguous, hedged, conflicting, or unmappable actions route to needs_review without writing.
       crm_schema:
         type: object
         required: true
@@ -350,8 +604,23 @@ runners:
             extract: text
             max_bytes: 1000000
 
+        - id: extract
+          label: extract schema-keyed candidates and unresolved review items from natural transcript prose
+          inputs:
+            transcript: $input.transcript
+            crm_schema: $input.crm_schema
+          run:
+            type: agent-task
+            agent: growth
+            task: crm-cleanup-extract
+            outputs:
+              extraction_draft: object
+          artifacts:
+            named_emits:
+              extraction_draft: extraction_draft
+
         - id: reconcile
-          label: validate transcript directives and prepare the schema-keyed update plan
+          label: validate the semantic extraction and prepare the schema-keyed update plan
           inputs:
             source_handle: $input.source_handle
             transcript: $input.transcript
@@ -360,6 +629,7 @@ runners:
             source_read: read-current.fetch_result.data
             transcript_digest: digest-transcript.digest_result.data.digest
             crm_schema_digest: digest-schema.digest_result.data.digest
+            extraction_draft: extract.extraction_draft.data
           run:
             type: cli-tool
             command: node
@@ -399,11 +669,13 @@ runners:
             outputs:
               crm_cleanup_result: object
               takeaways: array
+              needs_review: array
               field_updates: object
               write_result: object
           artifacts:
             named_emits:
               crm_cleanup_result: crm_cleanup_result
               takeaways: takeaways
+              needs_review: needs_review
               field_updates: field_updates
               write_result: write_result

--- a/skills/crm-cleanup/X.yaml
+++ b/skills/crm-cleanup/X.yaml
@@ -11,58 +11,6 @@ catalog:
   requires_adapter: false
   approval: none
 
-input_definitions:
-  source_handle:
-    type: object
-    required: true
-    description: Public connector-export handle read during this run; no record payload is accepted from the caller.
-    schema:
-      required: [kind, url, allowlist, record_id]
-      additionalProperties: false
-      properties:
-        kind: { type: string, const: connector_export }
-        url: { type: string, format: uri, pattern: '^https://' }
-        allowlist:
-          type: array
-          minItems: 1
-          maxItems: 64
-          uniqueItems: true
-          items: { type: string, minLength: 1, maxLength: 253 }
-        record_id: { type: string, minLength: 1, maxLength: 500 }
-  transcript:
-    type: string
-    required: true
-    description: Call transcript with optional Takeaway lines and explicit CRM update field=value directives.
-    schema: { minLength: 1, maxLength: 100000 }
-  crm_schema:
-    type: object
-    required: true
-    description: Record identity plus typed update authority for each writable CRM field.
-    schema:
-      required: [record_id_field, fields]
-      additionalProperties: false
-      properties:
-        record_id_field: { type: string, pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
-        fields:
-          type: object
-          minProperties: 1
-          maxProperties: 100
-          propertyNames: { pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
-          additionalProperties:
-            type: object
-            required: [type]
-            additionalProperties: false
-            properties:
-              type: { type: string, enum: [string, number, boolean] }
-              enum:
-                type: array
-                minItems: 1
-                maxItems: 100
-                items: { type: [string, number, boolean] }
-              max_length: { type: integer, minimum: 1, maximum: 10000 }
-              minimum: { type: number }
-              maximum: { type: number }
-
 harness:
   cases:
     - name: crm-cleanup-fetches-and-writes-changed-fields
@@ -365,11 +313,17 @@ runners:
     type: graph
     inputs:
       source_handle:
-        definition: source_handle
+        type: object
+        required: true
+        description: Public connector-export handle with kind, HTTPS url, host allowlist, and record_id; record payloads are rejected.
       transcript:
-        definition: transcript
+        type: string
+        required: true
+        description: Call transcript with optional Takeaway lines and explicit CRM update field=value directives; bounded to 100000 characters at runtime.
       crm_schema:
-        definition: crm_schema
+        type: object
+        required: true
+        description: Record ID field and typed string, number, or boolean definitions for each writable CRM field; closed and bounded at runtime.
     graph:
       name: crm-cleanup-reconcile-and-write
       result_from: [finalize]
@@ -411,70 +365,7 @@ runners:
             module: crm-cleanup.mjs
             export: reconcileCleanup
             outputs:
-              cleanup_plan:
-                type: object
-                schema:
-                  required: [decision, reason, takeaways, field_updates, record_id, before, source_read, transcript_digest, crm_schema_digest, validation]
-                  additionalProperties: false
-                  properties:
-                    decision: { type: string, enum: [ready, no_action, refused] }
-                    reason: { type: string, minLength: 1, maxLength: 2000 }
-                    takeaways:
-                      type: array
-                      maxItems: 50
-                      items: { type: string, minLength: 1, maxLength: 4000 }
-                    field_updates:
-                      type: object
-                      maxProperties: 100
-                      propertyNames: { pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
-                      additionalProperties:
-                        type: object
-                        required: [from, to, evidence_quote]
-                        additionalProperties: false
-                        properties:
-                          from: { type: [string, number, boolean, "null"] }
-                          to: { type: [string, number, boolean] }
-                          evidence_quote: { type: string, minLength: 1, maxLength: 4000 }
-                    record_id: { type: string, minLength: 1, maxLength: 500 }
-                    before: { type: object, additionalProperties: true }
-                    source_read:
-                      type: object
-                      required: [handle_kind, record_id, allowlist, requested_url, final_url, status, content_digest, fetched_at, bytes, truncated]
-                      additionalProperties: false
-                      properties:
-                        handle_kind: { type: string, const: connector_export }
-                        record_id: { type: string, minLength: 1, maxLength: 500 }
-                        allowlist:
-                          type: array
-                          minItems: 1
-                          maxItems: 64
-                          uniqueItems: true
-                          items: { type: string, minLength: 1, maxLength: 253 }
-                        requested_url: { type: string, format: uri, pattern: '^https://' }
-                        final_url: { type: string, format: uri, pattern: '^https://' }
-                        status: { type: integer, minimum: 200, maximum: 299 }
-                        content_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
-                        fetched_at: { type: string, format: date-time }
-                        bytes: { type: integer, minimum: 0, maximum: 1000000 }
-                        truncated: { type: boolean, const: false }
-                    transcript_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
-                    crm_schema_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
-                    validation:
-                      type: object
-                      required: [status, findings]
-                      additionalProperties: false
-                      properties:
-                        status: { type: string, enum: [pass, fail] }
-                        findings:
-                          type: array
-                          maxItems: 100
-                          items:
-                            type: object
-                            required: [code, message]
-                            additionalProperties: false
-                            properties:
-                              code: { type: string, minLength: 1, maxLength: 200 }
-                              message: { type: string, minLength: 1, maxLength: 2000 }
+              cleanup_plan: object
           artifacts:
             named_emits:
               cleanup_plan: cleanup_plan
@@ -488,26 +379,7 @@ runners:
             module: crm-cleanup.mjs
             export: applyMockCrmWrite
             outputs:
-              write_result:
-                type: object
-                schema:
-                  required: [transport, operation, status, executed, record_id, applied_fields, writes_attempted, writes_completed, before, after]
-                  additionalProperties: false
-                  properties:
-                    transport: { type: string, const: mock-crm }
-                    operation: { type: string, const: update_fields }
-                    status: { type: string, enum: [applied, no_op] }
-                    executed: { type: boolean }
-                    record_id: { type: string, minLength: 1, maxLength: 500 }
-                    applied_fields:
-                      type: array
-                      maxItems: 100
-                      uniqueItems: true
-                      items: { type: string, pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
-                    writes_attempted: { type: integer, minimum: 0, maximum: 1 }
-                    writes_completed: { type: integer, minimum: 0, maximum: 1 }
-                    before: { type: object, additionalProperties: true }
-                    after: { type: object, additionalProperties: true }
+              write_result: object
           artifacts:
             named_emits:
               write_result: write_result
@@ -522,87 +394,13 @@ runners:
             module: crm-cleanup.mjs
             export: finalizeCleanup
             outputs:
-              crm_cleanup_result:
-                type: object
-                schema:
-                  required: [decision, reason, takeaways, field_updates, write_result, source_read, transcript_digest, crm_schema_digest, validation]
-                  additionalProperties: false
-                  properties:
-                    decision: { type: string, enum: [updated, no_action, refused] }
-                    reason: { type: string, minLength: 1, maxLength: 2000 }
-                    takeaways:
-                      type: array
-                      maxItems: 50
-                      items: { type: string, minLength: 1, maxLength: 4000 }
-                    field_updates:
-                      type: object
-                      maxProperties: 100
-                      propertyNames: { pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
-                      additionalProperties:
-                        type: object
-                        required: [from, to, evidence_quote]
-                        additionalProperties: false
-                        properties:
-                          from: { type: [string, number, boolean, "null"] }
-                          to: { type: [string, number, boolean] }
-                          evidence_quote: { type: string, minLength: 1, maxLength: 4000 }
-                    write_result:
-                      type: object
-                      required: [transport, operation, status, executed, record_id, applied_fields, writes_attempted, writes_completed, before, after]
-                      additionalProperties: false
-                      properties:
-                        transport: { type: string, const: mock-crm }
-                        operation: { type: string, const: update_fields }
-                        status: { type: string, enum: [applied, no_op] }
-                        executed: { type: boolean }
-                        record_id: { type: string, minLength: 1, maxLength: 500 }
-                        applied_fields:
-                          type: array
-                          maxItems: 100
-                          uniqueItems: true
-                          items: { type: string, pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
-                        writes_attempted: { type: integer, minimum: 0, maximum: 1 }
-                        writes_completed: { type: integer, minimum: 0, maximum: 1 }
-                        before: { type: object, additionalProperties: true }
-                        after: { type: object, additionalProperties: true }
-                    source_read:
-                      type: object
-                      required: [handle_kind, record_id, allowlist, requested_url, final_url, status, content_digest, fetched_at, bytes, truncated]
-                      additionalProperties: false
-                      properties:
-                        handle_kind: { type: string, const: connector_export }
-                        record_id: { type: string, minLength: 1, maxLength: 500 }
-                        allowlist:
-                          type: array
-                          minItems: 1
-                          maxItems: 64
-                          uniqueItems: true
-                          items: { type: string, minLength: 1, maxLength: 253 }
-                        requested_url: { type: string, format: uri, pattern: '^https://' }
-                        final_url: { type: string, format: uri, pattern: '^https://' }
-                        status: { type: integer, minimum: 200, maximum: 299 }
-                        content_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
-                        fetched_at: { type: string, format: date-time }
-                        bytes: { type: integer, minimum: 0, maximum: 1000000 }
-                        truncated: { type: boolean, const: false }
-                    transcript_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
-                    crm_schema_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
-                    validation:
-                      type: object
-                      required: [status, findings]
-                      additionalProperties: false
-                      properties:
-                        status: { type: string, enum: [pass, fail] }
-                        findings:
-                          type: array
-                          maxItems: 100
-                          items:
-                            type: object
-                            required: [code, message]
-                            additionalProperties: false
-                            properties:
-                              code: { type: string, minLength: 1, maxLength: 200 }
-                              message: { type: string, minLength: 1, maxLength: 2000 }
+              crm_cleanup_result: object
+              takeaways: array
+              field_updates: object
+              write_result: object
           artifacts:
             named_emits:
               crm_cleanup_result: crm_cleanup_result
+              takeaways: takeaways
+              field_updates: field_updates
+              write_result: write_result

--- a/skills/crm-cleanup/X.yaml
+++ b/skills/crm-cleanup/X.yaml
@@ -1,175 +1,275 @@
 skill: crm-cleanup
-version: "0.1.0"
+version: "0.2.0"
 
 catalog:
   kind: graph
   audience: operator
   visibility: public
   role: canonical
-  execution: plan
+  execution: execute
   completion: runtime_receipt
   requires_adapter: false
   approval: none
 
+input_definitions:
+  source_handle:
+    type: object
+    required: true
+    description: Public connector-export handle read during this run; no record payload is accepted from the caller.
+    schema:
+      required: [kind, url, allowlist, record_id]
+      additionalProperties: false
+      properties:
+        kind: { type: string, const: connector_export }
+        url: { type: string, format: uri, pattern: '^https://' }
+        allowlist:
+          type: array
+          minItems: 1
+          maxItems: 64
+          uniqueItems: true
+          items: { type: string, minLength: 1, maxLength: 253 }
+        record_id: { type: string, minLength: 1, maxLength: 500 }
+  transcript:
+    type: string
+    required: true
+    description: Call transcript with optional Takeaway lines and explicit CRM update field=value directives.
+    schema: { minLength: 1, maxLength: 100000 }
+  crm_schema:
+    type: object
+    required: true
+    description: Record identity plus typed update authority for each writable CRM field.
+    schema:
+      required: [record_id_field, fields]
+      additionalProperties: false
+      properties:
+        record_id_field: { type: string, pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
+        fields:
+          type: object
+          minProperties: 1
+          maxProperties: 100
+          propertyNames: { pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
+          additionalProperties:
+            type: object
+            required: [type]
+            additionalProperties: false
+            properties:
+              type: { type: string, enum: [string, number, boolean] }
+              enum:
+                type: array
+                minItems: 1
+                maxItems: 100
+                items: { type: [string, number, boolean] }
+              max_length: { type: integer, minimum: 1, maximum: 10000 }
+              minimum: { type: number }
+              maximum: { type: number }
+
 harness:
   cases:
-    - name: crm-cleanup-proposes-traced-updates
+    - name: crm-cleanup-fetches-and-writes-changed-fields
       operator_journeys:
         - mode: standalone
           confusors: [lead-enrichment, lead-router]
-          request: Reconcile this call transcript against the CRM records and propose the field updates.
-          expected_outcome: Return allowlisted field updates, each traced to a verbatim transcript quote, with no CRM write performed.
+          request: Read the current Globex record, reconcile these explicit call updates, and execute the changed CRM fields.
+          expected_outcome: Fetch current state at runtime, execute two schema-authorized changes through the mock CRM transport, and seal before/after evidence.
         - mode: composed
-          request: Continue from this sealed update proposal into the CRM write step.
-          expected_outcome: Hand the sealed proposal to the gated CRM operator without re-deriving updates.
+          request: Continue from this sealed CRM cleanup result into an operator-controlled production connector.
+          expected_outcome: Reuse the sealed source and update evidence without re-deriving or claiming another write.
           prior_evidence:
-            - The transcript, records, and sealed proposal supplied by the prior step.
+            - The connector source digest, schema digest, field-keyed update map, and mock-transport before/after result.
           must_not_repeat:
-            - Do not re-reconcile updates already sealed.
+            - Do not fetch the same source or re-run the mock transport when the sealed result is already supplied.
       inputs:
-        transcript: "Call with Globex on renewal. Dana said the rollout stalled and they want an executive review before renewing. Next step agreed: send the Q3 usage report by Friday."
-        crm_records:
-          - id: acct-globex
-            account_status: healthy
-            next_action: none
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: |-
+          Takeaway: Rollout is blocked pending an executive review.
+          CRM update: account_status=at_risk
+          CRM update: next_action=send the Q3 usage report by Friday
         crm_schema:
-          allowed_fields: [account_status, next_action, health_score]
-      caller:
-        answers:
-          agent_task.crm-cleanup-reconcile.output:
-            update_draft:
-              updates:
-                - record_id: acct-globex
-                  field: account_status
-                  to: at_risk
-                  evidence_quote: the rollout stalled and they want an executive review before renewing
-                - record_id: acct-globex
-                  field: next_action
-                  to: send the Q3 usage report by Friday
-                  evidence_quote: "send the Q3 usage report by Friday"
+          record_id_field: id
+          fields:
+            account_status: { type: string, enum: [healthy, at_risk, churned] }
+            next_action: { type: string, max_length: 500 }
+            health_score: { type: number, minimum: 0, maximum: 100 }
       expect:
         status: sealed
-        steps: [digest-transcript, digest-records, reconcile, finalize]
+        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
-              crm_update_proposal:
+              crm_cleanup_result:
                 data:
-                  schema: runx.crm_update_proposal.v1
-                  decision: proposed
-                  write_performed: false
-                  gate: crm-operator-or-human-approver
-                  rejected_updates: []
+                  decision: updated
+                  takeaways: [Rollout is blocked pending an executive review.]
+                  field_updates:
+                    account_status:
+                      from: healthy
+                      to: at_risk
+                      evidence_quote: "CRM update: account_status=at_risk"
+                    next_action:
+                      from: none
+                      to: send the Q3 usage report by Friday
+                      evidence_quote: "CRM update: next_action=send the Q3 usage report by Friday"
+                  write_result:
+                    transport: mock-crm
+                    status: applied
+                    executed: true
+                    record_id: acct-globex
+                    applied_fields: [account_status, next_action]
+                    writes_attempted: 1
+                    writes_completed: 1
+                    before:
+                      id: acct-globex
+                      account_status: healthy
+                      next_action: none
+                      health_score: 82
+                    after:
+                      id: acct-globex
+                      account_status: at_risk
+                      next_action: send the Q3 usage report by Friday
+                      health_score: 82
                   validation: { status: pass, findings: [] }
         receipt: { schema: runx.receipt.v1 }
 
-    - name: crm-cleanup-rejects-unlisted-field
+    - name: crm-cleanup-no-op-does-not-write
       inputs:
-        transcript: "Owner said move the account to Kim."
-        crm_records:
-          - id: acct-1
-            owner: lee
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: |-
+          Takeaway: The account remains healthy.
+          CRM update: account_status=healthy
         crm_schema:
-          allowed_fields: [next_action]
-      caller:
-        answers:
-          agent_task.crm-cleanup-reconcile.output:
-            update_draft:
-              updates:
-                - record_id: acct-1
-                  field: owner
-                  to: kim
-                  evidence_quote: move the account to Kim
+          record_id_field: id
+          fields:
+            account_status: { type: string, enum: [healthy, at_risk, churned] }
       expect:
         status: sealed
-        steps: [digest-transcript, digest-records, reconcile, finalize]
+        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
-              crm_update_proposal:
+              crm_cleanup_result:
                 data:
                   decision: no_action
-                  updates: []
-                  rejected_updates:
-                    - record_id: acct-1
-                      field: owner
-                      reason: field is outside the crm_schema allowlist
+                  field_updates: {}
+                  write_result:
+                    status: no_op
+                    executed: false
+                    applied_fields: []
+                    writes_attempted: 0
+                    writes_completed: 0
+                    before: { id: acct-globex, account_status: healthy }
+                    after: { id: acct-globex, account_status: healthy }
                   validation: { status: pass, findings: [] }
         receipt: { schema: runx.receipt.v1 }
 
-    - name: crm-cleanup-refuses-invented-quote
+    - name: crm-cleanup-refuses-field-outside-schema
       inputs:
-        transcript: "Short call, no changes discussed."
-        crm_records:
-          - id: acct-1
-            account_status: healthy
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: "CRM update: owner=kim"
         crm_schema:
-          allowed_fields: [account_status]
-      caller:
-        answers:
-          agent_task.crm-cleanup-reconcile.output:
-            update_draft:
-              updates:
-                - record_id: acct-1
-                  field: account_status
-                  to: at_risk
-                  evidence_quote: customer threatened to churn immediately
+          record_id_field: id
+          fields:
+            account_status: { type: string }
       expect:
         status: sealed
-        steps: [digest-transcript, digest-records, reconcile, finalize]
+        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
         step_outputs:
           finalize:
             subset:
-              crm_update_proposal:
+              crm_cleanup_result:
                 data:
                   decision: refused
-                  updates: []
-                  validation: { status: fail }
+                  field_updates: {}
+                  write_result:
+                    status: no_op
+                    executed: false
+                    writes_attempted: 0
+                    writes_completed: 0
+                  validation:
+                    status: fail
+                    findings:
+                      - code: directive.field_not_allowed
+                        message: owner is not declared in crm_schema.fields.
         receipt: { schema: runx.receipt.v1 }
 
-    - name: crm-cleanup-needs-transcript
+    - name: crm-cleanup-refuses-malformed-directive
       inputs:
-        crm_records:
-          - id: acct-1
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: "CRM update: account_status="
         crm_schema:
-          allowed_fields: [next_action]
+          record_id_field: id
+          fields:
+            account_status: { type: string }
+      expect:
+        status: sealed
+        steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
+        step_outputs:
+          finalize:
+            subset:
+              crm_cleanup_result:
+                data:
+                  decision: refused
+                  field_updates: {}
+                  write_result:
+                    executed: false
+                    writes_attempted: 0
+                    writes_completed: 0
+                  validation:
+                    status: fail
+                    findings:
+                      - code: directive.malformed
+                        message: "CRM update directives must use CRM update: field=value with a non-empty value."
+        receipt: { schema: runx.receipt.v1 }
+
+    - name: crm-cleanup-refuses-unsuccessful-source-read
+      inputs:
+        source_handle:
+          kind: connector_export
+          url: https://gist.githubusercontent.com/SQbal1/00000000000000000000000000000000/raw/current-records.json
+          allowlist: [gist.githubusercontent.com]
+          record_id: acct-globex
+        transcript: "CRM update: account_status=at_risk"
+        crm_schema:
+          record_id_field: id
+          fields:
+            account_status: { type: string }
+      expect:
+        status: failure
+
+    - name: crm-cleanup-needs-all-typed-inputs
+      inputs:
+        transcript: "Takeaway: Nothing changed."
       expect:
         status: failure
 
 runners:
-  reconcile:
+  reconcile-and-write:
     default: true
     type: graph
     inputs:
+      source_handle:
+        definition: source_handle
       transcript:
-        type: string
-        required: true
-        description: Call transcript that is the only evidence for proposed updates.
-      crm_records:
-        type: json
-        required: true
-        description: Current CRM records read from the caller's source of truth.
+        definition: transcript
       crm_schema:
-        type: object
-        required: true
-        description: Explicit update authority; fields outside allowed_fields are rejected.
-        schema:
-          additionalProperties: false
-          properties:
-            allowed_fields:
-              type: array
-              minItems: 1
-              maxItems: 100
-              items: { type: string, minLength: 1, maxLength: 200 }
-    examples:
-      - transcript: "Dana said the rollout stalled."
-        crm_records:
-          - id: acct-globex
-            account_status: healthy
-        crm_schema:
-          allowed_fields: [account_status]
+        definition: crm_schema
     graph:
-      name: crm-cleanup-reconcile
+      name: crm-cleanup-reconcile-and-write
       result_from: [finalize]
       steps:
         - id: digest-transcript
@@ -178,80 +278,85 @@ runners:
             value: $input.transcript
             encoding: utf8_text
 
-        - id: digest-records
+        - id: digest-schema
           tool: data.digest
           inputs:
-            value: $input.crm_records
+            value: $input.crm_schema
+
+        - id: read-current
+          label: read current records from the connector export
+          tool: web.fetch
+          scopes:
+            - net:allowlist
+          inputs:
+            url: $input.source_handle.url
+            allowlist: $input.source_handle.allowlist
+            extract: text
+            max_bytes: 1000000
 
         - id: reconcile
-          label: derive candidate field updates from the transcript
-          run:
-            type: agent-task
-            agent: reviewer
-            task: crm-cleanup-reconcile
-            outputs:
-              update_draft: object
+          label: validate transcript directives and prepare the schema-keyed update plan
           inputs:
+            source_handle: $input.source_handle
             transcript: $input.transcript
-            crm_records: $input.crm_records
-            crm_schema: $input.crm_schema
-          allowed_tools: []
-          artifacts:
-            named_emits:
-              update_draft: update_draft
-
-        - id: finalize
-          label: enforce allowlist and transcript traceability deterministically
-          inputs:
-            transcript: $input.transcript
-            crm_records: $input.crm_records
             crm_schema: $input.crm_schema
           context:
-            update_draft: reconcile.update_draft.data
+            source_read: read-current.fetch_result.data
             transcript_digest: digest-transcript.digest_result.data.digest
-            records_digest: digest-records.digest_result.data.digest
+            crm_schema_digest: digest-schema.digest_result.data.digest
           run:
             type: javascript
             module: crm-cleanup.mjs
-            export: finalizeUpdates
+            export: reconcileCleanup
             outputs:
-              crm_update_proposal:
+              cleanup_plan:
                 type: object
                 schema:
-                  required: [schema, decision, reason, updates, rejected_updates, write_performed, gate, transcript_digest, records_digest, validation]
+                  required: [decision, reason, takeaways, field_updates, record_id, before, source_read, transcript_digest, crm_schema_digest, validation]
                   additionalProperties: false
                   properties:
-                    schema: { const: runx.crm_update_proposal.v1 }
-                    decision: { type: string, enum: [proposed, no_action, refused] }
+                    decision: { type: string, enum: [ready, no_action, refused] }
                     reason: { type: string, minLength: 1, maxLength: 2000 }
-                    updates:
+                    takeaways:
                       type: array
-                      maxItems: 200
-                      items:
+                      maxItems: 50
+                      items: { type: string, minLength: 1, maxLength: 4000 }
+                    field_updates:
+                      type: object
+                      maxProperties: 100
+                      propertyNames: { pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
+                      additionalProperties:
                         type: object
-                        required: [record_id, field, from, to, evidence_quote]
+                        required: [from, to, evidence_quote]
                         additionalProperties: false
                         properties:
-                          record_id: { type: string, minLength: 1, maxLength: 500 }
-                          field: { type: string, minLength: 1, maxLength: 200 }
-                          from: {}
-                          to: {}
+                          from: { type: [string, number, boolean, "null"] }
+                          to: { type: [string, number, boolean] }
                           evidence_quote: { type: string, minLength: 1, maxLength: 4000 }
-                    rejected_updates:
-                      type: array
-                      maxItems: 200
-                      items:
-                        type: object
-                        required: [record_id, field, reason]
-                        additionalProperties: false
-                        properties:
-                          record_id: { type: [string, "null"], maxLength: 500 }
-                          field: { type: string, maxLength: 200 }
-                          reason: { type: string, minLength: 1, maxLength: 500 }
-                    write_performed: { const: false }
-                    gate: { const: crm-operator-or-human-approver }
-                    transcript_digest: { type: string, pattern: "^sha256:[0-9a-f]{64}$" }
-                    records_digest: { type: string, pattern: "^sha256:[0-9a-f]{64}$" }
+                    record_id: { type: string, minLength: 1, maxLength: 500 }
+                    before: { type: object, additionalProperties: true }
+                    source_read:
+                      type: object
+                      required: [handle_kind, record_id, allowlist, requested_url, final_url, status, content_digest, fetched_at, bytes, truncated]
+                      additionalProperties: false
+                      properties:
+                        handle_kind: { type: string, const: connector_export }
+                        record_id: { type: string, minLength: 1, maxLength: 500 }
+                        allowlist:
+                          type: array
+                          minItems: 1
+                          maxItems: 64
+                          uniqueItems: true
+                          items: { type: string, minLength: 1, maxLength: 253 }
+                        requested_url: { type: string, format: uri, pattern: '^https://' }
+                        final_url: { type: string, format: uri, pattern: '^https://' }
+                        status: { type: integer, minimum: 200, maximum: 299 }
+                        content_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+                        fetched_at: { type: string, format: date-time }
+                        bytes: { type: integer, minimum: 0, maximum: 1000000 }
+                        truncated: { type: boolean, const: false }
+                    transcript_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+                    crm_schema_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
                     validation:
                       type: object
                       required: [status, findings]
@@ -270,4 +375,132 @@ runners:
                               message: { type: string, minLength: 1, maxLength: 2000 }
           artifacts:
             named_emits:
-              crm_update_proposal: crm_update_proposal
+              cleanup_plan: cleanup_plan
+
+        - id: write-through-transport
+          label: consume the update plan through the mock CRM transport
+          context:
+            cleanup_plan: reconcile.cleanup_plan.data
+          run:
+            type: javascript
+            module: crm-cleanup.mjs
+            export: applyMockCrmWrite
+            outputs:
+              write_result:
+                type: object
+                schema:
+                  required: [transport, operation, status, executed, record_id, applied_fields, writes_attempted, writes_completed, before, after]
+                  additionalProperties: false
+                  properties:
+                    transport: { type: string, const: mock-crm }
+                    operation: { type: string, const: update_fields }
+                    status: { type: string, enum: [applied, no_op] }
+                    executed: { type: boolean }
+                    record_id: { type: string, minLength: 1, maxLength: 500 }
+                    applied_fields:
+                      type: array
+                      maxItems: 100
+                      uniqueItems: true
+                      items: { type: string, pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
+                    writes_attempted: { type: integer, minimum: 0, maximum: 1 }
+                    writes_completed: { type: integer, minimum: 0, maximum: 1 }
+                    before: { type: object, additionalProperties: true }
+                    after: { type: object, additionalProperties: true }
+          artifacts:
+            named_emits:
+              write_result: write_result
+
+        - id: finalize
+          label: verify and seal the reconciliation and transport evidence
+          context:
+            cleanup_plan: reconcile.cleanup_plan.data
+            write_result: write-through-transport.write_result.data
+          run:
+            type: javascript
+            module: crm-cleanup.mjs
+            export: finalizeCleanup
+            outputs:
+              crm_cleanup_result:
+                type: object
+                schema:
+                  required: [decision, reason, takeaways, field_updates, write_result, source_read, transcript_digest, crm_schema_digest, validation]
+                  additionalProperties: false
+                  properties:
+                    decision: { type: string, enum: [updated, no_action, refused] }
+                    reason: { type: string, minLength: 1, maxLength: 2000 }
+                    takeaways:
+                      type: array
+                      maxItems: 50
+                      items: { type: string, minLength: 1, maxLength: 4000 }
+                    field_updates:
+                      type: object
+                      maxProperties: 100
+                      propertyNames: { pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
+                      additionalProperties:
+                        type: object
+                        required: [from, to, evidence_quote]
+                        additionalProperties: false
+                        properties:
+                          from: { type: [string, number, boolean, "null"] }
+                          to: { type: [string, number, boolean] }
+                          evidence_quote: { type: string, minLength: 1, maxLength: 4000 }
+                    write_result:
+                      type: object
+                      required: [transport, operation, status, executed, record_id, applied_fields, writes_attempted, writes_completed, before, after]
+                      additionalProperties: false
+                      properties:
+                        transport: { type: string, const: mock-crm }
+                        operation: { type: string, const: update_fields }
+                        status: { type: string, enum: [applied, no_op] }
+                        executed: { type: boolean }
+                        record_id: { type: string, minLength: 1, maxLength: 500 }
+                        applied_fields:
+                          type: array
+                          maxItems: 100
+                          uniqueItems: true
+                          items: { type: string, pattern: '^[A-Za-z][A-Za-z0-9_]{0,127}$' }
+                        writes_attempted: { type: integer, minimum: 0, maximum: 1 }
+                        writes_completed: { type: integer, minimum: 0, maximum: 1 }
+                        before: { type: object, additionalProperties: true }
+                        after: { type: object, additionalProperties: true }
+                    source_read:
+                      type: object
+                      required: [handle_kind, record_id, allowlist, requested_url, final_url, status, content_digest, fetched_at, bytes, truncated]
+                      additionalProperties: false
+                      properties:
+                        handle_kind: { type: string, const: connector_export }
+                        record_id: { type: string, minLength: 1, maxLength: 500 }
+                        allowlist:
+                          type: array
+                          minItems: 1
+                          maxItems: 64
+                          uniqueItems: true
+                          items: { type: string, minLength: 1, maxLength: 253 }
+                        requested_url: { type: string, format: uri, pattern: '^https://' }
+                        final_url: { type: string, format: uri, pattern: '^https://' }
+                        status: { type: integer, minimum: 200, maximum: 299 }
+                        content_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+                        fetched_at: { type: string, format: date-time }
+                        bytes: { type: integer, minimum: 0, maximum: 1000000 }
+                        truncated: { type: boolean, const: false }
+                    transcript_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+                    crm_schema_digest: { type: string, pattern: '^sha256:[0-9a-f]{64}$' }
+                    validation:
+                      type: object
+                      required: [status, findings]
+                      additionalProperties: false
+                      properties:
+                        status: { type: string, enum: [pass, fail] }
+                        findings:
+                          type: array
+                          maxItems: 100
+                          items:
+                            type: object
+                            required: [code, message]
+                            additionalProperties: false
+                            properties:
+                              code: { type: string, minLength: 1, maxLength: 200 }
+                              message: { type: string, minLength: 1, maxLength: 2000 }
+          artifacts:
+            named_emits:
+              crm_cleanup_result: crm_cleanup_result

--- a/skills/crm-cleanup/X.yaml
+++ b/skills/crm-cleanup/X.yaml
@@ -94,6 +94,30 @@ harness:
             account_status: { type: string, enum: [healthy, at_risk, churned] }
             next_action: { type: string, max_length: 500 }
             health_score: { type: number, minimum: 0, maximum: 100 }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  },
+                  {
+                    "id": "acct-initech",
+                    "account_status": "healthy",
+                    "next_action": "renewal review",
+                    "health_score": 91
+                  }
+                ]
+              }
       expect:
         status: sealed
         steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
@@ -148,6 +172,30 @@ harness:
           record_id_field: id
           fields:
             account_status: { type: string, enum: [healthy, at_risk, churned] }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  },
+                  {
+                    "id": "acct-initech",
+                    "account_status": "healthy",
+                    "next_action": "renewal review",
+                    "health_score": 91
+                  }
+                ]
+              }
       expect:
         status: sealed
         steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
@@ -181,6 +229,30 @@ harness:
           record_id_field: id
           fields:
             account_status: { type: string }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  },
+                  {
+                    "id": "acct-initech",
+                    "account_status": "healthy",
+                    "next_action": "renewal review",
+                    "health_score": 91
+                  }
+                ]
+              }
       expect:
         status: sealed
         steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
@@ -215,6 +287,30 @@ harness:
           record_id_field: id
           fields:
             account_status: { type: string }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json":
+            status: 200
+            headers: { content-type: application/json }
+            body: |
+              {
+                "exported_at": "2026-08-12T00:00:00Z",
+                "source": "synthetic-crm-connector-export",
+                "records": [
+                  {
+                    "id": "acct-globex",
+                    "account_status": "healthy",
+                    "next_action": "none",
+                    "health_score": 82
+                  },
+                  {
+                    "id": "acct-initech",
+                    "account_status": "healthy",
+                    "next_action": "renewal review",
+                    "health_score": 91
+                  }
+                ]
+              }
       expect:
         status: sealed
         steps: [digest-transcript, digest-schema, read-current, reconcile, write-through-transport, finalize]
@@ -248,6 +344,12 @@ harness:
           record_id_field: id
           fields:
             account_status: { type: string }
+      caller:
+        http_responses:
+          "https://gist.githubusercontent.com/SQbal1/00000000000000000000000000000000/raw/current-records.json":
+            status: 503
+            headers: { content-type: text/plain }
+            body: source unavailable
       expect:
         status: failure
 

--- a/skills/crm-cleanup/X.yaml
+++ b/skills/crm-cleanup/X.yaml
@@ -361,9 +361,10 @@ runners:
             transcript_digest: digest-transcript.digest_result.data.digest
             crm_schema_digest: digest-schema.digest_result.data.digest
           run:
-            type: javascript
-            module: crm-cleanup.mjs
-            export: reconcileCleanup
+            type: cli-tool
+            command: node
+            args: [crm-cleanup.mjs, reconcile]
+            input_mode: none
             outputs:
               cleanup_plan: object
           artifacts:
@@ -375,9 +376,10 @@ runners:
           context:
             cleanup_plan: reconcile.cleanup_plan.data
           run:
-            type: javascript
-            module: crm-cleanup.mjs
-            export: applyMockCrmWrite
+            type: cli-tool
+            command: node
+            args: [crm-cleanup.mjs, transport]
+            input_mode: none
             outputs:
               write_result: object
           artifacts:
@@ -390,9 +392,10 @@ runners:
             cleanup_plan: reconcile.cleanup_plan.data
             write_result: write-through-transport.write_result.data
           run:
-            type: javascript
-            module: crm-cleanup.mjs
-            export: finalizeCleanup
+            type: cli-tool
+            command: node
+            args: [crm-cleanup.mjs, finalize]
+            input_mode: none
             outputs:
               crm_cleanup_result: object
               takeaways: array

--- a/skills/crm-cleanup/crm-cleanup.mjs
+++ b/skills/crm-cleanup/crm-cleanup.mjs
@@ -1,83 +1,461 @@
-export function finalizeUpdates(inputs) {
-  const transcript = typeof inputs.transcript === "string" ? inputs.transcript : "";
-  const records = (Array.isArray(inputs.crm_records) ? inputs.crm_records : []).map(record);
-  const allowedFields = uniqueStrings(record(inputs.crm_schema).allowed_fields);
-  const draft = record(inputs.update_draft);
-  const proposed = (Array.isArray(draft.updates) ? draft.updates : []).map(record);
-  const recordsById = new Map(records.map((entry) => [stringValue(entry.id), entry]));
-  const findings = [];
-  const updates = [];
-  const rejected = [];
+export function reconcileCleanup(inputs) {
+  const transcript = requiredString(inputs.transcript, "transcript");
+  const sourceHandle = requiredRecord(inputs.source_handle, "source_handle");
+  const crmSchema = requiredRecord(inputs.crm_schema, "crm_schema");
+  const sourceRead = requiredRecord(inputs.source_read, "source_read");
+  const transcriptDigest = requiredDigest(inputs.transcript_digest, "transcript_digest");
+  const schemaDigest = requiredDigest(inputs.crm_schema_digest, "crm_schema_digest");
 
-  for (const update of proposed) {
-    const recordId = stringValue(update.record_id);
-    const field = stringValue(update.field);
-    const to = update.to;
-    const quote = stringValue(update.evidence_quote);
-    const target = recordsById.get(recordId);
-    if (!target) {
-      findings.push({ code: "update.unknown_record", message: `update targets unknown record ${recordId ?? "(missing)"}.` });
-      continue;
+  validateSourceHandle(sourceHandle);
+  if (transcript.length > 100000) {
+    throw new Error("transcript exceeds 100000 characters");
+  }
+  const sourceEvidence = validateSourceRead(sourceHandle, sourceRead);
+  const records = parseRecords(sourceRead.extracted);
+  const idField = requiredString(crmSchema.record_id_field, "crm_schema.record_id_field");
+  const targetId = requiredString(sourceHandle.record_id, "source_handle.record_id");
+  const matches = records.filter((candidate) => scalarKey(candidate[idField]) === targetId);
+  if (matches.length === 0) {
+    throw new Error(`source record ${targetId} was not found by ${idField}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`source record ${targetId} is ambiguous by ${idField}`);
+  }
+  const [before] = matches;
+
+  const fieldDefinitions = requiredRecord(crmSchema.fields, "crm_schema.fields");
+  const fieldNames = Object.keys(fieldDefinitions);
+  if (fieldNames.length === 0) {
+    throw new Error("crm_schema.fields must declare at least one writable field");
+  }
+  if (fieldNames.length > 100) {
+    throw new Error("crm_schema.fields exceeds 100 writable fields");
+  }
+  for (const field of fieldNames) {
+    if (!/^[A-Za-z][A-Za-z0-9_]{0,127}$/.test(field)) {
+      throw new Error(`crm_schema field ${field} has an invalid name`);
     }
-    if (!field || !allowedFields.includes(field)) {
-      rejected.push({ record_id: recordId, field: field ?? "", reason: "field is outside the crm_schema allowlist" });
-      continue;
-    }
-    if (!quote || !transcript.includes(quote)) {
-      findings.push({ code: "update.unsupported_evidence", message: `update to ${recordId}.${field} cites a quote that is not present in the transcript.` });
-      continue;
-    }
-    if (to === undefined || to === null || to === "") {
-      findings.push({ code: "update.empty_value", message: `update to ${recordId}.${field} carries no target value.` });
-      continue;
-    }
-    updates.push({
-      record_id: recordId,
-      field,
-      from: target[field] === undefined || target[field] === null ? null : target[field],
-      to,
-      evidence_quote: quote,
-    });
+    validateFieldDefinition(field, requiredRecord(fieldDefinitions[field], `crm_schema.fields.${field}`));
   }
 
-  const failed = findings.length > 0;
-  const decision = failed ? "refused" : updates.length > 0 ? "proposed" : "no_action";
+  const parsed = parseTranscript(transcript);
+  const findings = [...parsed.findings];
+  const candidates = {};
+  const seen = new Set();
+
+  for (const directive of parsed.directives) {
+    if (!Object.hasOwn(fieldDefinitions, directive.field)) {
+      findings.push({
+        code: "directive.field_not_allowed",
+        message: `${directive.field} is not declared in crm_schema.fields.`,
+      });
+      continue;
+    }
+    if (seen.has(directive.field)) {
+      findings.push({
+        code: "directive.duplicate_field",
+        message: `${directive.field} appears in more than one CRM update directive.`,
+      });
+      continue;
+    }
+    seen.add(directive.field);
+
+    try {
+      const definition = requiredRecord(
+        fieldDefinitions[directive.field],
+        `crm_schema.fields.${directive.field}`,
+      );
+      const to = parseTypedValue(directive.rawValue, definition, directive.field);
+      const from = Object.hasOwn(before, directive.field) ? before[directive.field] : null;
+      if (!sameJsonValue(from, to)) {
+        candidates[directive.field] = {
+          from: cloneJson(from),
+          to: cloneJson(to),
+          evidence_quote: directive.evidenceQuote,
+        };
+      }
+    } catch (error) {
+      findings.push({
+        code: "directive.invalid_value",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const refused = findings.length > 0;
+  const changed = Object.keys(candidates).length > 0;
   return {
-    crm_update_proposal: {
-      schema: "runx.crm_update_proposal.v1",
-      decision,
-      reason: failed
-        ? "Refused: the reconciliation draft does not reconcile deterministically with the supplied records and transcript."
-        : updates.length > 0
-          ? `Proposed ${updates.length} allowlisted field update(s), each traced to transcript evidence.`
-          : "No actionable field updates were supported by the transcript.",
-      updates: failed ? [] : updates,
-      rejected_updates: rejected,
-      write_performed: false,
-      gate: "crm-operator-or-human-approver",
-      transcript_digest: requiredDigest(inputs.transcript_digest),
-      records_digest: requiredDigest(inputs.records_digest),
-      validation: { status: failed ? "fail" : "pass", findings },
+    cleanup_plan: {
+      decision: refused ? "refused" : changed ? "ready" : "no_action",
+      reason: refused
+        ? "The transcript contained a directive that the CRM schema does not authorize."
+        : changed
+          ? `Prepared ${Object.keys(candidates).length} schema-authorized field update(s) for the CRM transport.`
+          : "No schema-authorized directive changed the current CRM record.",
+      takeaways: parsed.takeaways,
+      field_updates: refused ? {} : candidates,
+      record_id: targetId,
+      before: cloneJson(before),
+      source_read: sourceEvidence,
+      transcript_digest: transcriptDigest,
+      crm_schema_digest: schemaDigest,
+      validation: {
+        status: refused ? "fail" : "pass",
+        findings,
+      },
     },
   };
 }
 
-function requiredDigest(value) {
-  if (typeof value !== "string" || !value.startsWith("sha256:")) {
-    throw new Error("native digest evidence is missing");
+export function finalizeCleanup(inputs) {
+  const plan = requiredRecord(inputs.cleanup_plan, "cleanup_plan");
+  const writeResult = requiredRecord(inputs.write_result, "write_result");
+  const planDecision = requiredString(plan.decision, "cleanup_plan.decision");
+  if (!["ready", "no_action", "refused"].includes(planDecision)) {
+    throw new Error("cleanup_plan decision is invalid");
+  }
+  const fieldUpdates = requiredRecord(plan.field_updates, "cleanup_plan.field_updates");
+  const updateFields = Object.keys(fieldUpdates).sort();
+  const executed = writeResult.executed === true;
+  const before = requiredRecord(writeResult.before, "write_result.before");
+  const after = requiredRecord(writeResult.after, "write_result.after");
+  const recordId = requiredString(plan.record_id, "cleanup_plan.record_id");
+  if (
+    writeResult.transport !== "mock-crm" ||
+    writeResult.operation !== "update_fields" ||
+    writeResult.record_id !== recordId
+  ) {
+    throw new Error("CRM transport identity does not match the reconciliation plan");
+  }
+
+  if (!sameJsonValue(before, requiredRecord(plan.before, "cleanup_plan.before"))) {
+    throw new Error("CRM transport before record does not match the reconciliation plan");
+  }
+  if (planDecision === "ready") {
+    if (updateFields.length === 0 || !executed || writeResult.status !== "applied") {
+      throw new Error("CRM transport did not execute the ready update plan");
+    }
+    const appliedFields = Array.isArray(writeResult.applied_fields)
+      ? [...writeResult.applied_fields].map(String).sort()
+      : [];
+    if (!sameJsonValue(appliedFields, updateFields)) {
+      throw new Error("CRM transport applied fields do not match the reconciliation plan");
+    }
+    if (writeResult.writes_attempted !== 1 || writeResult.writes_completed !== 1) {
+      throw new Error("CRM transport did not complete exactly one atomic write");
+    }
+    const expectedAfter = cloneJson(before);
+    for (const field of updateFields) {
+      const update = requiredRecord(fieldUpdates[field], `cleanup_plan.field_updates.${field}`);
+      expectedAfter[field] = cloneJson(update.to);
+    }
+    if (!sameJsonValue(after, expectedAfter)) {
+      throw new Error("CRM transport after record contains an unplanned change");
+    }
+  } else {
+    if (
+      updateFields.length !== 0 ||
+      executed ||
+      writeResult.status !== "no_op" ||
+      writeResult.writes_attempted !== 0 ||
+      writeResult.writes_completed !== 0 ||
+      !sameJsonValue(before, after)
+    ) {
+      throw new Error("CRM transport must not write a no-action or refused plan");
+    }
+  }
+
+  const validation = requiredRecord(plan.validation, "cleanup_plan.validation");
+  const expectedValidation = planDecision === "refused" ? "fail" : "pass";
+  if (validation.status !== expectedValidation || !Array.isArray(validation.findings)) {
+    throw new Error("cleanup_plan validation does not match its decision");
+  }
+
+  return {
+    crm_cleanup_result: {
+      decision: planDecision === "ready" ? "updated" : planDecision,
+      reason: planDecision === "ready"
+        ? `Applied ${updateFields.length} schema-authorized field update(s) through the mock CRM transport.`
+        : requiredString(plan.reason, "cleanup_plan.reason"),
+      takeaways: Array.isArray(plan.takeaways) ? plan.takeaways : [],
+      field_updates: fieldUpdates,
+      write_result: writeResult,
+      source_read: requiredRecord(plan.source_read, "cleanup_plan.source_read"),
+      transcript_digest: requiredDigest(plan.transcript_digest, "cleanup_plan.transcript_digest"),
+      crm_schema_digest: requiredDigest(plan.crm_schema_digest, "cleanup_plan.crm_schema_digest"),
+      validation,
+    },
+  };
+}
+
+export function applyMockCrmWrite(inputs) {
+  const plan = requiredRecord(inputs.cleanup_plan, "cleanup_plan");
+  const decision = requiredString(plan.decision, "cleanup_plan.decision");
+  if (!["ready", "no_action", "refused"].includes(decision)) {
+    throw new Error("cleanup_plan decision is invalid");
+  }
+  const before = cloneJson(requiredRecord(plan.before, "cleanup_plan.before"));
+  const fieldUpdates = requiredRecord(plan.field_updates, "cleanup_plan.field_updates");
+  const fields = Object.keys(fieldUpdates).sort();
+
+  if (decision === "ready" && fields.length === 0) {
+    throw new Error("ready cleanup_plan has no field updates");
+  }
+  if (decision !== "ready" && fields.length > 0) {
+    throw new Error("non-ready cleanup_plan must not carry field updates");
+  }
+
+  const execute = decision === "ready";
+  const after = cloneJson(before);
+  for (const field of execute ? fields : []) {
+    const update = requiredRecord(fieldUpdates[field], `cleanup_plan.field_updates.${field}`);
+    if (!Object.hasOwn(update, "from") || !Object.hasOwn(update, "to")) {
+      throw new Error(`${field} update is missing from or to`);
+    }
+    if (JSON.stringify(before[field] ?? null) !== JSON.stringify(update.from)) {
+      throw new Error(`${field} update does not match current source state`);
+    }
+    after[field] = cloneJson(update.to);
+  }
+
+  return {
+    write_result: {
+      transport: "mock-crm",
+      operation: "update_fields",
+      status: execute ? "applied" : "no_op",
+      executed: execute,
+      record_id: requiredString(plan.record_id, "cleanup_plan.record_id"),
+      applied_fields: execute ? fields : [],
+      writes_attempted: execute ? 1 : 0,
+      writes_completed: execute ? 1 : 0,
+      before,
+      after,
+    },
+  };
+}
+
+function validateSourceHandle(sourceHandle) {
+  if (requiredString(sourceHandle.kind, "source_handle.kind") !== "connector_export") {
+    throw new Error("source_handle.kind must be connector_export");
+  }
+  const sourceUrl = requiredString(sourceHandle.url, "source_handle.url");
+  if (!/^https:\/\/[^/\s]+(?:\/|$)/i.test(sourceUrl)) {
+    throw new Error("source_handle.url must be a valid HTTPS URL");
+  }
+  if (!Array.isArray(sourceHandle.allowlist) || sourceHandle.allowlist.length === 0) {
+    throw new Error("source_handle.allowlist must contain at least one host");
+  }
+  if (sourceHandle.allowlist.length > 64) {
+    throw new Error("source_handle.allowlist exceeds 64 hosts");
+  }
+  for (const host of sourceHandle.allowlist) {
+    requiredString(host, "source_handle.allowlist host");
+  }
+}
+
+function validateSourceRead(sourceHandle, sourceRead) {
+  if (sourceRead.decision !== "ready") {
+    const blockers = Array.isArray(sourceRead.blockers)
+      ? sourceRead.blockers.map((entry) => String(entry)).join("; ")
+      : "";
+    throw new Error(
+      `source read was not ready: ${String(sourceRead.decision)}${blockers ? ` (${blockers})` : ""}`,
+    );
+  }
+  if (!Number.isInteger(sourceRead.status) || sourceRead.status < 200 || sourceRead.status >= 300) {
+    throw new Error(`source read returned HTTP ${String(sourceRead.status)}`);
+  }
+  const provenance = requiredRecord(sourceRead.provenance, "source_read.provenance");
+  if (provenance.truncated === true) {
+    throw new Error("source read was truncated");
+  }
+  const policy = requiredRecord(sourceRead.policy, "source_read.policy");
+  if (policy.allowlist_decision !== "allowed") {
+    throw new Error("source read did not pass the supplied allowlist");
+  }
+  const finalUrl = requiredString(sourceRead.final_url, "source_read.final_url");
+  const requestedUrl = requiredString(sourceHandle.url, "source_handle.url");
+  const contentDigest = requiredDigest(sourceRead.content_digest, "source_read.content_digest");
+  return {
+    handle_kind: requiredString(sourceHandle.kind, "source_handle.kind"),
+    record_id: requiredString(sourceHandle.record_id, "source_handle.record_id"),
+    allowlist: cloneJson(sourceHandle.allowlist),
+    requested_url: requestedUrl,
+    final_url: finalUrl,
+    status: sourceRead.status,
+    content_digest: contentDigest,
+    fetched_at: requiredString(provenance.fetched_at, "source_read.provenance.fetched_at"),
+    bytes: requiredNonNegativeInteger(provenance.bytes, "source_read.provenance.bytes"),
+    truncated: false,
+  };
+}
+
+function parseRecords(extracted) {
+  if (typeof extracted !== "string" || !extracted.trim()) {
+    throw new Error("source read did not return JSON text");
+  }
+  let payload;
+  try {
+    payload = JSON.parse(extracted);
+  } catch {
+    throw new Error("source read returned malformed JSON");
+  }
+  const records = Array.isArray(payload) ? payload : record(payload).records;
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error("source export must contain at least one record");
+  }
+  return records.map((entry, index) => requiredRecord(entry, `source record ${index}`));
+}
+
+function parseTranscript(transcript) {
+  const directives = [];
+  const takeaways = [];
+  const findings = [];
+  for (const rawLine of transcript.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const update = /^CRM update\s*:\s*([A-Za-z][A-Za-z0-9_]{0,127})\s*=\s*(.+)$/i.exec(line);
+    if (update) {
+      directives.push({
+        field: update[1],
+        rawValue: update[2].trim(),
+        evidenceQuote: line,
+      });
+      continue;
+    }
+    if (/^CRM update\s*:/i.test(line)) {
+      findings.push({
+        code: "directive.malformed",
+        message: "CRM update directives must use CRM update: field=value with a non-empty value.",
+      });
+      continue;
+    }
+    const takeaway = /^Takeaway\s*:\s*(.+)$/i.exec(line);
+    if (takeaway) {
+      takeaways.push(takeaway[1].trim());
+    }
+  }
+  return { directives, findings, takeaways: [...new Set(takeaways)].slice(0, 50) };
+}
+
+function validateFieldDefinition(field, definition) {
+  const allowedKeys = new Set(["type", "enum", "max_length", "minimum", "maximum"]);
+  for (const key of Object.keys(definition)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`crm_schema.fields.${field}.${key} is not supported`);
+    }
+  }
+  const type = requiredString(definition.type, `crm_schema.fields.${field}.type`);
+  if (!new Set(["string", "number", "boolean"]).has(type)) {
+    throw new Error(`crm_schema.fields.${field}.type is not supported`);
+  }
+  if (definition.enum !== undefined) {
+    if (!Array.isArray(definition.enum) || definition.enum.length === 0 || definition.enum.length > 100) {
+      throw new Error(`crm_schema.fields.${field}.enum must contain 1 to 100 values`);
+    }
+    const enumMatchesType = definition.enum.every((value) => typeof value === type);
+    if (!enumMatchesType) {
+      throw new Error(`crm_schema.fields.${field}.enum values must match type ${type}`);
+    }
+  }
+  if (definition.max_length !== undefined) {
+    if (type !== "string" || !Number.isInteger(definition.max_length) || definition.max_length < 1 || definition.max_length > 10000) {
+      throw new Error(`crm_schema.fields.${field}.max_length requires a string field and an integer from 1 to 10000`);
+    }
+  }
+  if (definition.minimum !== undefined && (type !== "number" || !Number.isFinite(definition.minimum))) {
+    throw new Error(`crm_schema.fields.${field}.minimum requires a finite number field`);
+  }
+  if (definition.maximum !== undefined && (type !== "number" || !Number.isFinite(definition.maximum))) {
+    throw new Error(`crm_schema.fields.${field}.maximum requires a finite number field`);
+  }
+  if (
+    typeof definition.minimum === "number" &&
+    typeof definition.maximum === "number" &&
+    definition.minimum > definition.maximum
+  ) {
+    throw new Error(`crm_schema.fields.${field}.minimum exceeds maximum`);
+  }
+}
+
+function parseTypedValue(rawValue, definition, field) {
+  const type = requiredString(definition.type, `crm_schema.fields.${field}.type`);
+  let value;
+  if (type === "string") {
+    value = rawValue.trim();
+    if (!value) throw new Error(`${field} must not be empty`);
+    if (Number.isInteger(definition.max_length) && value.length > definition.max_length) {
+      throw new Error(`${field} exceeds max_length ${definition.max_length}`);
+    }
+  } else if (type === "number") {
+    if (!/^-?(?:\d+\.?\d*|\.\d+)$/.test(rawValue.trim())) {
+      throw new Error(`${field} must be a number`);
+    }
+    value = Number(rawValue);
+    if (!Number.isFinite(value)) throw new Error(`${field} must be finite`);
+    if (typeof definition.minimum === "number" && value < definition.minimum) {
+      throw new Error(`${field} is below minimum ${definition.minimum}`);
+    }
+    if (typeof definition.maximum === "number" && value > definition.maximum) {
+      throw new Error(`${field} is above maximum ${definition.maximum}`);
+    }
+  } else if (type === "boolean") {
+    const normalized = rawValue.trim().toLowerCase();
+    if (normalized !== "true" && normalized !== "false") {
+      throw new Error(`${field} must be true or false`);
+    }
+    value = normalized === "true";
+  } else {
+    throw new Error(`${field} uses unsupported type ${type}`);
+  }
+
+  if (Array.isArray(definition.enum) && !definition.enum.some((entry) => sameJsonValue(entry, value))) {
+    throw new Error(`${field} must be one of the declared enum values`);
   }
   return value;
 }
 
-function stringValue(value) {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function uniqueStrings(value) {
-  if (!Array.isArray(value)) return [];
-  return [...new Set(value.map(stringValue).filter(Boolean))];
+function requiredRecord(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
 }
 
 function record(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function requiredDigest(value, label) {
+  const digest = requiredString(value, label);
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(`${label} must be a sha256 digest`);
+  }
+  return digest;
+}
+
+function requiredNonNegativeInteger(value, label) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function scalarKey(value) {
+  return typeof value === "string" || typeof value === "number" ? String(value) : "";
+}
+
+function sameJsonValue(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function cloneJson(value) {
+  return value === undefined ? null : JSON.parse(JSON.stringify(value));
 }

--- a/skills/crm-cleanup/crm-cleanup.mjs
+++ b/skills/crm-cleanup/crm-cleanup.mjs
@@ -171,20 +171,24 @@ export function finalizeCleanup(inputs) {
     throw new Error("cleanup_plan validation does not match its decision");
   }
 
+  const crmCleanupResult = {
+    decision: planDecision === "ready" ? "updated" : planDecision,
+    reason: planDecision === "ready"
+      ? `Applied ${updateFields.length} schema-authorized field update(s) through the mock CRM transport.`
+      : requiredString(plan.reason, "cleanup_plan.reason"),
+    takeaways: Array.isArray(plan.takeaways) ? plan.takeaways : [],
+    field_updates: fieldUpdates,
+    write_result: writeResult,
+    source_read: requiredRecord(plan.source_read, "cleanup_plan.source_read"),
+    transcript_digest: requiredDigest(plan.transcript_digest, "cleanup_plan.transcript_digest"),
+    crm_schema_digest: requiredDigest(plan.crm_schema_digest, "cleanup_plan.crm_schema_digest"),
+    validation,
+  };
   return {
-    crm_cleanup_result: {
-      decision: planDecision === "ready" ? "updated" : planDecision,
-      reason: planDecision === "ready"
-        ? `Applied ${updateFields.length} schema-authorized field update(s) through the mock CRM transport.`
-        : requiredString(plan.reason, "cleanup_plan.reason"),
-      takeaways: Array.isArray(plan.takeaways) ? plan.takeaways : [],
-      field_updates: fieldUpdates,
-      write_result: writeResult,
-      source_read: requiredRecord(plan.source_read, "cleanup_plan.source_read"),
-      transcript_digest: requiredDigest(plan.transcript_digest, "cleanup_plan.transcript_digest"),
-      crm_schema_digest: requiredDigest(plan.crm_schema_digest, "cleanup_plan.crm_schema_digest"),
-      validation,
-    },
+    crm_cleanup_result: crmCleanupResult,
+    takeaways: crmCleanupResult.takeaways,
+    field_updates: crmCleanupResult.field_updates,
+    write_result: crmCleanupResult.write_result,
   };
 }
 

--- a/skills/crm-cleanup/crm-cleanup.mjs
+++ b/skills/crm-cleanup/crm-cleanup.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 export function reconcileCleanup(inputs) {
   const transcript = requiredString(inputs.transcript, "transcript");
   const sourceHandle = requiredRecord(inputs.source_handle, "source_handle");
@@ -462,4 +464,30 @@ function sameJsonValue(left, right) {
 
 function cloneJson(value) {
   return value === undefined ? null : JSON.parse(JSON.stringify(value));
+}
+
+function readCliInputs() {
+  if (process.env.RUNX_INPUTS_PATH) {
+    return JSON.parse(readFileSync(process.env.RUNX_INPUTS_PATH, "utf8"));
+  }
+  return JSON.parse(process.env.RUNX_INPUTS_JSON || "{}");
+}
+
+function runCli() {
+  const operation = process.argv[2];
+  const inputs = readCliInputs();
+  if (operation === "reconcile") return reconcileCleanup(inputs);
+  if (operation === "transport") return applyMockCrmWrite(inputs);
+  if (operation === "finalize") return finalizeCleanup(inputs);
+  throw new Error("operation must be reconcile, transport, or finalize");
+}
+
+if (process.argv[1]?.endsWith("crm-cleanup.mjs")) {
+  try {
+    process.stdout.write(`${JSON.stringify(runCli())}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`crm-cleanup failed: ${message}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/skills/crm-cleanup/crm-cleanup.mjs
+++ b/skills/crm-cleanup/crm-cleanup.mjs
@@ -9,6 +9,7 @@ export function reconcileCleanup(inputs) {
   const schemaDigest = requiredDigest(inputs.crm_schema_digest, "crm_schema_digest");
 
   validateSourceHandle(sourceHandle);
+  assertClosedKeys(crmSchema, ["record_id_field", "fields"], "crm_schema");
   if (transcript.length > 100000) {
     throw new Error("transcript exceeds 100000 characters");
   }
@@ -40,7 +41,8 @@ export function reconcileCleanup(inputs) {
     validateFieldDefinition(field, requiredRecord(fieldDefinitions[field], `crm_schema.fields.${field}`));
   }
 
-  const parsed = parseTranscript(transcript);
+  const extractionDraft = requiredRecord(inputs.extraction_draft, "extraction_draft");
+  const parsed = validateExtractionDraft(transcript, fieldDefinitions, extractionDraft);
   const findings = [...parsed.findings];
   const candidates = {};
   const seen = new Set();
@@ -90,11 +92,14 @@ export function reconcileCleanup(inputs) {
     cleanup_plan: {
       decision: refused ? "refused" : changed ? "ready" : "no_action",
       reason: refused
-        ? "The transcript contained a directive that the CRM schema does not authorize."
+        ? parsed.needsReview.length > 0
+          ? "The transcript contains a possible CRM change that is ambiguous, hedged, or not safely extractable; human review is required and no write was executed."
+          : "The transcript contained a directive that the CRM schema does not authorize."
         : changed
           ? `Prepared ${Object.keys(candidates).length} schema-authorized field update(s) for the CRM transport.`
-          : "No schema-authorized directive changed the current CRM record.",
+          : "No schema-authorized candidate changed the current CRM record.",
       takeaways: parsed.takeaways,
+      needs_review: parsed.needsReview,
       field_updates: refused ? {} : candidates,
       record_id: targetId,
       before: cloneJson(before),
@@ -107,6 +112,141 @@ export function reconcileCleanup(inputs) {
       },
     },
   };
+}
+
+function validateExtractionDraft(transcript, fieldDefinitions, draft) {
+  const allowedKeys = new Set(["takeaways", "candidates", "review_items"]);
+  for (const key of Object.keys(draft)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`extraction_draft.${key} is not supported`);
+    }
+  }
+  if (!Array.isArray(draft.takeaways) || draft.takeaways.length > 50) {
+    throw new Error("extraction_draft.takeaways must be an array of at most 50 strings");
+  }
+  if (!Array.isArray(draft.candidates) || draft.candidates.length > 100) {
+    throw new Error("extraction_draft.candidates must be an array of at most 100 objects");
+  }
+  if (!Array.isArray(draft.review_items) || draft.review_items.length > 100) {
+    throw new Error("extraction_draft.review_items must be an array of at most 100 objects");
+  }
+
+  const takeaways = draft.takeaways.map((value, index) => {
+    const takeaway = requiredString(value, `extraction_draft.takeaways.${index}`);
+    if (takeaway.length > 2000) throw new Error("extraction_draft takeaway exceeds 2000 characters");
+    return takeaway;
+  });
+  const directives = [];
+  const findings = [];
+  const needsReview = [];
+  const candidateFields = new Set();
+  for (const [index, rawCandidate] of draft.candidates.entries()) {
+    const candidate = requiredRecord(rawCandidate, `extraction_draft.candidates.${index}`);
+    assertClosedKeys(
+      candidate,
+      ["field", "to", "evidence_quote"],
+      `extraction_draft.candidates.${index}`,
+    );
+    const field = requiredString(candidate.field, `extraction_draft.candidates.${index}.field`);
+    const evidenceQuote = requiredString(
+      candidate.evidence_quote,
+      `extraction_draft.candidates.${index}.evidence_quote`,
+    );
+    if (evidenceQuote.length > 2000) {
+      throw new Error(`extraction_draft.candidates.${index}.evidence_quote exceeds 2000 characters`);
+    }
+    if (!Object.hasOwn(fieldDefinitions, field)) {
+      findings.push({
+        code: "extraction.field_not_allowed",
+        message: `${field} is not declared in crm_schema.fields.`,
+      });
+      continue;
+    }
+    if (!transcript.includes(evidenceQuote)) {
+      findings.push({
+        code: "extraction.quote_not_found",
+        message: `${field} evidence_quote is not an exact transcript substring.`,
+      });
+      continue;
+    }
+    if (candidateFields.has(field)) {
+      needsReview.push({
+        field,
+        evidence_quote: evidenceQuote,
+        reason: `${field} has conflicting or duplicate extracted values; confirm one exact value before writing.`,
+      });
+      continue;
+    }
+    candidateFields.add(field);
+    if (/\b(?:maybe|might|may|possibly|probably|perhaps|uncertain|unsure|not\s+sure|i\s+think|i\s+guess|seems?|appears?|looks?)\b/i.test(evidenceQuote)) {
+      needsReview.push({
+        field,
+        evidence_quote: evidenceQuote,
+        reason: `${field} is mentioned with hedged or uncertain language; confirm an exact value before writing.`,
+      });
+      continue;
+    }
+    const rawValue = scalarExtractionValue(candidate.to, field);
+    directives.push({ field, rawValue, evidenceQuote });
+  }
+
+  for (const [index, rawItem] of draft.review_items.entries()) {
+    const item = requiredRecord(rawItem, `extraction_draft.review_items.${index}`);
+    assertClosedKeys(
+      item,
+      ["field", "evidence_quote", "reason"],
+      `extraction_draft.review_items.${index}`,
+    );
+    const evidenceQuote = requiredString(
+      item.evidence_quote,
+      `extraction_draft.review_items.${index}.evidence_quote`,
+    );
+    if (evidenceQuote.length > 2000) {
+      throw new Error(`extraction_draft.review_items.${index}.evidence_quote exceeds 2000 characters`);
+    }
+    if (!transcript.includes(evidenceQuote)) {
+      findings.push({
+        code: "extraction.review_quote_not_found",
+        message: `review_items.${index}.evidence_quote is not an exact transcript substring.`,
+      });
+      continue;
+    }
+    const field = item.field === null || item.field === undefined
+      ? "unmapped"
+      : requiredString(item.field, `extraction_draft.review_items.${index}.field`);
+    if (field !== "unmapped" && !Object.hasOwn(fieldDefinitions, field)) {
+      findings.push({
+        code: "extraction.review_field_not_allowed",
+        message: `${field} is not declared in crm_schema.fields.`,
+      });
+      continue;
+    }
+    const reason = requiredString(item.reason, `extraction_draft.review_items.${index}.reason`);
+    if (reason.length > 2000) {
+      throw new Error(`extraction_draft.review_items.${index}.reason exceeds 2000 characters`);
+    }
+    needsReview.push({
+      field,
+      evidence_quote: evidenceQuote,
+      reason,
+    });
+  }
+  for (const item of needsReview) {
+    findings.push({
+      code: "transcript.needs_review",
+      field: item.field,
+      evidence_quote: item.evidence_quote,
+      message: item.reason,
+    });
+  }
+  return { directives, findings, needsReview, takeaways };
+}
+
+function scalarExtractionValue(value, field) {
+  if (!["string", "number", "boolean"].includes(typeof value)) {
+    throw new Error(`extraction candidate ${field}.to must be a string, number, or boolean`);
+  }
+  return String(value);
 }
 
 export function finalizeCleanup(inputs) {
@@ -179,6 +319,7 @@ export function finalizeCleanup(inputs) {
       ? `Applied ${updateFields.length} schema-authorized field update(s) through the mock CRM transport.`
       : requiredString(plan.reason, "cleanup_plan.reason"),
     takeaways: Array.isArray(plan.takeaways) ? plan.takeaways : [],
+    needs_review: Array.isArray(plan.needs_review) ? plan.needs_review : [],
     field_updates: fieldUpdates,
     write_result: writeResult,
     source_read: requiredRecord(plan.source_read, "cleanup_plan.source_read"),
@@ -189,6 +330,7 @@ export function finalizeCleanup(inputs) {
   return {
     crm_cleanup_result: crmCleanupResult,
     takeaways: crmCleanupResult.takeaways,
+    needs_review: crmCleanupResult.needs_review,
     field_updates: crmCleanupResult.field_updates,
     write_result: crmCleanupResult.write_result,
   };
@@ -241,10 +383,18 @@ export function applyMockCrmWrite(inputs) {
 }
 
 function validateSourceHandle(sourceHandle) {
+  assertClosedKeys(
+    sourceHandle,
+    ["kind", "url", "allowlist", "record_id"],
+    "source_handle",
+  );
   if (requiredString(sourceHandle.kind, "source_handle.kind") !== "connector_export") {
     throw new Error("source_handle.kind must be connector_export");
   }
   const sourceUrl = requiredString(sourceHandle.url, "source_handle.url");
+  if (sourceUrl.length > 2048) {
+    throw new Error("source_handle.url exceeds 2048 characters");
+  }
   if (!/^https:\/\/[^/\s]+(?:\/|$)/i.test(sourceUrl)) {
     throw new Error("source_handle.url must be a valid HTTPS URL");
   }
@@ -254,9 +404,14 @@ function validateSourceHandle(sourceHandle) {
   if (sourceHandle.allowlist.length > 64) {
     throw new Error("source_handle.allowlist exceeds 64 hosts");
   }
-  for (const host of sourceHandle.allowlist) {
-    requiredString(host, "source_handle.allowlist host");
+  for (const hostValue of sourceHandle.allowlist) {
+    const host = requiredString(hostValue, "source_handle.allowlist host");
+    if (host.length > 253 || !/^(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$/.test(host)) {
+      throw new Error("source_handle.allowlist contains an invalid host");
+    }
   }
+  const recordId = requiredString(sourceHandle.record_id, "source_handle.record_id");
+  if (recordId.length > 500) throw new Error("source_handle.record_id exceeds 500 characters");
 }
 
 function validateSourceRead(sourceHandle, sourceRead) {
@@ -313,39 +468,16 @@ function parseRecords(extracted) {
   return records.map((entry, index) => requiredRecord(entry, `source record ${index}`));
 }
 
-function parseTranscript(transcript) {
-  const directives = [];
-  const takeaways = [];
-  const findings = [];
-  for (const rawLine of transcript.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    const update = /^CRM update\s*:\s*([A-Za-z][A-Za-z0-9_]{0,127})\s*=\s*(.+)$/i.exec(line);
-    if (update) {
-      directives.push({
-        field: update[1],
-        rawValue: update[2].trim(),
-        evidenceQuote: line,
-      });
-      continue;
-    }
-    if (/^CRM update\s*:/i.test(line)) {
-      findings.push({
-        code: "directive.malformed",
-        message: "CRM update directives must use CRM update: field=value with a non-empty value.",
-      });
-      continue;
-    }
-    const takeaway = /^Takeaway\s*:\s*(.+)$/i.exec(line);
-    if (takeaway) {
-      takeaways.push(takeaway[1].trim());
-    }
-  }
-  return { directives, findings, takeaways: [...new Set(takeaways)].slice(0, 50) };
-}
-
 function validateFieldDefinition(field, definition) {
-  const allowedKeys = new Set(["type", "enum", "max_length", "minimum", "maximum"]);
+  const allowedKeys = new Set([
+    "type",
+    "enum",
+    "max_length",
+    "minimum",
+    "maximum",
+    "aliases",
+    "semantic_role",
+  ]);
   for (const key of Object.keys(definition)) {
     if (!allowedKeys.has(key)) {
       throw new Error(`crm_schema.fields.${field}.${key} is not supported`);
@@ -354,6 +486,22 @@ function validateFieldDefinition(field, definition) {
   const type = requiredString(definition.type, `crm_schema.fields.${field}.type`);
   if (!new Set(["string", "number", "boolean"]).has(type)) {
     throw new Error(`crm_schema.fields.${field}.type is not supported`);
+  }
+  if (definition.aliases !== undefined) {
+    if (!Array.isArray(definition.aliases) || definition.aliases.length > 20) {
+      throw new Error(`crm_schema.fields.${field}.aliases must contain at most 20 strings`);
+    }
+    for (const alias of definition.aliases) {
+      if (typeof alias !== "string" || !alias.trim() || alias.length > 100) {
+        throw new Error(`crm_schema.fields.${field}.aliases contains an invalid alias`);
+      }
+    }
+  }
+  if (
+    definition.semantic_role !== undefined
+    && !new Set(["status", "score", "next_action"]).has(definition.semantic_role)
+  ) {
+    throw new Error(`crm_schema.fields.${field}.semantic_role is not supported`);
   }
   if (definition.enum !== undefined) {
     if (!Array.isArray(definition.enum) || definition.enum.length === 0 || definition.enum.length > 100) {
@@ -426,6 +574,13 @@ function requiredRecord(value, label) {
     throw new Error(`${label} must be an object`);
   }
   return value;
+}
+
+function assertClosedKeys(value, allowedKeys, label) {
+  const allowed = new Set(allowedKeys);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${label}.${key} is not supported`);
+  }
 }
 
 function record(value) {

--- a/skills/crm-cleanup/fixtures/current-records.json
+++ b/skills/crm-cleanup/fixtures/current-records.json
@@ -1,0 +1,18 @@
+{
+  "exported_at": "2026-08-12T00:00:00Z",
+  "source": "synthetic-crm-connector-export",
+  "records": [
+    {
+      "id": "acct-globex",
+      "account_status": "healthy",
+      "next_action": "none",
+      "health_score": 82
+    },
+    {
+      "id": "acct-initech",
+      "account_status": "healthy",
+      "next_action": "renewal review",
+      "health_score": 91
+    }
+  ]
+}

--- a/skills/crm-cleanup/fixtures/harness-evidence.json
+++ b/skills/crm-cleanup/fixtures/harness-evidence.json
@@ -1,6 +1,6 @@
 {
   "schema": "runx.crm_cleanup.harness_evidence.v1",
-  "generated_at": "2026-08-12T16:11:01Z",
+  "generated_at": "2026-08-12T16:14:53Z",
   "runtime": "runx-cli 0.8.2",
   "runtime_distribution": "@runxhq/cli@0.8.2",
   "command": "runx harness ./skills/crm-cleanup --json",

--- a/skills/crm-cleanup/fixtures/harness-evidence.json
+++ b/skills/crm-cleanup/fixtures/harness-evidence.json
@@ -1,8 +1,8 @@
 {
   "schema": "runx.crm_cleanup.harness_evidence.v1",
-  "generated_at": "2026-08-12T16:04:56Z",
+  "generated_at": "2026-08-12T16:11:01Z",
   "runtime": "runx-cli 0.8.2",
-  "runtime_source_revision": "71a61ca72abe37050a0072f1d380447de0958de0",
+  "runtime_distribution": "@runxhq/cli@0.8.2",
   "command": "runx harness ./skills/crm-cleanup --json",
   "status": "passed",
   "case_count": 6,
@@ -16,7 +16,7 @@
     "crm-cleanup-needs-all-typed-inputs"
   ],
   "happy_path": {
-    "case": "crm-cleanup-write-happy-path",
+    "case": "crm-cleanup-fetches-and-writes-changed-fields",
     "decision": "updated",
     "separate_transport_step": true,
     "write_executed": true,
@@ -24,7 +24,7 @@
     "writes_completed": 1
   },
   "no_op_path": {
-    "case": "crm-cleanup-no-op",
+    "case": "crm-cleanup-no-op-does-not-write",
     "decision": "no_action",
     "write_executed": false,
     "writes_attempted": 0,

--- a/skills/crm-cleanup/fixtures/harness-evidence.json
+++ b/skills/crm-cleanup/fixtures/harness-evidence.json
@@ -1,23 +1,29 @@
 {
   "schema": "runx.crm_cleanup.harness_evidence.v1",
-  "generated_at": "2026-08-12T16:14:53Z",
+  "package_version": "0.3.0",
+  "generated_at": "2026-08-12T16:44:32Z",
   "runtime": "runx-cli 0.8.2",
   "runtime_distribution": "@runxhq/cli@0.8.2",
   "command": "runx harness ./skills/crm-cleanup --json",
   "status": "passed",
-  "case_count": 6,
+  "case_count": 9,
   "assertion_error_count": 0,
   "cases": [
     "crm-cleanup-fetches-and-writes-changed-fields",
     "crm-cleanup-no-op-does-not-write",
     "crm-cleanup-refuses-field-outside-schema",
     "crm-cleanup-refuses-malformed-directive",
+    "crm-cleanup-routes-hedged-change-to-review",
+    "crm-cleanup-routes-actionable-unmapped-prose-to-review",
+    "crm-cleanup-routes-conflicting-values-to-review",
     "crm-cleanup-refuses-unsuccessful-source-read",
     "crm-cleanup-needs-all-typed-inputs"
   ],
   "happy_path": {
     "case": "crm-cleanup-fetches-and-writes-changed-fields",
     "decision": "updated",
+    "natural_transcript_without_update_dsl": true,
+    "schema_keyed_fields": ["account_status", "health_score", "next_action"],
     "separate_transport_step": true,
     "write_executed": true,
     "writes_attempted": 1,
@@ -26,6 +32,7 @@
   "no_op_path": {
     "case": "crm-cleanup-no-op-does-not-write",
     "decision": "no_action",
+    "natural_transcript_without_update_dsl": true,
     "write_executed": false,
     "writes_attempted": 0,
     "writes_completed": 0,
@@ -34,6 +41,9 @@
   "safety_paths": {
     "out_of_schema_field_refused": true,
     "malformed_directive_refused": true,
+    "hedged_change_routed_to_review_without_write": true,
+    "actionable_unmapped_prose_routed_to_review_without_write": true,
+    "conflicting_values_routed_to_review_without_write": true,
     "unsuccessful_source_read_failed_closed": true,
     "missing_typed_inputs_failed_preflight": true
   },

--- a/skills/crm-cleanup/fixtures/harness-evidence.json
+++ b/skills/crm-cleanup/fixtures/harness-evidence.json
@@ -1,6 +1,6 @@
 {
   "schema": "runx.crm_cleanup.harness_evidence.v1",
-  "generated_at": "2026-08-12T16:02:21Z",
+  "generated_at": "2026-08-12T16:04:56Z",
   "runtime": "runx-cli 0.8.2",
   "runtime_source_revision": "71a61ca72abe37050a0072f1d380447de0958de0",
   "command": "runx harness ./skills/crm-cleanup --json",
@@ -41,7 +41,9 @@
     "kind": "connector_export",
     "url": "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json",
     "content_digest": "sha256:489ff9fbdde5a885525a5ca0a0573bcd27136f4314684d28c87f01e0c5be3024",
-    "read_at_runtime": true
+    "read_at_runtime": true,
+    "harness_transport": "explicit deterministic HTTP response",
+    "live_dogfood_required": true
   },
   "receipt_binding": "Receipt IDs are generated from the final immutable package revision and published in the external verification report to avoid a self-referential package digest."
 }

--- a/skills/crm-cleanup/fixtures/harness-evidence.json
+++ b/skills/crm-cleanup/fixtures/harness-evidence.json
@@ -1,0 +1,47 @@
+{
+  "schema": "runx.crm_cleanup.harness_evidence.v1",
+  "generated_at": "2026-08-12T16:02:21Z",
+  "runtime": "runx-cli 0.8.2",
+  "runtime_source_revision": "71a61ca72abe37050a0072f1d380447de0958de0",
+  "command": "runx harness ./skills/crm-cleanup --json",
+  "status": "passed",
+  "case_count": 6,
+  "assertion_error_count": 0,
+  "cases": [
+    "crm-cleanup-fetches-and-writes-changed-fields",
+    "crm-cleanup-no-op-does-not-write",
+    "crm-cleanup-refuses-field-outside-schema",
+    "crm-cleanup-refuses-malformed-directive",
+    "crm-cleanup-refuses-unsuccessful-source-read",
+    "crm-cleanup-needs-all-typed-inputs"
+  ],
+  "happy_path": {
+    "case": "crm-cleanup-write-happy-path",
+    "decision": "updated",
+    "separate_transport_step": true,
+    "write_executed": true,
+    "writes_attempted": 1,
+    "writes_completed": 1
+  },
+  "no_op_path": {
+    "case": "crm-cleanup-no-op",
+    "decision": "no_action",
+    "write_executed": false,
+    "writes_attempted": 0,
+    "writes_completed": 0,
+    "before_equals_after": true
+  },
+  "safety_paths": {
+    "out_of_schema_field_refused": true,
+    "malformed_directive_refused": true,
+    "unsuccessful_source_read_failed_closed": true,
+    "missing_typed_inputs_failed_preflight": true
+  },
+  "public_source": {
+    "kind": "connector_export",
+    "url": "https://gist.githubusercontent.com/SQbal1/b4d40911bc08c261fbedcdebcf069a96/raw/62c45933ebb94ba01a18b9eb0ffc76c4ed47eb12/current-records.json",
+    "content_digest": "sha256:489ff9fbdde5a885525a5ca0a0573bcd27136f4314684d28c87f01e0c5be3024",
+    "read_at_runtime": true
+  },
+  "receipt_binding": "Receipt IDs are generated from the final immutable package revision and published in the external verification report to avoid a self-referential package digest."
+}


### PR DESCRIPTION
## Summary

- read the current CRM record at runtime through native web.fetch with a caller-supplied host allowlist
- extract schema-keyed candidates from ordinary call-transcript prose through one bounded agent task
- deterministically require exact evidence quotes, declared fields, scalar values, type/enum/range conformance, and one unambiguous value per field
- route hedged, conflicting, malformed, out-of-schema, and actionable-but-unmappable prose to needs_review with zero writes
- consume only ready plans through a separate atomic mock-CRM transport and seal source provenance plus exact before/after evidence
- retain an explicit no-action path whose transport performs zero writes and whose before/after records are identical

The mock transport is deliberate: it proves the complete runtime source-read and separately consumed write loop without requiring production CRM credentials. Harnesses bind deterministic HTTP responses; post-publish dogfood reads the public connector URL through the native network effect.

## Validation

- node --check skills/crm-cleanup/crm-cleanup.mjs
- released @runxhq/cli 0.8.2 skill inspect: ready and fully bound
- released @runxhq/cli 0.8.2 harness: 9 cases, 0 assertion errors
- current-source runx-cli 0.8.2 inspect: ready and fully bound
- current-source runx-cli 0.8.2 harness: 9 cases, 0 assertion errors
- natural happy path: 3 schema-keyed changes, 1 atomic mock write
- natural no-op plus hedged, conflicting, and unmappable paths: 0 writes
- git diff --check -- skills/crm-cleanup
- package secret-pattern scan: no findings
- commits carry DCO sign-off