### PR TITLE
fix(nitrosend): qualify billing result evidence

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -222,7 +222,7 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nitrosend",
-        version: "sha-006a6bb91acf",
+        version: "sha-a0d182721d94",
         digest: "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     },
     OfficialSkillLockEntry {

--- a/skills/nitrosend/X.yaml
+++ b/skills/nitrosend/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend
-version: "0.4.0"
+version: "0.4.1"
 catalog:
   kind: skill
   audience: public
@@ -29,7 +29,7 @@ runners:
       - {}
     graph:
       name: nitrosend-billing-status
-      result_from: [status, plans]
+      result_from: [present]
       steps:
         - id: status
           skill: graph/provider-operation
@@ -43,6 +43,17 @@ runners:
           inputs:
             operation: billing_plans
             arguments: {}
+        - id: present
+          context:
+            status_evidence: status.provider_evidence.data
+            plans_evidence: plans.provider_evidence.data
+          run:
+            type: javascript
+            module: graph/provider-operation/nitrosend-operation.mjs
+            export: presentEvidence
+            outputs:
+              status_evidence: object
+              plans_evidence: object
   plan-checkout:
     type: graph
     credential: nitrosend
@@ -64,7 +75,7 @@ runners:
         idempotency_key: account-1-plan-202-v1
     graph:
       name: nitrosend-plan-checkout
-      result_from: [checkout, readback]
+      result_from: [present]
       steps:
         - id: status
           skill: graph/provider-operation
@@ -104,6 +115,17 @@ runners:
           inputs:
             operation: billing_status
             arguments: {}
+        - id: present
+          context:
+            checkout_evidence: checkout.provider_evidence.data
+            status_evidence: readback.provider_evidence.data
+          run:
+            type: javascript
+            module: graph/provider-operation/nitrosend-operation.mjs
+            export: presentEvidence
+            outputs:
+              checkout_evidence: object
+              status_evidence: object
     policy:
       guards:
         - step: approve

--- a/skills/nitrosend/fixtures/billing-status-returns-status-and-plans.yaml
+++ b/skills/nitrosend/fixtures/billing-status-returns-status-and-plans.yaml
@@ -1,0 +1,32 @@
+name: nitrosend-billing-status-returns-status-and-plans
+kind: skill
+target: ..
+runner: billing-status
+operator_journeys:
+  - mode: standalone
+    confusors: [plan-checkout, purchase-approval]
+    request: Show the current Nitrosend subscription and the eligible plans without changing billing.
+    expected_outcome: Return current subscription evidence and the eligible plan catalog from two bounded reads without creating a checkout.
+env:
+  NITROSEND_API_KEY: harness-nitrosend-token
+inputs: {}
+caller:
+  http_responses:
+    "https://api.nitrosend.com/mcp":
+      status: 200
+      headers: { content-type: application/json }
+      body: >-
+        {"jsonrpc":"2.0","id":"nitrosend-billing-status","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"commercial_tier\":\"pro\",\"has_subscription\":true,\"subscription\":{\"id\":101,\"plan_name\":\"Pro\",\"status\":\"active\",\"activated\":true},\"plans\":[{\"id\":202,\"name\":\"Scale\",\"eligible\":true}],\"can_upgrade\":true}}"}]}}
+expect:
+  status: sealed
+  steps: [status, plans, present]
+  step_outputs:
+    present:
+      subset:
+        status_evidence: { decision: ok, operation: billing_status }
+        plans_evidence: { decision: ok, operation: billing_plans }
+  receipt: { schema: runx.receipt.v1 }
+metadata:
+  public_skill: nitrosend
+  source_case: billing-status-returns-status-and-plans
+  source: skills-fixture

--- a/skills/nitrosend/graph/provider-operation/X.yaml
+++ b/skills/nitrosend/graph/provider-operation/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend-provider-operation
-version: "0.2.0"
+version: "0.2.1"
 catalog:
   kind: graph
   audience: operator

--- a/skills/nitrosend/graph/provider-operation/nitrosend-operation.mjs
+++ b/skills/nitrosend/graph/provider-operation/nitrosend-operation.mjs
@@ -32,6 +32,10 @@ const DELIVERY_OPERATIONS = new Set([
 const SENSITIVE_KEYS = /authorization|api[_-]?key|bearer|credential|secret|token/iu;
 const SECRET_VALUE = /\b(?:nskey|wpkey)_(?:live|test)_[A-Za-z0-9_-]+\b/gu;
 
+export function presentEvidence(evidence) {
+  return { ...evidence };
+}
+
 export function prepareOperation(inputs) {
   const mode = text(inputs.mode);
   const operation = text(inputs.operation);

--- a/skills/nitrosend/graph/provider-operation/nitrosend-operation.test.mjs
+++ b/skills/nitrosend/graph/provider-operation/nitrosend-operation.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   blockedOperation,
   normalizeOperation,
+  presentEvidence,
   prepareOperation,
 } from "./nitrosend-operation.mjs";
 
@@ -19,6 +20,16 @@ function mcpPayload(result, meta = { tool: "fixture" }) {
     },
   };
 }
+
+test("presents step-qualified evidence without another provider layer", () => {
+  const status_evidence = { decision: "ok", operation: "billing_status" };
+  const plans_evidence = { decision: "ok", operation: "billing_plans" };
+
+  assert.deepEqual(presentEvidence({ status_evidence, plans_evidence }), {
+    status_evidence,
+    plans_evidence,
+  });
+});
 
 test("prepares a bounded read through native authenticated HTTP", () => {
   const { operation_plan: plan } = prepareOperation({

--- a/skills/official.lock.json
+++ b/skills/official.lock.json
@@ -295,7 +295,7 @@
   },
   {
     "skill_id": "runx/nitrosend",
-    "version": "sha-006a6bb91acf",
+    "version": "sha-a0d182721d94",
     "digest": "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     "catalog_visibility": "public",
     "catalog_role": "branded"


### PR DESCRIPTION
Live dogfood of the first plan-purchasing release found a graph composition collision before any mutation: billing-status returned two successful internal provider steps that both exposed provider_evidence. The same latent collision existed after checkout readback.

This keeps the existing single provider-operation bridge and adds one deterministic presentation projection with step-qualified outputs. It covers the live-shaped billing-status response, bumps the immutable skill version, and refreshes the official lock.

Proof:
- pnpm verify:fast
- Nitrosend harness: 18/18
- provider-operation tests: 18/18
- official lock audit: 81 skills, 0 findings
- local-source production billing-status sealed successfully with no mutation: sha256:35733bb81dc977711757a9a94b9b1a9a1b435516ffdfb98379b08328c2e3a751