### PR TITLE
feat(nitrosend): govern plan purchasing

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -222,8 +222,8 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nitrosend",
-        version: "sha-3e99d9f6adad",
-        digest: "86176bb53ad30ebcc525efcafb12809b6bb9b244eaef03d0d643cc4123c57424",
+        version: "sha-006a6bb91acf",
+        digest: "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nws-weather-forecast",

--- a/skills/nitrosend/SKILL.md
+++ b/skills/nitrosend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nitrosend
-description: "Operate a Nitrosend account through one governed Runx skill: inspect readiness and analytics, plan and apply campaign/flow/template/segment drafts, import consented contacts through inline or bulk CSV paths, and approve or deliver campaign, flow, and transactional email operations with provider readback."
+description: "Operate a Nitrosend account through one governed Runx skill: inspect readiness, analytics, subscription plans, and purchase status; plan and apply campaign/flow/template/segment drafts; import consented contacts; and approve or deliver email operations with provider readback."
 runx:
   category: growth
 ---
@@ -20,6 +20,15 @@ work. Those are product-operator concerns owned by the Nitrosend repository.
 
 - `status` (default): live account, brand, sender, domain, provider, warmup, and
   deliverability readiness.
+- `billing-status`: read the current account subscription and eligible paid-plan
+  catalog together. It does not create a checkout or expose prepaid funding.
+- `plan-checkout`: re-read current billing and plans, approve one exact plan,
+  create the idempotent hosted checkout or confirmed in-place plan change, then
+  read billing again. A checkout URL is pending operator work, not proof of
+  payment or activation.
+- `plan-checkout-status`: reconcile one returned plan-purchase ID without
+  creating another checkout. Use it after hosted approval, timeout, or an
+  ambiguous client response.
 - `configure-sender`: read, approve, update, and independently read back one
   explicitly selected brand's exact sender defaults. It configures no content,
   audience, campaign, flow, or delivery.
@@ -90,6 +99,27 @@ into another repo-local skill.
    provider evidence. A plan receipt is not proof of send, schedule, activation,
    or import.
 
+## Plan billing
+
+Nitrosend is the merchant for its account subscription. Runx governs the exact
+account operation and receipt, but it does not settle the operator's Stripe or
+Shopify payment and must not route this hosted checkout through `spend`.
+
+Start with `billing-status`; select only a returned eligible `plan_id`. Call
+`plan-checkout` with one stable idempotency key and approve the exact selected
+plan once. The same approval derives Nitrosend's provider confirmation flag, so
+there is no second confirmation prompt. Reuse the key only for an unchanged
+request.
+
+A returned checkout URL means the provider is awaiting the operator. Preserve
+its `purchase_id` and `next_action`, complete or abandon checkout outside the
+runner, and call `plan-checkout-status` later. Do not mint another checkout to
+poll. Only provider readback that reports activation is completion.
+
+Prepaid balance is a separate Nitrosend product path. These plan runners refuse
+amount, currency, instrument, add-funds, and funding-purchase arguments rather
+than forwarding them through the shared billing MCP tool.
+
 ## Contact import rules
 
 Every import requires a stable `source_id` and a plain-language
@@ -110,6 +140,9 @@ rather than keeping a resident polling loop.
 - Missing consent source, recipient, schedule time, or idempotency key.
 - Failed provider review or preflight.
 - Missing or denied approval.
+- Missing plan or purchase identity, changed idempotent checkout input, prepaid
+  funding arguments on a plan runner, or a request to treat checkout creation as
+  payment completion.
 - Any request to expose credentials, signed upload URLs, raw contact files, or
   unbounded provider responses.
 - Any claim of completion without provider readback evidence.

--- a/skills/nitrosend/X.yaml
+++ b/skills/nitrosend/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend
-version: "0.3.3"
+version: "0.4.0"
 catalog:
   kind: skill
   audience: public
@@ -21,6 +21,125 @@ credentials:
         delivery:
           env: NITROSEND_API_KEY
 runners:
+  billing-status:
+    type: graph
+    credential: nitrosend
+    inputs: {}
+    examples:
+      - {}
+    graph:
+      name: nitrosend-billing-status
+      result_from: [status, plans]
+      steps:
+        - id: status
+          skill: graph/provider-operation
+          runner: read
+          inputs:
+            operation: billing_status
+            arguments: {}
+        - id: plans
+          skill: graph/provider-operation
+          runner: read
+          inputs:
+            operation: billing_plans
+            arguments: {}
+  plan-checkout:
+    type: graph
+    credential: nitrosend
+    act:
+      purpose: Create one operator-approved Nitrosend hosted plan checkout or confirmed in-place plan change.
+    inputs:
+      plan_id:
+        type: integer
+        required: true
+        description: Positive plan ID returned by the current billing-status catalog.
+        schema: { minimum: 1 }
+      idempotency_key:
+        type: string
+        required: true
+        description: Stable retry identity for this exact account and selected plan.
+        schema: { minLength: 1, maxLength: 255 }
+    examples:
+      - plan_id: 202
+        idempotency_key: account-1-plan-202-v1
+    graph:
+      name: nitrosend-plan-checkout
+      result_from: [checkout, readback]
+      steps:
+        - id: status
+          skill: graph/provider-operation
+          runner: read
+          inputs:
+            operation: billing_status
+            arguments: {}
+        - id: plans
+          skill: graph/provider-operation
+          runner: read
+          inputs:
+            operation: billing_plans
+            arguments: {}
+        - id: approve
+          run:
+            type: approval
+          inputs:
+            gate_id: nitrosend.plan_checkout.approval
+            reason: Create the Nitrosend hosted checkout or confirmed plan change for this exact selected plan.
+          context:
+            billing_status: status.provider_evidence.data
+            eligible_plans: plans.provider_evidence.data
+        - id: checkout
+          skill: graph/provider-operation
+          runner: act
+          idempotency_key: "$input.idempotency_key"
+          inputs:
+            operation: plan_checkout
+            arguments:
+              plan_id: "$input.plan_id"
+              confirm: true
+              idempotency_key: "$input.idempotency_key"
+            idempotency_key: "$input.idempotency_key"
+        - id: readback
+          skill: graph/provider-operation
+          runner: read
+          inputs:
+            operation: billing_status
+            arguments: {}
+    policy:
+      guards:
+        - step: approve
+          field: status.provider_evidence.data.decision
+          equals: ok
+        - step: approve
+          field: plans.provider_evidence.data.decision
+          equals: ok
+        - step: checkout
+          field: approve.approval_decision.data.approved
+          equals: true
+        - step: readback
+          field: checkout.provider_evidence.data.decision
+          equals: ok
+  plan-checkout-status:
+    type: graph
+    credential: nitrosend
+    inputs:
+      purchase_id:
+        type: integer
+        required: true
+        description: Positive local plan-purchase ID returned by plan-checkout.
+        schema: { minimum: 1 }
+    examples:
+      - purchase_id: 701
+    graph:
+      name: nitrosend-plan-checkout-status
+      result_from: [status]
+      steps:
+        - id: status
+          skill: graph/provider-operation
+          runner: read
+          inputs:
+            operation: plan_checkout_status
+            arguments:
+              purchase_id: "$input.purchase_id"
   status:
     default: true
     type: graph

--- a/skills/nitrosend/fixtures/plan-checkout-requires-approval.yaml
+++ b/skills/nitrosend/fixtures/plan-checkout-requires-approval.yaml
@@ -1,0 +1,27 @@
+name: nitrosend-plan-checkout-requires-approval
+kind: skill
+target: ..
+runner: plan-checkout
+operator_journeys:
+  - mode: refusal
+    confusors: [purchase-approval, spend, charge]
+    request: Attempt to upgrade this Nitrosend account to plan 202 without approving the exact account mutation.
+    expected_outcome: Re-read current billing and plans, bind the selected plan at one approval request, and stop without creating a checkout or claiming payment.
+env:
+  NITROSEND_API_KEY: harness-nitrosend-token
+inputs:
+  plan_id: 202
+  idempotency_key: account-1-plan-202-v1
+caller:
+  http_responses:
+    "https://api.nitrosend.com/mcp":
+      status: 200
+      headers: { content-type: application/json }
+      body: >-
+        {"jsonrpc":"2.0","id":"nitrosend-billing-preflight","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"operation\":\"status\",\"commercial_tier\":\"pro\",\"has_subscription\":true,\"subscription\":{\"id\":101,\"plan_name\":\"Pro\",\"status\":\"active\",\"activated\":true},\"plans\":[{\"id\":202,\"name\":\"Scale\",\"eligible\":true}],\"next_action\":\"Approve only the exact selected plan.\"}}"}]}}
+expect:
+  status: needs_agent
+metadata:
+  public_skill: nitrosend
+  source_case: plan-checkout-requires-approval
+  source: operator-journey

--- a/skills/nitrosend/fixtures/plan-checkout-status-reuses-purchase.yaml
+++ b/skills/nitrosend/fixtures/plan-checkout-status-reuses-purchase.yaml
@@ -1,0 +1,32 @@
+name: nitrosend-plan-checkout-status-reuses-purchase
+kind: skill
+target: ..
+runner: plan-checkout-status
+operator_journeys:
+  - mode: composed
+    request: Reconcile this existing Nitrosend plan purchase after hosted checkout.
+    expected_outcome: Reuse the supplied purchase ID and return provider readback without another approval or checkout.
+    prior_evidence:
+      - The prior plan-checkout provider evidence and purchase ID 701.
+    must_not_repeat:
+      - Do not create another plan checkout.
+      - Do not repeat the original approval.
+env:
+  NITROSEND_API_KEY: harness-nitrosend-token
+inputs:
+  purchase_id: 701
+caller:
+  http_responses:
+    "https://api.nitrosend.com/mcp":
+      status: 200
+      headers: { content-type: application/json }
+      body: >-
+        {"jsonrpc":"2.0","id":"nitrosend-plan-checkout-status","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"operation\":\"checkout_status\",\"purchase_id\":701,\"plan_id\":202,\"plan_name\":\"Scale\",\"status\":\"active\",\"activated\":true,\"next_action\":\"Subscription active.\"}}"}]}}
+expect:
+  status: sealed
+  steps: [status]
+  receipt: { schema: runx.receipt.v1 }
+metadata:
+  public_skill: nitrosend
+  source_case: plan-checkout-status-reuses-purchase
+  source: skills-fixture

--- a/skills/nitrosend/graph/provider-operation/X.yaml
+++ b/skills/nitrosend/graph/provider-operation/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend-provider-operation
-version: "0.1.0"
+version: "0.2.0"
 catalog:
   kind: graph
   audience: operator
@@ -145,6 +145,12 @@ runners:
         type: json
         required: true
         description: Arguments for the selected operation.
+      idempotency_key:
+        type: string
+        required: false
+        default: nitrosend-provider-operation
+        description: Caller-bound transport retry identity when the parent runner has one; otherwise the existing shared fallback.
+        schema: { minLength: 1, maxLength: 255 }
       brand_sid:
         type: string
         required: false
@@ -171,7 +177,7 @@ runners:
             equals: ready
           tool: http.execute
           scopes: [nitrosend:write, net:http]
-          idempotency_key: nitrosend-provider-operation
+          idempotency_key: "$input.idempotency_key"
           inputs:
             stop_on_error: true
           context:

--- a/skills/nitrosend/graph/provider-operation/nitrosend-operation.mjs
+++ b/skills/nitrosend/graph/provider-operation/nitrosend-operation.mjs
@@ -9,8 +9,12 @@ const READ_OPERATIONS = new Map([
   ["import_status", "nitro_query"],
   ["compose_campaign_intent", "nitro_compose_campaign"],
   ["validate_campaign_composition", "nitro_compose_campaign"],
+  ["billing_status", "nitro_manage_billing"],
+  ["billing_plans", "nitro_manage_billing"],
+  ["plan_checkout_status", "nitro_manage_billing"],
 ]);
 const ACT_OPERATIONS = new Map([
+  ["plan_checkout", "nitro_manage_billing"],
   ["send_transactional", "nitro_send_message"],
   ["configure_sender", "nitro_configure_account"],
   ["control_delivery", "nitro_control_delivery"],
@@ -145,6 +149,31 @@ function validate(mode, operation, args, brandSid) {
   const operations = mode === "read" ? READ_OPERATIONS : ACT_OPERATIONS;
   if (!operations.has(operation)) {
     return [`operation must be one of: ${[...operations.keys()].join(", ")}`];
+  }
+  if (mode === "read" && ["billing_status", "billing_plans"].includes(operation)) {
+    if (Object.keys(args).length > 0) {
+      return [`refused:${operation} does not accept provider arguments`];
+    }
+  }
+  if (mode === "read" && operation === "plan_checkout_status") {
+    const allowed = new Set(["purchase_id"]);
+    const unexpected = Object.keys(args).filter((key) => !allowed.has(key));
+    if (unexpected.length > 0) {
+      return [`refused:plan_checkout_status received unsupported fields: ${unexpected.join(", ")}`];
+    }
+    if (!positiveInteger(args.purchase_id)) {
+      return ["plan_checkout_status requires arguments.purchase_id"];
+    }
+  }
+  if (mode === "act" && operation === "plan_checkout") {
+    const allowed = new Set(["plan_id", "confirm", "idempotency_key"]);
+    const unexpected = Object.keys(args).filter((key) => !allowed.has(key));
+    if (unexpected.length > 0) {
+      return [`refused:plan_checkout received unsupported fields: ${unexpected.join(", ")}`];
+    }
+    if (!positiveInteger(args.plan_id) || args.confirm !== true || !text(args.idempotency_key)) {
+      return ["plan_checkout requires a positive plan_id, approved confirm=true, and stable idempotency_key"];
+    }
   }
   if (["sender_settings", "configure_sender"].includes(operation) && !brandSid) {
     return ["refused:sender settings require an explicit brand_sid"];
@@ -296,6 +325,21 @@ function utf8Bytes(value) {
 }
 
 function providerArguments(operation, args) {
+  if (operation === "billing_status") return { operation: "status" };
+  if (operation === "billing_plans") return { operation: "plans" };
+  if (operation === "plan_checkout_status") {
+    return {
+      operation: "checkout_status",
+      params: { purchase_id: Number(args.purchase_id) },
+    };
+  }
+  if (operation === "plan_checkout") {
+    return {
+      operation: "checkout",
+      params: { plan_id: Number(args.plan_id), confirm: true },
+      idempotency_key: args.idempotency_key,
+    };
+  }
   if (operation === "sender_settings") return {};
   if (operation === "compose_campaign_intent") {
     return { ...args, composition_mode: "intent" };

--- a/skills/nitrosend/graph/provider-operation/nitrosend-operation.test.mjs
+++ b/skills/nitrosend/graph/provider-operation/nitrosend-operation.test.mjs
@@ -447,3 +447,73 @@ test("refuses persistence and delivery fields on campaign composition reads", ()
     assert.deepEqual(plan.requests, []);
   }
 });
+
+test("pins plan billing MCP sub-actions and caller retry identity", () => {
+  const status = prepareOperation({
+    mode: "read",
+    operation: "billing_status",
+    arguments: {},
+  }).operation_plan;
+  assert.equal(status.decision, "ready");
+  assert.equal(status.tool, "nitro_manage_billing");
+  assert.deepEqual(status.requests[0].body.params.arguments, { operation: "status" });
+
+  const plans = prepareOperation({
+    mode: "read",
+    operation: "billing_plans",
+    arguments: {},
+  }).operation_plan;
+  assert.deepEqual(plans.requests[0].body.params.arguments, { operation: "plans" });
+
+  const checkout = prepareOperation({
+    mode: "act",
+    operation: "plan_checkout",
+    arguments: {
+      plan_id: 202,
+      confirm: true,
+      idempotency_key: "account-1-plan-202-v1",
+    },
+  }).operation_plan;
+  assert.equal(checkout.decision, "ready");
+  assert.equal(checkout.tool, "nitro_manage_billing");
+  assert.deepEqual(checkout.requests[0].body.params.arguments, {
+    operation: "checkout",
+    params: { plan_id: 202, confirm: true },
+    idempotency_key: "account-1-plan-202-v1",
+  });
+
+  const readback = prepareOperation({
+    mode: "read",
+    operation: "plan_checkout_status",
+    arguments: { purchase_id: 701 },
+  }).operation_plan;
+  assert.deepEqual(readback.requests[0].body.params.arguments, {
+    operation: "checkout_status",
+    params: { purchase_id: 701 },
+  });
+});
+
+test("refuses widened or prepaid arguments on every plan billing lane", () => {
+  const cases = [
+    ["read", "billing_status", { operation: "checkout" }],
+    ["read", "billing_plans", { amount_cents: 5000 }],
+    ["read", "plan_checkout_status", { purchase_id: 701, instrument: "card" }],
+    ["act", "plan_checkout", {
+      plan_id: 202,
+      confirm: true,
+      idempotency_key: "account-1-plan-202-v1",
+      currency: "USD",
+    }],
+    ["act", "plan_checkout", {
+      plan_id: 202,
+      confirm: false,
+      idempotency_key: "account-1-plan-202-v1",
+    }],
+  ];
+
+  for (const [mode, operation, args] of cases) {
+    const plan = prepareOperation({ mode, operation, arguments: args }).operation_plan;
+    assert.notEqual(plan.decision, "ready", `${operation} admitted ${JSON.stringify(args)}`);
+    assert.deepEqual(plan.requests, []);
+  }
+});

--- a/skills/official.lock.json
+++ b/skills/official.lock.json
@@ -295,8 +295,8 @@
   },
   {
     "skill_id": "runx/nitrosend",
-    "version": "sha-3e99d9f6adad",
-    "digest": "86176bb53ad30ebcc525efcafb12809b6bb9b244eaef03d0d643cc4123c57424",
+    "version": "sha-006a6bb91acf",
+    "digest": "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     "catalog_visibility": "public",
     "catalog_role": "branded"
   },


### PR DESCRIPTION
## Outcome

Adds the first subscription-plan billing lane to the existing public Nitrosend skill without introducing another client or payment rail.

- `billing-status` returns current subscription and eligible plans together
- `plan-checkout` re-reads both, uses one exact approval, carries a stable retry identity, and performs provider readback
- `plan-checkout-status` reconciles an existing purchase without minting another checkout
- the shared adapter pins all four `nitro_manage_billing` sub-actions and rejects widened/prepaid arguments
- hosted checkout remains pending operator work; it is never represented as payment or activation

## Proof

- Skill Lab sealed receipt: `sha256:588a42c837e2b47672c79b129ffb086b13680a549ef41f3fa5e8c62a0257ea3c`
- provider-operation tests: 17/17
- all focused Nitrosend module tests: 25/25
- complete Nitrosend harness: passed
- official lock and catalog checks: passed
- native inspect: ready, zero semantic diagnostics

Manifest version: `0.4.0`
Registry lock version: `sha-006a6bb91acf`
Package digest before merge: `sha256:2e2a3edbee9b86af4d02cc32d5cbf7ae5f8dc52bd1e455599b8ad2841c570421`