### PR TITLE
fix(release): use the existing aggregate CI result

### DIFF
--- a/scripts/lib/runx-cli-release-evidence.mjs
+++ b/scripts/lib/runx-cli-release-evidence.mjs
@@ -45,8 +45,8 @@ export const RUNX_CLI_RELEASE_NOTE_SECTIONS = Object.freeze([
 ]);
 
 export const RUNX_CLI_REQUIRED_CANDIDATE_CHECKS = Object.freeze([
+  // CI owns the affected platform checks and secret scan behind this aggregate.
   "checks",
-  "gitleaks",
 ]);
 
 const GITHUB_ACTIONS_SKIP_MARKERS = Object.freeze([

--- a/tests/runx-cli-release-evidence.test.ts
+++ b/tests/runx-cli-release-evidence.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   RUNX_CLI_NPM_PACKAGES,
   RUNX_CLI_RELEASE_NOTE_SECTIONS,
-  RUNX_CLI_REQUIRED_CANDIDATE_CHECKS,
   RUNX_CLI_REQUIRED_RELEASE_CHANNELS,
   RUNX_CLI_REQUIRED_RELEASE_CHECKS,
   githubActionsSkipDirective,
@@ -85,7 +84,7 @@ describe("Runx CLI release evidence", () => {
       .every(({ authorization }) => authorization !== "Bearer github-readback-token")).toBe(true);
   });
 
-  it("binds release readiness to the required checks on the exact commit", async () => {
+  it("binds release readiness to the CI aggregate on the exact commit", async () => {
     const requests: Array<{ url: string; authorization: string | null }> = [];
     const evidence = await observeRunxCliCandidateChecks({
       commit,
@@ -96,11 +95,10 @@ describe("Runx CLI release evidence", () => {
           authorization: new Headers(init?.headers).get("authorization"),
         });
         return jsonResponse({
-          check_runs: RUNX_CLI_REQUIRED_CANDIDATE_CHECKS.map((name) => ({
-            name,
-            status: "completed",
-            conclusion: "success",
-          })),
+          check_runs: [
+            { name: "checks", status: "completed", conclusion: "success" },
+            { name: "Dependabot", status: "completed", conclusion: "failure" },
+          ],
         });
       },
     });
@@ -108,7 +106,7 @@ describe("Runx CLI release evidence", () => {
     expect(evidence.ready).toBe(true);
     expect(evidence.commitRef).toBe(commit);
     expect(evidence.checks.map((check: { id: string }) => check.id))
-      .toEqual(["candidate_checks", "candidate_gitleaks"]);
+      .toEqual(["candidate_checks"]);
     expect(requests).toEqual([{
       url:
         `https://api.github.com/repos/runxhq/runx/commits/${commit}/check-runs`
@@ -118,20 +116,25 @@ describe("Runx CLI release evidence", () => {
   });
 
   it("refuses missing, pending, or failed exact-commit checks", async () => {
-    const evidence = await observeRunxCliCandidateChecks({
-      commit,
-      githubToken: "",
-      fetchImpl: async () => jsonResponse({
-        check_runs: [
-          { name: "checks", status: "completed", conclusion: "success" },
-          { name: "checks", status: "in_progress", conclusion: null },
-          { name: "gitleaks", status: "completed", conclusion: "failure" },
-        ],
-      }),
-    });
+    for (const checkRuns of [
+      [],
+      [{ name: "classify", status: "completed", conclusion: "success" }],
+      [{ name: "checks", status: "completed", conclusion: "failure" }],
+      [{ name: "checks", status: "completed", conclusion: "skipped" }],
+      [
+        { name: "checks", status: "completed", conclusion: "success" },
+        { name: "checks", status: "in_progress", conclusion: null },
+      ],
+    ]) {
+      const evidence = await observeRunxCliCandidateChecks({
+        commit,
+        githubToken: "",
+        fetchImpl: async () => jsonResponse({ check_runs: checkRuns }),
+      });
 
-    expect(evidence.ready).toBe(false);
-    expect(failedIds(evidence)).toEqual(["candidate_checks", "candidate_gitleaks"]);
+      expect(evidence.ready).toBe(false);
+      expect(failedIds(evidence)).toEqual(["candidate_checks"]);
+    }
   });
 
   it("refuses workflow, npm-latest, and anonymous-container drift", async () => {


### PR DESCRIPTION
CLI release preparation refused a green candidate because it still required the removed standalone `gitleaks` job. Use the existing `checks` aggregate, which already covers the secret scan and affected platform checks.

The two existing candidate-readiness tests now use independent provider fixtures: a passing aggregate admits the candidate, while missing, failed, skipped or pending aggregate results refuse it. An unrelated Dependabot result does not affect source CI readiness. No runtime or workflow changes.

Validation: all 9 release-evidence tests pass; live GitHub readback of merged commit `1269c25fbc6c53579a972cba916a74514b2aef33` returns ready through the corrected observer.
