### PR TITLE
fix(nitrosend): close plan billing review

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -222,7 +222,7 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nitrosend",
-        version: "sha-a0d182721d94",
+        version: "sha-a310e65e951c",
         digest: "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     },
     OfficialSkillLockEntry {

--- a/crates/runx-runtime/src/tool_catalogs/native/http.rs
+++ b/crates/runx-runtime/src/tool_catalogs/native/http.rs
@@ -62,8 +62,29 @@ impl BatchMode {
         }
     }
 
-    fn retries_as_idempotent(self) -> bool {
-        self == Self::Query
+    fn retries_as_idempotent(
+        self,
+        request: &runx_contracts::JsonObject,
+    ) -> Result<bool, RuntimeError> {
+        if self == Self::Query {
+            return Ok(true);
+        }
+        if self != Self::Execute {
+            return Ok(false);
+        }
+        let Some(value) = request.get("idempotency_key") else {
+            return Ok(false);
+        };
+        let key = value
+            .as_str()
+            .map(str::trim)
+            .filter(|key| !key.is_empty() && key.len() <= 255 && !key.chars().any(char::is_control))
+            .ok_or_else(|| {
+                invalid(
+                    "request idempotency_key must be a non-empty string of at most 255 characters",
+                )
+            })?;
+        Ok(!key.is_empty())
     }
 }
 
@@ -186,12 +207,20 @@ mod tests {
     }
 
     #[test]
-    fn batch_modes_keep_queries_read_only_by_contract() {
+    fn batch_modes_keep_queries_read_only_by_contract() -> Result<(), Box<dyn std::error::Error>> {
         assert!(BatchMode::Read.admits(HttpMethod::Get));
         assert!(!BatchMode::Read.admits(HttpMethod::Post));
         assert!(BatchMode::Query.admits(HttpMethod::Post));
         assert!(!BatchMode::Query.admits(HttpMethod::Get));
         assert!(!BatchMode::Query.admits(HttpMethod::Delete));
         assert!(BatchMode::Execute.admits(HttpMethod::Delete));
+        let keyed = JsonObject::from([(
+            "idempotency_key".to_owned(),
+            JsonValue::String("account-1-plan-202-v1".to_owned()),
+        )]);
+        assert!(BatchMode::Query.retries_as_idempotent(&JsonObject::new())?);
+        assert!(BatchMode::Execute.retries_as_idempotent(&keyed)?);
+        assert!(!BatchMode::Execute.retries_as_idempotent(&JsonObject::new())?);
+        Ok(())
     }
 }

--- a/crates/runx-runtime/src/tool_catalogs/native/http/batch.rs
+++ b/crates/runx-runtime/src/tool_catalogs/native/http/batch.rs
@@ -131,7 +131,7 @@ pub(super) fn execute_batch(
                     auth: &auth,
                     invocation,
                     prior: &batch.prior,
-                    retry_as_idempotent: mode.retries_as_idempotent(),
+                    retry_as_idempotent: mode.retries_as_idempotent(request)?,
                 },
             )?,
         };

--- a/crates/runx-runtime/src/tool_catalogs/native/http/capability.rs
+++ b/crates/runx-runtime/src/tool_catalogs/native/http/capability.rs
@@ -28,7 +28,7 @@ impl CapabilityInput for HttpBatchInput {
 const FIELDS: &[CapabilityField] = &[
     CapabilityField {
         name: "requests",
-        description: "One to fifty typed request records.",
+        description: "One to fifty typed request records. A mutation POST may declare its stable idempotency_key for safe retry and deterministic harness replay.",
     },
     CapabilityField {
         name: "allowed_hosts",

--- a/skills/nitrosend/X.yaml
+++ b/skills/nitrosend/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend
-version: "0.4.1"
+version: "0.4.2"
 catalog:
   kind: skill
   audience: public
@@ -8,10 +8,10 @@ catalog:
   canonical_skill: runx/send-as
   provider: nitrosend
   runtime_path: mcp
-  execution: read
+  execution: execute
   completion: provider_readback
   requires_adapter: true
-  approval: none
+  approval: conditional
 credentials:
   nitrosend:
     provider: nitrosend
@@ -54,6 +54,13 @@ runners:
             outputs:
               status_evidence: object
               plans_evidence: object
+          artifacts:
+            named_emits:
+              status_evidence: status_evidence
+              plans_evidence: plans_evidence
+            packets:
+              status_evidence: nitrosend.provider_evidence.v1
+              plans_evidence: nitrosend.provider_evidence.v1
   plan-checkout:
     type: graph
     credential: nitrosend
@@ -69,7 +76,7 @@ runners:
         type: string
         required: true
         description: Stable retry identity for this exact account and selected plan.
-        schema: { minLength: 1, maxLength: 255 }
+        schema: { minLength: 1, maxLength: 128 }
     examples:
       - plan_id: 202
         idempotency_key: account-1-plan-202-v1
@@ -126,6 +133,13 @@ runners:
             outputs:
               checkout_evidence: object
               status_evidence: object
+          artifacts:
+            named_emits:
+              checkout_evidence: checkout_evidence
+              status_evidence: status_evidence
+            packets:
+              checkout_evidence: nitrosend.provider_evidence.v1
+              status_evidence: nitrosend.provider_evidence.v1
     policy:
       guards:
         - step: approve
@@ -153,7 +167,7 @@ runners:
       - purchase_id: 701
     graph:
       name: nitrosend-plan-checkout-status
-      result_from: [status]
+      result_from: [present]
       steps:
         - id: status
           skill: graph/provider-operation
@@ -162,6 +176,20 @@ runners:
             operation: plan_checkout_status
             arguments:
               purchase_id: "$input.purchase_id"
+        - id: present
+          context:
+            purchase_evidence: status.provider_evidence.data
+          run:
+            type: javascript
+            module: graph/provider-operation/nitrosend-operation.mjs
+            export: presentEvidence
+            outputs:
+              purchase_evidence: object
+          artifacts:
+            named_emits:
+              purchase_evidence: purchase_evidence
+            packets:
+              purchase_evidence: nitrosend.provider_evidence.v1
   status:
     default: true
     type: graph

--- a/skills/nitrosend/fixtures/billing-status-returns-status-and-plans.yaml
+++ b/skills/nitrosend/fixtures/billing-status-returns-status-and-plans.yaml
@@ -23,8 +23,10 @@ expect:
   step_outputs:
     present:
       subset:
-        status_evidence: { decision: ok, operation: billing_status }
-        plans_evidence: { decision: ok, operation: billing_plans }
+        status_evidence:
+          data: { decision: ok, operation: billing_status }
+        plans_evidence:
+          data: { decision: ok, operation: billing_plans }
   receipt: { schema: runx.receipt.v1 }
 metadata:
   public_skill: nitrosend

--- a/skills/nitrosend/fixtures/plan-checkout-approved-through-readback.yaml
+++ b/skills/nitrosend/fixtures/plan-checkout-approved-through-readback.yaml
@@ -1,0 +1,50 @@
+name: nitrosend-plan-checkout-approved-through-readback
+kind: skill
+target: ..
+runner: plan-checkout
+operator_journeys:
+  - mode: standalone
+    confusors: [purchase-approval, spend, charge]
+    request: Approve this exact Nitrosend plan and create its idempotent hosted checkout.
+    expected_outcome: Re-read billing and plans, approve once, create the checkout with the caller key, and return provider readback without claiming payment.
+env:
+  NITROSEND_API_KEY: harness-nitrosend-token
+inputs:
+  plan_id: 202
+  idempotency_key: account-1-plan-202-v1
+caller:
+  approvals:
+    nitrosend.plan_checkout.approval: true
+  http_responses:
+    "https://api.nitrosend.com/mcp":
+      status: 200
+      headers: { content-type: application/json }
+      body: >-
+        {"jsonrpc":"2.0","id":"nitrosend-plan-checkout","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"operation\":\"checkout\",\"purchase_id\":701,\"plan_id\":202,\"state\":\"awaiting_provider_approval\",\"checkout_url\":\"https://checkout.stripe.test/session\",\"next_action\":\"Open the hosted checkout, then poll purchase 701.\"}}"}]}}
+expect:
+  status: sealed
+  steps: [status, plans, approve, checkout, readback, present]
+  step_outputs:
+    checkout:
+      subset:
+        provider_evidence:
+          data:
+            decision: ok
+            operation: plan_checkout
+            provider_ref: nitrosend:plan_purchase:701
+    present:
+      subset:
+        checkout_evidence:
+          data:
+            decision: ok
+            operation: plan_checkout
+            provider_ref: nitrosend:plan_purchase:701
+        status_evidence:
+          data:
+            decision: ok
+            operation: billing_status
+  receipt: { schema: runx.receipt.v1, state: sealed, disposition: closed }
+metadata:
+  public_skill: nitrosend
+  source_case: plan-checkout-approved-through-readback
+  source: skills-fixture

--- a/skills/nitrosend/fixtures/plan-checkout-status-reuses-purchase.yaml
+++ b/skills/nitrosend/fixtures/plan-checkout-status-reuses-purchase.yaml
@@ -24,7 +24,15 @@ caller:
         {"jsonrpc":"2.0","id":"nitrosend-plan-checkout-status","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"operation\":\"checkout_status\",\"purchase_id\":701,\"plan_id\":202,\"plan_name\":\"Scale\",\"status\":\"active\",\"activated\":true,\"next_action\":\"Subscription active.\"}}"}]}}
 expect:
   status: sealed
-  steps: [status]
+  steps: [status, present]
+  step_outputs:
+    present:
+      subset:
+        purchase_evidence:
+          data:
+            decision: ok
+            operation: plan_checkout_status
+            provider_ref: nitrosend:plan_purchase:701
   receipt: { schema: runx.receipt.v1 }
 metadata:
   public_skill: nitrosend

--- a/skills/nitrosend/graph/provider-operation/X.yaml
+++ b/skills/nitrosend/graph/provider-operation/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend-provider-operation
-version: "0.2.1"
+version: "0.2.2"
 catalog:
   kind: graph
   audience: operator

--- a/skills/nitrosend/graph/provider-operation/nitrosend-operation.mjs
+++ b/skills/nitrosend/graph/provider-operation/nitrosend-operation.mjs
@@ -33,7 +33,11 @@ const SENSITIVE_KEYS = /authorization|api[_-]?key|bearer|credential|secret|token
 const SECRET_VALUE = /\b(?:nskey|wpkey)_(?:live|test)_[A-Za-z0-9_-]+\b/gu;
 
 export function presentEvidence(evidence) {
-  return { ...evidence };
+  return Object.fromEntries(
+    ["status_evidence", "plans_evidence", "checkout_evidence", "purchase_evidence"]
+      .filter((key) => Object.hasOwn(evidence, key))
+      .map((key) => [key, evidence[key]]),
+  );
 }
 
 export function prepareOperation(inputs) {
@@ -71,6 +75,9 @@ export function prepareOperation(inputs) {
             id: requestId,
             method: "POST",
             url: API_URL,
+            ...(mode === "act" && text(args.idempotency_key)
+              ? { idempotency_key: args.idempotency_key }
+              : {}),
             headers: {
               accept: "application/json, text/event-stream",
               ...(brandSid ? { "x-brand-sid": brandSid } : {}),
@@ -111,9 +118,11 @@ export function normalizeOperation(inputs) {
     };
   }
   try {
-    const result = parseToolContent(providerPayload(response), text(plan.operation));
+    const payload = providerPayload(response);
+    const result = parseToolContent(payload, text(plan.operation));
     const safeResult = redact(result);
-    const providerError = safeResult?.error === true || safeResult?.isError === true;
+    const providerError = record(payload.result).isError === true ||
+      safeResult?.error === true || safeResult?.isError === true;
     return {
       provider_evidence: evidence(
         plan,
@@ -175,7 +184,8 @@ function validate(mode, operation, args, brandSid) {
     if (unexpected.length > 0) {
       return [`refused:plan_checkout received unsupported fields: ${unexpected.join(", ")}`];
     }
-    if (!positiveInteger(args.plan_id) || args.confirm !== true || !text(args.idempotency_key)) {
+    if (!positiveInteger(args.plan_id) || args.confirm !== true ||
+        !text(args.idempotency_key) || text(args.idempotency_key).length > 128) {
       return ["plan_checkout requires a positive plan_id, approved confirm=true, and stable idempotency_key"];
     }
   }
@@ -462,6 +472,9 @@ function evidence(plan, decision, response, result, blockers) {
 
 function providerReference(operation, result) {
   const data = result?.data ?? result;
+  if (data?.purchase_id !== undefined && data?.purchase_id !== null) {
+    return `nitrosend:plan_purchase:${data.purchase_id}`;
+  }
   const id = data?.id ?? data?.message_id ?? data?.import_id ?? data?.target_id ?? data?.campaign_id ?? data?.flow_id;
   return id === undefined || id === null ? null : `nitrosend:${operation}:${id}`;
 }

--- a/skills/nitrosend/graph/provider-operation/nitrosend-operation.test.mjs
+++ b/skills/nitrosend/graph/provider-operation/nitrosend-operation.test.mjs
@@ -29,6 +29,10 @@ test("presents step-qualified evidence without another provider layer", () => {
     status_evidence,
     plans_evidence,
   });
+  assert.deepEqual(
+    presentEvidence({ purchase_id: 701, purchase_evidence: status_evidence }),
+    { purchase_evidence: status_evidence },
+  );
 });
 
 test("prepares a bounded read through native authenticated HTTP", () => {
@@ -407,6 +411,37 @@ test("preserves redacted MCP error detail as provider evidence", () => {
   assert.equal(JSON.stringify(failed).includes(returnedSecret), false);
 });
 
+test("projects an HTTP 200 MCP tool error as provider failure", () => {
+  const plan = prepareOperation({
+    mode: "act",
+    operation: "plan_checkout",
+    arguments: { plan_id: 202, confirm: true, idempotency_key: "account-1-plan-202-v1" },
+  }).operation_plan;
+  const failed = normalizeOperation({
+    operation_plan: plan,
+    http_execution: {
+      responses: [{
+        id: "nitrosend-plan_checkout",
+        status: 200,
+        ok: true,
+        body_digest: "sha256:tool-error",
+        json: {
+          jsonrpc: "2.0",
+          id: "nitrosend-plan_checkout",
+          result: {
+            isError: true,
+            content: [{ type: "text", text: "plan unavailable" }],
+          },
+        },
+      }],
+    },
+  }).provider_evidence;
+
+  assert.equal(failed.decision, "provider_error");
+  assert.deepEqual(failed.blockers, ["plan unavailable"]);
+  assert.equal(failed.result.message, "plan unavailable");
+});
+
 test("admits only non-persisting campaign composition reads", () => {
   const intent = prepareOperation({
     mode: "read",
@@ -487,6 +522,7 @@ test("pins plan billing MCP sub-actions and caller retry identity", () => {
   }).operation_plan;
   assert.equal(checkout.decision, "ready");
   assert.equal(checkout.tool, "nitro_manage_billing");
+  assert.equal(checkout.requests[0].idempotency_key, "account-1-plan-202-v1");
   assert.deepEqual(checkout.requests[0].body.params.arguments, {
     operation: "checkout",
     params: { plan_id: 202, confirm: true },
@@ -519,6 +555,11 @@ test("refuses widened or prepaid arguments on every plan billing lane", () => {
       plan_id: 202,
       confirm: false,
       idempotency_key: "account-1-plan-202-v1",
+    }],
+    ["act", "plan_checkout", {
+      plan_id: 202,
+      confirm: true,
+      idempotency_key: "x".repeat(129),
     }],
   ];
 

--- a/skills/official.lock.json
+++ b/skills/official.lock.json
@@ -295,7 +295,7 @@
   },
   {
     "skill_id": "runx/nitrosend",
-    "version": "sha-a0d182721d94",
+    "version": "sha-a310e65e951c",
     "digest": "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     "catalog_visibility": "public",
     "catalog_role": "branded"


### PR DESCRIPTION
## Outcome

Makes plan purchase a first-class, reviewable Nitrosend path without adding a billing-specific transport layer.

- qualifies all public billing results with the canonical provider-evidence packet
- classifies the branded skill as conditional execution
- propagates stable checkout identity into native HTTP so keyed mutations replay safely while unkeyed mutations remain fail-closed
- treats MCP result.isError as a provider failure even when HTTP returns 200
- adds an approved checkout -> provider readback journey and purchase-status presentation

## Review findings

The deployed Nitrosend API and authenticated live tools/list receipt sha256:0a0311d7c4d8d0b537f7f4d1c174a70a1619c6de1c151625a75120145c7b7dba disprove the two schema findings: checkout requires confirm plus root idempotency_key, and checkout_status accepts purchase_id. This PR fixes the remaining four findings.

## Proof

- pnpm verify:fast
- cargo clippy -p runx-runtime --all-features --all-targets -- -D warnings
- targeted keyed HTTP replay unit test with catalog feature
- Nitrosend harness: 19/19, including approved checkout receipt sha256:ab1ed2a40d4d8caf29c733fdc2c9dbe4a3f01c91238b277edecc9daff986b8aa