### PR TITLE
fix(runtime): preserve nested graph progress across host pauses

### DIFF
--- a/crates/runx-cli/tests/operator_journeys.rs
+++ b/crates/runx-cli/tests/operator_journeys.rs
@@ -1116,6 +1116,169 @@ fn stdin_resume_reuses_run_and_rejects_digest_drift() -> TestResult {
 }
 
 #[test]
+fn nested_graph_resume_preserves_completed_effects_and_request_digests() -> TestResult {
+    for topology in ["nested", "deep", "fanout"] {
+        let root = crate::support::temp_root(&format!("runx-{topology}-resume-effects"));
+        let skill_dir = root.join("skills/nested-resume");
+        let receipt_dir = root.join(".runx/receipts");
+        fs::create_dir_all(&skill_dir)?;
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: nested-resume\ndescription: Preserve completed child steps across host turns.\n---\n# Nested resume\nReturn a bounded decision for each review.\n",
+        )?;
+        let mut manifest = r#"skill: nested-resume
+runners:
+  run:
+    default: true
+    type: graph
+    graph:
+      name: parent
+      result_from: [child]
+      steps:
+        - id: child
+          skill: .
+          runner: child
+  child:
+    type: graph
+    graph:
+      name: child
+      result_from: [second-review]
+      steps:
+        - id: first-write
+          tool: fs.write
+          scopes: [fs.write]
+          inputs:
+            path: first.txt
+            contents: executed once
+        - id: first-review
+          run:
+            type: agent-task
+            agent: reviewer
+            task: first-review
+            outputs: { decision: object }
+          context: { written: first-write.file_write.data }
+        - id: second-write
+          tool: fs.write
+          scopes: [fs.write]
+          inputs:
+            path: second.txt
+            contents: executed once
+        - id: second-review
+          run:
+            type: agent-task
+            agent: reviewer
+            task: second-review
+            outputs: { decision: object }
+          context:
+            written: second-write.file_write.data
+            prior: first-review.decision
+"#
+        .to_owned();
+        if topology == "deep" {
+            manifest = manifest.replacen("          runner: child", "          runner: middle", 1);
+            manifest.push_str(
+                r#"  middle:
+    type: graph
+    graph:
+      name: middle
+      result_from: [inner]
+      steps:
+        - id: inner
+          skill: .
+          runner: child
+"#,
+            );
+        } else if topology == "fanout" {
+            manifest = manifest.replacen(
+                "      name: parent",
+                r#"      name: parent
+      fanout:
+        groups:
+          work:
+            strategy: all
+            on_branch_failure: halt"#,
+                1,
+            );
+            manifest = manifest.replacen(
+                "        - id: child",
+                r#"        - id: sibling
+          mode: fanout
+          fanout_group: work
+          tool: fs.write
+          scopes: [fs.write]
+          inputs: { path: sibling.txt, contents: executed once }
+        - id: child
+          mode: fanout
+          fanout_group: work"#,
+                1,
+            );
+        }
+        fs::write(skill_dir.join("X.yaml"), manifest)?;
+        let initial = command(&root)
+            .arg("skill")
+            .arg(&skill_dir)
+            .arg("--receipt-dir")
+            .arg(&receipt_dir)
+            .arg("--json")
+            .output()?;
+        let mut paused = assert_json(&initial, 2)?;
+        let run_id = json_string(&paused, "run_id")?.to_owned();
+
+        if topology == "fanout" {
+            assert_eq!(
+                fs::read_to_string(root.join("sibling.txt"))?,
+                "executed once"
+            );
+            fs::write(root.join("sibling.txt"), "observed after pause")?;
+        }
+
+        for (index, marker) in ["first.txt", "second.txt"].into_iter().enumerate() {
+            assert_eq!(paused["status"], "needs_agent");
+            assert_eq!(fs::read_to_string(root.join(marker))?, "executed once");
+            // A replay would overwrite this external observation of the first effect.
+            fs::write(root.join(marker), "observed after pause")?;
+            let request = &paused["requests"][0];
+            let request_id = json_string(request, "id")?;
+            let digest = json_string(request, "request_digest")?;
+            let answers = serde_json::json!({
+                "request_digests": { (request_id): digest },
+                "answers": { (request_id): { "decision": { "accepted": true } } }
+            });
+            let mut resume = command(&root);
+            resume
+                .arg("resume")
+                .arg(&run_id)
+                .arg("-")
+                .arg("--receipt-dir")
+                .arg(&receipt_dir)
+                .arg("--json");
+            let resumed = output_with_stdin(&mut resume, &answers.to_string())?;
+            paused = assert_json(&resumed, if index == 0 { 2 } else { 0 })?;
+            assert_eq!(paused["run_id"], run_id);
+            assert_eq!(
+                fs::read_to_string(root.join(marker))?,
+                "observed after pause"
+            );
+            assert_eq!(
+                fs::read_to_string(root.join("first.txt"))?,
+                "observed after pause"
+            );
+        }
+        if topology == "fanout" {
+            assert_eq!(
+                fs::read_to_string(root.join("sibling.txt"))?,
+                "observed after pause"
+            );
+        }
+        assert_eq!(paused["status"], "sealed");
+        assert_eq!(paused["outcome"], "completed");
+        assert_eq!(paused["result"]["decision"]["accepted"], true);
+        assert_receipt_verifies(&root, &receipt_dir, json_string(&paused, "receipt_id")?)?;
+    }
+    Ok(())
+}
+
+#[test]
 fn compact_skill_output_externalizes_oversized_intermediate_context() -> TestResult {
     let root = crate::support::temp_root("runx-operator-compact-output-journey");
     let skill_dir = root.join("skills/compact-output");

--- a/crates/runx-runtime/src/error.rs
+++ b/crates/runx-runtime/src/error.rs
@@ -51,7 +51,11 @@ pub enum RuntimeError {
     #[error("graph step '{step_id}' is blocked: {reason}")]
     GraphBlocked { step_id: String, reason: String },
     #[error("graph step '{step_id}' is waiting for host resolution: {reason}")]
-    ResolutionPending { step_id: String, reason: String },
+    ResolutionPending {
+        step_id: String,
+        reason: String,
+        checkpoint: Option<Box<crate::execution::runner::GraphCheckpoint>>,
+    },
     #[error(transparent)]
     ContextEdgeUnresolved(Box<ContextEdgeUnresolvedError>),
     #[error("authority {verb:?} denied graph step '{step_id}': {reason}")]
@@ -391,9 +395,12 @@ impl RuntimeError {
                 step_id: step_id.to_owned(),
                 reason,
             },
-            Self::ResolutionPending { reason, .. } => Self::ResolutionPending {
+            Self::ResolutionPending {
+                reason, checkpoint, ..
+            } => Self::ResolutionPending {
                 step_id: step_id.to_owned(),
                 reason,
+                checkpoint,
             },
             Self::AuthorityDenied { verb, reason, .. } => Self::AuthorityDenied {
                 verb,

--- a/crates/runx-runtime/src/execution/runner.rs
+++ b/crates/runx-runtime/src/execution/runner.rs
@@ -13,7 +13,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use runx_contracts::{ClosureDisposition, FanoutReceiptSyncPoint, JsonObject, JsonValue, Receipt};
-use runx_core::state_machine::{GraphStatus, SequentialGraphState, StepAdmissionWitness};
+use runx_core::state_machine::{
+    GraphStatus, GraphStepStatus, SequentialGraphState, StepAdmissionWitness,
+};
 use runx_parser::ExecutionGraph;
 use serde::{Deserialize, Serialize};
 
@@ -197,6 +199,16 @@ pub struct GraphCheckpoint {
     pub steps: Vec<StepRun>,
     pub sync_points: Vec<FanoutReceiptSyncPoint>,
     pub journal: ExecutionJournal,
+    /// A host-suspended step retains its attempt and any unfinished child graph.
+    /// This is allocated only when execution yields, never for completed steps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suspended_step: Option<Box<SuspendedGraphStep>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SuspendedGraphStep {
+    pub step_id: String,
+    pub child: Option<Box<GraphCheckpoint>>,
 }
 
 pub struct Runtime<A> {
@@ -379,9 +391,9 @@ where
                 )?;
                 Ok(execution.finish(graph, receipt))
             }
-            Err(RuntimeError::ResolutionPending { step_id, reason })
-                if terminal_outcome == GraphTerminalOutcome::SealReceipt =>
-            {
+            Err(RuntimeError::ResolutionPending {
+                step_id, reason, ..
+            }) if terminal_outcome == GraphTerminalOutcome::SealReceipt => {
                 let receipt = graph_receipt_with_disposition_and_policy(
                     &graph.name,
                     &mut execution.runs,
@@ -401,7 +413,7 @@ where
                 )?;
                 Ok(execution.finish(graph, receipt))
             }
-            Err(error) => Err(error),
+            Err(error) => Err(execution.checkpoint_error(&graph.name, error)),
         }
     }
 
@@ -434,7 +446,9 @@ where
         host: &mut dyn Host,
     ) -> Result<GraphCheckpoint, RuntimeError> {
         let mut execution = GraphExecution::new(graph);
-        execution.run(self, graph_dir, graph, host, Some(max_steps))?;
+        if let Err(error) = execution.run(self, graph_dir, graph, host, Some(max_steps)) {
+            return Err(execution.checkpoint_error(&graph.name, error));
+        }
         Ok(execution.checkpoint(graph.name.clone()))
     }
 
@@ -495,7 +509,9 @@ where
         host: &mut dyn Host,
     ) -> Result<GraphRun, RuntimeError> {
         let mut execution = GraphExecution::from_checkpoint(&graph, checkpoint)?;
-        execution.run(self, graph_dir, &graph, host, None)?;
+        if let Err(error) = execution.run(self, graph_dir, &graph, host, None) {
+            return Err(execution.checkpoint_error(&graph.name, error));
+        }
         let receipt = graph_receipt_with_effects_and_signature_policy(
             &graph.name,
             &mut execution.runs,
@@ -615,7 +631,13 @@ where
             .steps
             .iter()
             .find(|step| step.step_id == step_id)
-            .map_or(1, |step| step.attempts.saturating_add(1).max(1));
+            .map_or(1, |step| {
+                if step.status == GraphStepStatus::Running {
+                    step.attempts
+                } else {
+                    step.attempts.saturating_add(1).max(1)
+                }
+            });
         let step = graph
             .steps
             .iter()
@@ -652,7 +674,9 @@ where
         host: &mut dyn Host,
     ) -> Result<GraphCheckpoint, RuntimeError> {
         let mut execution = GraphExecution::from_checkpoint(graph, checkpoint)?;
-        execution.run(self, graph_dir, graph, host, Some(max_steps))?;
+        if let Err(error) = execution.run(self, graph_dir, graph, host, Some(max_steps)) {
+            return Err(execution.checkpoint_error(&graph.name, error));
+        }
         Ok(execution.checkpoint(graph.name.clone()))
     }
 }
@@ -1107,6 +1131,7 @@ mod tests {
             steps: run.steps,
             sync_points: run.sync_points,
             journal: run.journal,
+            suspended_step: None,
         };
         let serialized = serde_json::to_value(checkpoint)?;
         let step = serialized

--- a/crates/runx-runtime/src/execution/runner/admission.rs
+++ b/crates/runx-runtime/src/execution/runner/admission.rs
@@ -89,6 +89,7 @@ pub(super) fn prepare_effect_execution(
         Ok(EffectPreparationOutcome::Pending { reason }) => Err(RuntimeError::ResolutionPending {
             step_id: step.id.clone(),
             reason,
+            checkpoint: None,
         }),
         Err(source) => Err(runtime_effect_error(step, source)),
     }

--- a/crates/runx-runtime/src/execution/runner/dispatch.rs
+++ b/crates/runx-runtime/src/execution/runner/dispatch.rs
@@ -12,7 +12,7 @@ use super::super::graph::{
 };
 use super::super::graph_index::PriorRunIndex;
 use super::step_handlers::{StepRunRequest, run_step_with_inputs};
-use super::{Runtime, StepRun};
+use super::{GraphCheckpoint, Runtime, StepRun};
 use crate::RuntimeError;
 use crate::adapter::SkillAdapter;
 use crate::host::Host;
@@ -61,6 +61,7 @@ pub(super) struct LoadedStepExecutionRequest<'a, A: SkillAdapter> {
     pub(super) attempt: u32,
     pub(super) loaded_skill: Option<LoadedStepSkill>,
     pub(super) policy_approval_refs: Vec<Reference>,
+    pub(super) child_checkpoint: Option<Box<GraphCheckpoint>>,
     pub(super) host: &'a mut dyn Host,
 }
 
@@ -109,6 +110,7 @@ where
         attempt,
         loaded_skill,
         policy_approval_refs,
+        child_checkpoint,
         host,
     } = request;
     let request = StepRunRequest {
@@ -120,6 +122,7 @@ where
         inputs,
         provenance,
         policy_approval_refs,
+        child_checkpoint,
         host,
     };
     match loaded_skill {

--- a/crates/runx-runtime/src/execution/runner/graph_engine.rs
+++ b/crates/runx-runtime/src/execution/runner/graph_engine.rs
@@ -27,7 +27,7 @@ use super::scheduler::{
 };
 use super::step_handlers::{output_error, runtime_error_step_run};
 use super::sync::fanout_sync_point;
-use super::{GraphCheckpoint, GraphRun, Runtime, StepRun};
+use super::{GraphCheckpoint, GraphRun, Runtime, StepRun, SuspendedGraphStep};
 use crate::RuntimeError;
 use crate::adapter::{BorrowedSkillAdapter, SkillAdapter};
 use crate::host::{Host, RejectingParallelHost};
@@ -78,6 +78,7 @@ pub(super) struct GraphExecution {
     run_positions: BTreeMap<String, usize>,
     pub(super) sync_points: Vec<FanoutReceiptSyncPoint>,
     journal: ExecutionJournal,
+    suspended_step: Option<Box<SuspendedGraphStep>>,
 }
 
 struct ParallelFanoutJob<'a> {
@@ -129,6 +130,7 @@ impl GraphExecution {
             run_positions: BTreeMap::new(),
             sync_points: Vec::new(),
             journal: ExecutionJournal::default(),
+            suspended_step: None,
         }
     }
 
@@ -148,8 +150,15 @@ impl GraphExecution {
         }
         let definitions = super::super::graph::step_definitions(graph);
         let graph_index = ExecutionGraphIndex::new(graph, definitions);
-        let planning_cursor =
-            checkpoint_planning_cursor(graph, &checkpoint.state, &checkpoint.sync_points)?;
+        let planning_cursor = checkpoint_planning_cursor(
+            graph,
+            &checkpoint.state,
+            &checkpoint.sync_points,
+            checkpoint
+                .suspended_step
+                .as_ref()
+                .map(|pending| pending.step_id.as_str()),
+        )?;
         let run_positions = run_positions(&checkpoint.steps);
         Ok(Self {
             graph_index,
@@ -160,6 +169,7 @@ impl GraphExecution {
             run_positions,
             sync_points: checkpoint.sync_points,
             journal: checkpoint.journal,
+            suspended_step: checkpoint.suspended_step,
         })
     }
 
@@ -176,6 +186,39 @@ impl GraphExecution {
     {
         let fanout_policies = fanout_policies(graph);
         let initial_step_count = self.runs.len();
+        if max_new_steps != Some(0)
+            && let Some(pending) = &self.suspended_step
+        {
+            let step_id = pending.step_id.clone();
+            let attempt = self
+                .state
+                .steps
+                .iter()
+                .find(|step| step.step_id == step_id)
+                .ok_or_else(|| RuntimeError::StepMissing {
+                    step_id: step_id.clone(),
+                })?
+                .attempts;
+            let group_id = self.find_step(graph, &step_id)?.fanout_group.clone();
+            self.run_one_step_with_mode(
+                runtime,
+                graph_dir,
+                graph,
+                host,
+                StepExecutionPlan {
+                    step_id: &step_id,
+                    attempt,
+                    failure_mode: if group_id.is_some() {
+                        StepFailureMode::RecordAndContinue
+                    } else {
+                        StepFailureMode::Propagate
+                    },
+                },
+            )?;
+            if let Some(group_id) = group_id {
+                self.record_proceeding_fanout_sync_point(graph, &fanout_policies, &group_id)?;
+            }
+        }
         loop {
             if reached_step_limit(initial_step_count, self.runs.len(), max_new_steps) {
                 return Ok(());
@@ -752,12 +795,45 @@ impl GraphExecution {
         let policy_approval_refs =
             verified_approval_references(context.runtime, context.graph, context.step, &self.runs)?;
         let retry_remaining = retry_budget_remaining(context.step, context.plan.attempt);
-        self.record_lifecycle(
-            context.host,
-            LifecycleEvent::step_started(context.plan.step_id),
-        )?;
-        self.start_step(context.runtime, context.plan.step_id);
-        let run = self.execute_step_plan(&mut context, loaded_skill, policy_approval_refs)?;
+        let child_checkpoint = if let Some(pending) = self.suspended_step.take() {
+            if pending.step_id != context.plan.step_id {
+                return Err(RuntimeError::EngineInvariant {
+                    context: "resuming a graph step",
+                    message: "pending checkpoint does not belong to the selected step".to_owned(),
+                });
+            }
+            pending.child
+        } else {
+            self.record_lifecycle(
+                context.host,
+                LifecycleEvent::step_started(context.plan.step_id),
+            )?;
+            self.start_step(context.runtime, context.plan.step_id);
+            None
+        };
+        let run = match self.execute_step_plan(
+            &mut context,
+            loaded_skill,
+            policy_approval_refs,
+            child_checkpoint,
+        ) {
+            Err(RuntimeError::ResolutionPending {
+                step_id,
+                reason,
+                checkpoint,
+            }) => {
+                self.suspended_step = Some(Box::new(SuspendedGraphStep {
+                    step_id: context.plan.step_id.to_owned(),
+                    child: checkpoint,
+                }));
+                return Err(RuntimeError::ResolutionPending {
+                    step_id,
+                    reason,
+                    checkpoint: None,
+                });
+            }
+            result => result?,
+        };
         self.commit_step_run(
             context.runtime,
             context.host,
@@ -772,6 +848,7 @@ impl GraphExecution {
         context: &mut StepExecutionContext<'_, A>,
         loaded_skill: Result<Option<LoadedStepSkill>, RuntimeError>,
         policy_approval_refs: Vec<Reference>,
+        child_checkpoint: Option<Box<GraphCheckpoint>>,
     ) -> Result<StepRun, RuntimeError>
     where
         A: SkillAdapter,
@@ -785,14 +862,27 @@ impl GraphExecution {
                     .env
                     .contains_key(DISABLE_RUNTIME_INDEXES_ENV)
                 {
-                    self.execute_step_without_index(context, loaded_skill, policy_approval_refs)
+                    self.execute_step_without_index(
+                        context,
+                        loaded_skill,
+                        policy_approval_refs,
+                        child_checkpoint,
+                    )
                 } else {
-                    self.execute_step_with_index(context, loaded_skill, policy_approval_refs)
+                    self.execute_step_with_index(
+                        context,
+                        loaded_skill,
+                        policy_approval_refs,
+                        child_checkpoint,
+                    )
                 }
             });
         let run_result = run_result.map_err(|fault| fault.at_graph_step(&context.step.id));
         Ok(match run_result {
             Ok(run) => run,
+            Err(StepFault::Sealable(error @ RuntimeError::ResolutionPending { .. })) => {
+                return Err(error);
+            }
             Err(StepFault::Sealable(error))
                 if context.plan.failure_mode == StepFailureMode::RecordAndContinue =>
             {
@@ -813,6 +903,7 @@ impl GraphExecution {
         context: &mut StepExecutionContext<'_, A>,
         loaded_skill: Option<LoadedStepSkill>,
         policy_approval_refs: Vec<Reference>,
+        child_checkpoint: Option<Box<GraphCheckpoint>>,
     ) -> Result<StepRun, StepFault>
     where
         A: SkillAdapter,
@@ -826,6 +917,7 @@ impl GraphExecution {
                 attempt: context.plan.attempt,
                 loaded_skill,
                 policy_approval_refs,
+                child_checkpoint,
                 host: context.host,
             },
             &self.runs,
@@ -837,6 +929,7 @@ impl GraphExecution {
         context: &mut StepExecutionContext<'_, A>,
         loaded_skill: Option<LoadedStepSkill>,
         policy_approval_refs: Vec<Reference>,
+        child_checkpoint: Option<Box<GraphCheckpoint>>,
     ) -> Result<StepRun, StepFault>
     where
         A: SkillAdapter,
@@ -851,6 +944,7 @@ impl GraphExecution {
                 attempt: context.plan.attempt,
                 loaded_skill,
                 policy_approval_refs,
+                child_checkpoint,
                 host: context.host,
             },
             &prior_run_index,
@@ -946,8 +1040,16 @@ impl GraphExecution {
     where
         A: SkillAdapter,
     {
-        self.record_lifecycle(host, LifecycleEvent::step_started(step_id))?;
-        self.start_step(runtime, step_id);
+        if self
+            .suspended_step
+            .as_ref()
+            .is_some_and(|suspended| suspended.step_id == step_id)
+        {
+            self.suspended_step = None;
+        } else {
+            self.record_lifecycle(host, LifecycleEvent::step_started(step_id))?;
+            self.start_step(runtime, step_id);
+        }
         self.fail_step(runtime, step_id, &run);
         self.push_run(run);
         self.apply_state_event(SequentialGraphEvent::FailGraph {
@@ -995,6 +1097,20 @@ impl GraphExecution {
             steps: self.runs,
             sync_points: self.sync_points,
             journal: self.journal,
+            suspended_step: self.suspended_step,
+        }
+    }
+
+    pub(super) fn checkpoint_error(self, graph_name: &str, error: RuntimeError) -> RuntimeError {
+        match error {
+            RuntimeError::ResolutionPending {
+                step_id, reason, ..
+            } => RuntimeError::ResolutionPending {
+                step_id,
+                reason,
+                checkpoint: Some(Box::new(self.checkpoint(graph_name.to_owned()))),
+            },
+            error => error,
         }
     }
 
@@ -1109,6 +1225,7 @@ fn execute_parallel_fanout_job(
             attempt: job.attempt,
             loaded_skill: job.loaded_skill,
             policy_approval_refs: job.policy_approval_refs,
+            child_checkpoint: None,
             host: &mut host,
         },
         context.prior_run_index,
@@ -1151,15 +1268,29 @@ fn checkpoint_planning_cursor(
     graph: &ExecutionGraph,
     state: &SequentialGraphState,
     sync_points: &[FanoutReceiptSyncPoint],
+    suspended_step_id: Option<&str>,
 ) -> Result<usize, RuntimeError> {
-    if let Some(step) = state
+    let mut found_pending = false;
+    for step in state
         .steps
         .iter()
-        .find(|step| step.status == GraphStepStatus::Running)
+        .filter(|step| step.status == GraphStepStatus::Running)
+    {
+        if found_pending || suspended_step_id != Some(step.step_id.as_str()) || step.attempts == 0 {
+            return Err(RuntimeError::GraphPlanningFailed {
+                step_id: step.step_id.clone(),
+                reason: "checkpoint contains a running step without one matching host suspension"
+                    .to_owned(),
+            });
+        }
+        found_pending = true;
+    }
+    if let Some(step_id) = suspended_step_id
+        && !found_pending
     {
         return Err(RuntimeError::GraphPlanningFailed {
-            step_id: step.step_id.clone(),
-            reason: "checkpoint contains a running step".to_owned(),
+            step_id: step_id.to_owned(),
+            reason: "pending checkpoint does not identify a running step".to_owned(),
         });
     }
     Ok(terminal_prefix_cursor(graph, state, sync_points, 0))
@@ -1468,7 +1599,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            checkpoint_planning_cursor(&graph, &state, &[]).expect("valid checkpoint"),
+            checkpoint_planning_cursor(&graph, &state, &[], None).expect("valid checkpoint"),
             2
         );
     }
@@ -1481,7 +1612,7 @@ mod tests {
             GraphStepStatus::Running,
         ]);
 
-        let error = checkpoint_planning_cursor(&graph, &state, &[])
+        let error = checkpoint_planning_cursor(&graph, &state, &[], None)
             .expect_err("running checkpoint must fail");
         assert!(
             error

--- a/crates/runx-runtime/src/execution/runner/step_handlers.rs
+++ b/crates/runx-runtime/src/execution/runner/step_handlers.rs
@@ -33,7 +33,7 @@ use super::admission::{
     recover_pending_effects, validate_replayed_effect,
 };
 use super::{
-    GraphRun, Runtime, StepRun, graph_run_ephemeral_result, graph_run_result,
+    GraphCheckpoint, GraphRun, Runtime, StepRun, graph_run_ephemeral_result, graph_run_result,
     graph_run_skill_output,
 };
 use crate::RuntimeError;
@@ -108,6 +108,7 @@ pub(super) struct StepRunRequest<'a, A> {
     pub(super) inputs: JsonObject,
     pub(super) provenance: Vec<ProvenanceEntry>,
     pub(super) policy_approval_refs: Vec<Reference>,
+    pub(super) child_checkpoint: Option<Box<GraphCheckpoint>>,
     pub(super) host: &'a mut dyn Host,
 }
 
@@ -120,6 +121,7 @@ struct StepHandlerCtx<'a, A> {
     inputs: JsonObject,
     provenance: Vec<ProvenanceEntry>,
     policy_approval_refs: Vec<Reference>,
+    child_checkpoint: Option<Box<GraphCheckpoint>>,
     host: &'a mut dyn Host,
     authority: Option<StepAuthorityContext>,
     loaded_skill: Option<LoadedStepSkill>,
@@ -191,6 +193,7 @@ where
         inputs,
         provenance,
         policy_approval_refs,
+        child_checkpoint,
         host,
     } = request;
     let effect_target = ResolvedEffectTarget {
@@ -252,6 +255,7 @@ where
         inputs,
         provenance,
         policy_approval_refs,
+        child_checkpoint,
         host,
         authority,
         loaded_skill,
@@ -280,6 +284,12 @@ where
     // `<step>.<packet>.data`, never the sub-skill's internal step ids.
     let runner_artifacts = skill.runner.artifacts.clone();
     let (skill_name, invocation) = loaded_skill_invocation(skill, &request)?;
+    if request.child_checkpoint.is_some() && invocation.source.source_type != SourceKind::Graph {
+        return Err(RuntimeError::InvalidRunStep {
+            step_id: request.step.id.clone(),
+            reason: "child graph checkpoint cannot resume a non-graph runner".to_owned(),
+        });
+    }
     crate::execution_environment::resolve_declared_environment(
         &invocation.requirements,
         &invocation.env,
@@ -343,7 +353,12 @@ where
     let skill_directory = invocation.skill_directory.clone();
     let invocation_env = invocation.env.clone();
     let policy_approval_refs = request.policy_approval_refs.clone();
-    let run = execute_nested_graph(request.runtime, request.host, &invocation)?;
+    let run = execute_nested_graph(
+        request.runtime,
+        request.host,
+        &invocation,
+        request.child_checkpoint,
+    )?;
     let result = graph_run_result(&run)?;
     let ephemeral_result = graph_run_ephemeral_result(&run);
     let mut output = graph_run_skill_output(&result, &run)?;
@@ -395,6 +410,7 @@ fn execute_nested_graph<A>(
     runtime: &Runtime<A>,
     host: &mut dyn Host,
     invocation: &SkillInvocation,
+    checkpoint: Option<Box<GraphCheckpoint>>,
 ) -> Result<GraphRun, RuntimeError>
 where
     A: SkillAdapter,
@@ -418,7 +434,15 @@ where
         runtime.javascript.clone(),
         runtime.local_artifacts.clone(),
     );
-    child_runtime.run_graph_with_host(&invocation.skill_directory, graph, host)
+    match checkpoint {
+        Some(checkpoint) => child_runtime.resume_graph_with_host(
+            &invocation.skill_directory,
+            graph,
+            *checkpoint,
+            host,
+        ),
+        None => child_runtime.run_graph_with_host(&invocation.skill_directory, graph, host),
+    }
 }
 
 /// A nested graph exposes the same canonical public result that a top-level
@@ -841,6 +865,12 @@ where
     A: SkillAdapter,
 {
     let kind = step_execution_kind(request.step)?;
+    if request.child_checkpoint.is_some() && !matches!(kind, StepExecutionKind::Subskill) {
+        return Err(RuntimeError::InvalidRunStep {
+            step_id: request.step.id.clone(),
+            reason: "child graph checkpoint requires a graph skill target".to_owned(),
+        });
+    }
     // Every registered step is admitted centrally (enforce_step_authority_admission,
     // upstream) and sealed centrally here: this is the single place a step's
     // admission witness records which authority admitted the act, or falls back to a
@@ -921,6 +951,7 @@ where
         authority,
         loaded_skill: _,
         policy_approval_refs,
+        child_checkpoint: _,
     } = request;
     let source = inline_source(step)?;
     let requirements = inline_step_requirements(step, &source);
@@ -1067,6 +1098,7 @@ where
         authority: _,
         loaded_skill: _,
         policy_approval_refs: _,
+        child_checkpoint: _,
     } = request;
     let source = agent_task_source(step)?;
     let requirements = inline_step_requirements(step, &source);
@@ -1103,6 +1135,7 @@ where
         return Err(RuntimeError::ResolutionPending {
             step_id: step.id.clone(),
             reason: format!("agent act {request_id} requires resolution"),
+            checkpoint: None,
         });
     };
     let verification_metadata = verified_agent_metadata_with_artifacts(
@@ -1211,6 +1244,7 @@ fn resolve_agent_act(
         .ok_or_else(|| RuntimeError::ResolutionPending {
             step_id: step.id.clone(),
             reason: format!("agent act {request_id} requires resolution"),
+            checkpoint: None,
         })
 }
 
@@ -1262,6 +1296,7 @@ where
         host: _,
         authority,
         loaded_skill: _,
+        child_checkpoint: _,
     } = request;
     #[cfg(not(feature = "catalog"))]
     {
@@ -1525,6 +1560,7 @@ fn completed_approval_resolution(
         return Err(RuntimeError::ResolutionPending {
             step_id: step.id.clone(),
             reason: format!("approval gate '{}' is pending", gate.id),
+            checkpoint: None,
         });
     }
     Ok(resolution)

--- a/crates/runx-runtime/src/execution/skill_front/graph.rs
+++ b/crates/runx-runtime/src/execution/skill_front/graph.rs
@@ -249,7 +249,9 @@ pub(super) fn execute_graph_skill_run(
                 )?;
                 checkpoint = next_checkpoint;
             }
-            Err(RuntimeError::ResolutionPending { .. }) if host.pending_request().is_some() => {
+            Err(RuntimeError::ResolutionPending {
+                checkpoint: paused, ..
+            }) if host.pending_request().is_some() => {
                 write_graph_state(
                     request,
                     workspace,
@@ -263,7 +265,8 @@ pub(super) fn execute_graph_skill_run(
                         execution_closure_digest: execution_closure_digest.to_owned(),
                         graph_inputs: graph_inputs.clone(),
                         resolution_answers: answers.clone(),
-                        checkpoint: previous_checkpoint,
+                        checkpoint: *paused
+                            .ok_or_else(|| invalid("graph pause omitted its checkpoint"))?,
                     },
                 )?;
                 let (request_id, request_value) = host
@@ -289,7 +292,9 @@ pub(super) fn execute_graph_skill_run(
                     request_value.clone(),
                 ));
             }
-            Err(RuntimeError::ResolutionPending { step_id, reason }) => {
+            Err(RuntimeError::ResolutionPending {
+                step_id, reason, ..
+            }) => {
                 return Err(invalid(format!(
                     "graph step {step_id:?} suspended without a pending host request: {reason}"
                 )));
@@ -1212,122 +1217,137 @@ mod tests {
         use runx_core::state_machine::{GraphStatus, create_sequential_graph_state};
         use runx_parser::{parse_graph_yaml, validate_graph};
 
-        let temp = tempfile::tempdir()?;
-        let receipt_dir = temp.path().join("receipts");
-        let graph = validate_graph(parse_graph_yaml(
-            r#"
+        for suspended in [false, true] {
+            let temp = tempfile::tempdir()?;
+            let receipt_dir = temp.path().join("receipts");
+            let graph = validate_graph(parse_graph_yaml(
+                r#"
 name: managed-agent-graph-failure
 steps:
   - id: compose
     skill: ./compose
 "#,
-        )?)?;
-        let checkpoint = GraphCheckpoint {
-            graph_name: graph.name.clone(),
-            state: create_sequential_graph_state(
-                graph.name.clone(),
-                &crate::execution::graph::step_definitions(&graph),
-            ),
-            steps: Vec::new(),
-            sync_points: Vec::new(),
-            journal: crate::ExecutionJournal::default(),
-        };
-        let runtime = Runtime::new(
-            SkillSourceAdapter::default(),
-            RuntimeOptions::local_development(std::env::vars().collect()),
-        );
-        let error = AgentResolverError::bounded_failure(
-            "round_budget_exhausted",
-            "Managed agent exceeded 3 tool-call rounds without finalizing.",
-            AgentExecutionTelemetry {
-                rounds: Some(3),
-                model_calls: Some(4),
-                tool_calls: Some(3),
-                tools: Some(vec!["data.read".to_owned()]),
-                tool_executions: Some(vec![AgentToolExecutionTrace {
-                    tool: "data.read".to_owned(),
-                    status: "success".to_owned(),
-                    receipt_id: Some("rct_child".to_owned()),
-                    resolution_kind: None,
-                }]),
-            },
-        );
-        let runtime_error = RuntimeError::managed_agent_resolution(
-            "referenced-agent-runner",
-            "agent_task.compose.output",
-            error,
-        )
-        .at_graph_step("compose");
-        let mut host = SkillRunGraphHost::new(ResolutionAnswers::default());
-        let run = runtime.seal_failed_graph_checkpoint_with_host(
-            graph,
-            checkpoint,
-            "compose",
-            runtime_error,
-            crate::receipts::GraphClosure {
-                disposition: ClosureDisposition::Failed,
-                reason_code: "managed_agent_round_budget_exhausted".to_owned(),
-                summary: "managed agent failed at compose".to_owned(),
-            },
-            &mut host,
-        )?;
+            )?)?;
+            let mut checkpoint = GraphCheckpoint {
+                graph_name: graph.name.clone(),
+                state: create_sequential_graph_state(
+                    graph.name.clone(),
+                    &crate::execution::graph::step_definitions(&graph),
+                ),
+                steps: Vec::new(),
+                sync_points: Vec::new(),
+                journal: crate::ExecutionJournal::default(),
+                suspended_step: None,
+            };
+            if suspended {
+                checkpoint.state.steps[0].status =
+                    runx_core::state_machine::GraphStepStatus::Running;
+                checkpoint.state.steps[0].attempts = 1;
+                checkpoint.suspended_step =
+                    Some(Box::new(crate::execution::runner::SuspendedGraphStep {
+                        step_id: "compose".to_owned(),
+                        child: None,
+                    }));
+            }
+            let runtime = Runtime::new(
+                SkillSourceAdapter::default(),
+                RuntimeOptions::local_development(std::env::vars().collect()),
+            );
+            let error = AgentResolverError::bounded_failure(
+                "round_budget_exhausted",
+                "Managed agent exceeded 3 tool-call rounds without finalizing.",
+                AgentExecutionTelemetry {
+                    rounds: Some(3),
+                    model_calls: Some(4),
+                    tool_calls: Some(3),
+                    tools: Some(vec!["data.read".to_owned()]),
+                    tool_executions: Some(vec![AgentToolExecutionTrace {
+                        tool: "data.read".to_owned(),
+                        status: "success".to_owned(),
+                        receipt_id: Some("rct_child".to_owned()),
+                        resolution_kind: None,
+                    }]),
+                },
+            );
+            let runtime_error = RuntimeError::managed_agent_resolution(
+                "referenced-agent-runner",
+                "agent_task.compose.output",
+                error,
+            )
+            .at_graph_step("compose");
+            let mut host = SkillRunGraphHost::new(ResolutionAnswers::default());
+            let run = runtime.seal_failed_graph_checkpoint_with_host(
+                graph,
+                checkpoint,
+                "compose",
+                runtime_error,
+                crate::receipts::GraphClosure {
+                    disposition: ClosureDisposition::Failed,
+                    reason_code: "managed_agent_round_budget_exhausted".to_owned(),
+                    summary: "managed agent failed at compose".to_owned(),
+                },
+                &mut host,
+            )?;
 
-        assert_eq!(run.state.status, GraphStatus::Failed);
-        assert_eq!(run.receipt.seal.disposition, ClosureDisposition::Failed);
-        assert_eq!(run.steps.len(), 1);
-        let step = &run.steps[0];
-        assert_eq!(step.receipt.seal.disposition, ClosureDisposition::Failed);
-        let metadata = step
-            .receipt
-            .metadata
-            .as_ref()
-            .ok_or("managed-agent failure metadata missing from child receipt")?;
-        let encoded = serde_json::to_string(metadata)?;
-        assert!(encoded.contains("\"reason_code\":\"round_budget_exhausted\""));
-        assert!(encoded.contains("\"model_calls\":4"));
-        assert!(encoded.contains("\"tool_calls\":3"));
-        assert!(!encoded.contains("prompt"));
-        assert!(!encoded.contains("credential"));
-        assert!(!encoded.contains("raw_output"));
+            assert_eq!(run.state.status, GraphStatus::Failed);
+            assert_eq!(run.receipt.seal.disposition, ClosureDisposition::Failed);
+            assert_eq!(run.steps.len(), 1);
+            assert_eq!(run.state.steps[0].attempts, 1);
+            let step = &run.steps[0];
+            assert_eq!(step.attempt, 1);
+            assert_eq!(step.receipt.seal.disposition, ClosureDisposition::Failed);
+            let metadata = step
+                .receipt
+                .metadata
+                .as_ref()
+                .ok_or("managed-agent failure metadata missing from child receipt")?;
+            let encoded = serde_json::to_string(metadata)?;
+            assert!(encoded.contains("\"reason_code\":\"round_budget_exhausted\""));
+            assert!(encoded.contains("\"model_calls\":4"));
+            assert!(encoded.contains("\"tool_calls\":3"));
+            assert!(!encoded.contains("prompt"));
+            assert!(!encoded.contains("credential"));
+            assert!(!encoded.contains("raw_output"));
 
-        let request = SkillRunRequest {
-            skill_path: temp.path().join("skill"),
-            receipt_dir: Some(receipt_dir.clone()),
-            run_id: None,
-            answers_path: None,
-            inputs: Default::default(),
-            env: Default::default(),
-            cwd: temp.path().to_path_buf(),
-            managed_agent: Default::default(),
-            local_credential: None,
-        };
-        let workspace = WorkspaceEnv::new(Default::default(), temp.path().to_path_buf())?;
-        let receipts = ReceiptServices::from_env_or_local_development(workspace.env())?;
-        write_graph_receipts(&request, &workspace, &receipts, &run)?;
-        let history = list_local_history(
-            &LocalReceiptStore::new(&receipt_dir),
-            temp.path(),
-            &temp.path().join(".runx"),
-            &HistoryFilter::default(),
-        )?;
-        assert_eq!(history.receipts.len(), 1);
-        assert!(
-            history
-                .receipts
-                .iter()
-                .all(|receipt| receipt.status == "failed")
-        );
-        assert!(history.pending_runs.is_empty());
-        let diagnostic_history = list_local_history(
-            &LocalReceiptStore::new(&receipt_dir),
-            temp.path(),
-            &temp.path().join(".runx"),
-            &HistoryFilter {
-                include_internal: true,
-                ..HistoryFilter::default()
-            },
-        )?;
-        assert_eq!(diagnostic_history.receipts.len(), 2);
+            let request = SkillRunRequest {
+                skill_path: temp.path().join("skill"),
+                receipt_dir: Some(receipt_dir.clone()),
+                run_id: None,
+                answers_path: None,
+                inputs: Default::default(),
+                env: Default::default(),
+                cwd: temp.path().to_path_buf(),
+                managed_agent: Default::default(),
+                local_credential: None,
+            };
+            let workspace = WorkspaceEnv::new(Default::default(), temp.path().to_path_buf())?;
+            let receipts = ReceiptServices::from_env_or_local_development(workspace.env())?;
+            write_graph_receipts(&request, &workspace, &receipts, &run)?;
+            let history = list_local_history(
+                &LocalReceiptStore::new(&receipt_dir),
+                temp.path(),
+                &temp.path().join(".runx"),
+                &HistoryFilter::default(),
+            )?;
+            assert_eq!(history.receipts.len(), 1);
+            assert!(
+                history
+                    .receipts
+                    .iter()
+                    .all(|receipt| receipt.status == "failed")
+            );
+            assert!(history.pending_runs.is_empty());
+            let diagnostic_history = list_local_history(
+                &LocalReceiptStore::new(&receipt_dir),
+                temp.path(),
+                &temp.path().join(".runx"),
+                &HistoryFilter {
+                    include_internal: true,
+                    ..HistoryFilter::default()
+                },
+            )?;
+            assert_eq!(diagnostic_history.receipts.len(), 2);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
A host pause inside a nested graph discarded completed child progress. Resuming release preparation consequently reran its commands and changed the digest of the pending release-notes request, so an answer bound to the original request was rejected.

Preserve the suspended step and recursive child checkpoint in the existing native graph engine. Resume the original attempt, retain completed outputs and effects, and propagate host suspension through serial fanout. Terminal failures also retain the original attempt. Checkpoint allocation occurs when execution yields; ordinary completed steps gain no persistence operation.

Validation: the new CLI journey fails before the fix and passes through two digest-bound host turns for nested, deeper nested, and serial fanout graphs. It verifies completed writes are not repeated and the final receipt tree is valid. The existing managed-agent failure test now covers both fresh and suspended failures. All-feature Clippy, all 1,732 native tests, and workspace doctests pass. Fast verification passes all 263 tests plus the release candidate smoke. The release dry run passed all five native builds, all five platform smoke tests, runtime-quality checks and channel-manifest validation.

Performance: distinct optimized baseline/candidate binaries were compared in four adjacent pairs across five existing workloads. Graph execution, module reuse, fanout and provider-finality median latency ratios were 0.993, 0.993, 1.002 and 0.994; all intervals included 1. Native wall time was noisy, so additional wall-time and process-CPU measurements were taken. No repeatable CPU increase was detected, and worker spawn counts stayed unchanged. This is local microbenchmark evidence and cannot guarantee an exactly zero timing change. An earlier comparison that reused the same Cargo executable was discarded.
