### PR TITLE
fix(nitrosend): reject blank mutation retry keys

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -222,7 +222,7 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nitrosend",
-        version: "sha-79a8beef082f",
+        version: "sha-7cfec2595868",
         digest: "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     },
     OfficialSkillLockEntry {

--- a/skills/nitrosend/X.yaml
+++ b/skills/nitrosend/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend
-version: "0.4.4"
+version: "0.4.5"
 catalog:
   kind: skill
   audience: public

--- a/skills/nitrosend/fixtures/configure-sender-rejects-blank-idempotency.yaml
+++ b/skills/nitrosend/fixtures/configure-sender-rejects-blank-idempotency.yaml
@@ -1,0 +1,24 @@
+name: configure-sender-rejects-blank-idempotency
+kind: skill
+target: ../graph/provider-operation
+runner: act
+inputs:
+  operation: configure_sender
+  arguments:
+    from_name: Sourcey
+    from_email: hello@sourcey.com
+    reply_to: hello@sourcey.com
+    test_email_recipients: []
+  brand_sid: br_sourcey
+  idempotency_key: "   "
+expect:
+  status: failure
+  receipt:
+    schema: runx.receipt.v1
+    state: sealed
+    disposition: failed
+    reason_code: input_contract_invalid
+metadata:
+  public_skill: nitrosend
+  source_case: configure-sender-rejects-blank-idempotency
+  source: skills-fixture

--- a/skills/nitrosend/graph/provider-operation/X.yaml
+++ b/skills/nitrosend/graph/provider-operation/X.yaml
@@ -156,6 +156,7 @@ runners:
         required: false
         default: nitrosend-provider-operation
         description: Caller-bound transport retry identity when the parent runner has one; otherwise the existing shared fallback.
+        schema: { minLength: 1, pattern: '\S' }
       brand_sid:
         type: string
         required: false

--- a/skills/official.lock.json
+++ b/skills/official.lock.json
@@ -295,7 +295,7 @@
   },
   {
     "skill_id": "runx/nitrosend",
-    "version": "sha-79a8beef082f",
+    "version": "sha-7cfec2595868",
     "digest": "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
     "catalog_visibility": "public",
     "catalog_role": "branded"


### PR DESCRIPTION
Closes the final non-blocking review finding from the Nitrosend plan-billing release. Enforces one trimmed non-empty retry-key floor at the shared provider-operation act boundary, adds a falsifiable admission-reason fixture, bumps Nitrosend to 0.4.5, and regenerates official locks.\n\nVerified locally: complete Nitrosend harness 20/20, provider-operation module tests 20/20, official lock/catalog checks, and pnpm verify:fast.