### PR TITLE
docs(nitrosend): align plan and prepaid billing guidance

### DIFF
--- a/crates/runx-cli/src/official_skills.rs
+++ b/crates/runx-cli/src/official_skills.rs
@@ -222,8 +222,8 @@ pub(crate) const OFFICIAL_SKILLS: &[OfficialSkillLockEntry] = &[
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nitrosend",
-        version: "sha-7cfec2595868",
-        digest: "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
+        version: "sha-388c91762a69",
+        digest: "a7e68ef11f9ed4c385941152cef8a68e2a2338025440e7ea120728a917a26af3",
     },
     OfficialSkillLockEntry {
         skill_id: "runx/nws-weather-forecast",

--- a/skills/nitrosend/SKILL.md
+++ b/skills/nitrosend/SKILL.md
@@ -21,7 +21,8 @@ work. Those are product-operator concerns owned by the Nitrosend repository.
 - `status` (default): live account, brand, sender, domain, provider, warmup, and
   deliverability readiness.
 - `billing-status`: read the current account subscription and eligible paid-plan
-  catalog together. It does not create a checkout or expose prepaid funding.
+  catalog together. It creates no checkout; prepaid balance and add-funds
+  readiness remain a distinct `funding` block in the status evidence.
 - `plan-checkout`: re-read current billing and plans, approve one exact plan,
   create the idempotent hosted checkout or confirmed in-place plan change, then
   read billing again. A checkout URL is pending operator work, not proof of

--- a/skills/nitrosend/X.yaml
+++ b/skills/nitrosend/X.yaml
@@ -1,5 +1,5 @@
 skill: nitrosend
-version: "0.4.5"
+version: "0.4.6"
 catalog:
   kind: skill
   audience: public

--- a/skills/nitrosend/fixtures/billing-status-returns-status-and-plans.yaml
+++ b/skills/nitrosend/fixtures/billing-status-returns-status-and-plans.yaml
@@ -27,7 +27,7 @@ caller:
         status: 200
         headers: { content-type: application/json }
         body: >-
-          {"jsonrpc":"2.0","id":"nitrosend-billing_status","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"operation\":\"status\",\"commercial_tier\":\"pro\",\"has_subscription\":true,\"subscription\":{\"id\":101,\"plan_name\":\"Pro\",\"status\":\"active\",\"activated\":true}}}"}]}}
+          {"jsonrpc":"2.0","id":"nitrosend-billing_status","result":{"content":[{"type":"text","text":"{\"meta\":{\"tool\":\"nitro_manage_billing\"},\"result\":{\"operation\":\"status\",\"commercial_tier\":\"pro\",\"has_subscription\":true,\"subscription\":{\"id\":101,\"plan_name\":\"Pro\",\"status\":\"active\",\"activated\":true},\"funding\":{\"state\":\"ready\",\"available_cents\":490,\"currency\":\"USD\",\"add_funds\":{\"state\":\"available\",\"available\":true,\"minimum_cents\":500,\"maximum_cents\":100000,\"preset_cents\":[2000,5000,10000],\"currency\":\"USD\"}}}}"}]}}
     - request:
         method: POST
         url: https://api.nitrosend.com/mcp
@@ -51,7 +51,13 @@ expect:
     present:
       subset:
         status_evidence:
-          data: { decision: ok, operation: billing_status }
+          data:
+            decision: ok
+            operation: billing_status
+            result:
+              funding:
+                available_cents: 490
+                add_funds: { available: true }
         plans_evidence:
           data: { decision: ok, operation: billing_plans }
   receipt: { schema: runx.receipt.v1 }

--- a/skills/official.lock.json
+++ b/skills/official.lock.json
@@ -295,8 +295,8 @@
   },
   {
     "skill_id": "runx/nitrosend",
-    "version": "sha-7cfec2595868",
-    "digest": "181138ac55043d03e25ad8a7d86ba972dba3835be378a8ba0f14cdfb7ae1bfa9",
+    "version": "sha-388c91762a69",
+    "digest": "a7e68ef11f9ed4c385941152cef8a68e2a2338025440e7ea120728a917a26af3",
     "catalog_visibility": "public",
     "catalog_role": "branded"
   },


### PR DESCRIPTION
Summary:
- align the public billing-status guidance with the live separate funding block
- publish Nitrosend skill version 0.4.6 and regenerate official locks
- make prepaid funding and add-funds preservation a load-bearing fixture assertion

Architecture:
- plan purchasing remains the first-class Runx lifecycle
- prepaid funding remains a separate Nitrosend MCP path
- no new client, adapter, runner, or settlement layer

Verification:
- complete 20-case Nitrosend harness
- pnpm verify:fast (251 tests)
- mutation proof: renaming the mocked funding key fails at the new nested assertion
- two passing independent scafld reviews