### PR TITLE
fix(registry): bundle schemas for every retained runner

### DIFF
--- a/crates/runx-runtime/src/registry/publish_package.rs
+++ b/crates/runx-runtime/src/registry/publish_package.rs
@@ -315,6 +315,7 @@ runners:
     fn publish_harness_preserves_local_sibling_execution_closure()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
+        fs::write(temp.path().join("pnpm-workspace.yaml"), "packages: []\n")?;
         let catalog = temp.path().join("skills");
         let root = catalog.join("root");
         let sibling = catalog.join("sibling");
@@ -368,8 +369,32 @@ runners:
           tool: data.digest
           inputs:
             value: sibling
+  verify:
+    type: agent
+    inputs:
+      provider_operation:
+        type: json
+        required: true
+        packet: runx.test.provider-operation.v1
+    outputs:
+      verification: object
+    artifacts:
+      named_emits:
+        verification: verification
+      packets:
+        verification: runx.test.verification.v1
 "#,
         )?;
+        fs::create_dir_all(temp.path().join("dist/packets"))?;
+        for (name, packet) in [
+            ("provider-operation", "runx.test.provider-operation.v1"),
+            ("verification", "runx.test.verification.v1"),
+        ] {
+            fs::write(
+                temp.path().join(format!("dist/packets/{name}.schema.json")),
+                format!(r#"{{"x-runx-packet-id":"{packet}","type":"object"}}"#),
+            )?;
+        }
         fs::create_dir_all(root.join("packets"))?;
         fs::write(
             root.join("packets/sibling.schema.json"),
@@ -396,6 +421,13 @@ runners:
         assert!(package_paths.contains(&"runx.package.json"));
         assert!(package_paths.contains(&"dependencies/sibling/SKILL.md"));
         assert!(package_paths.contains(&"dependencies/sibling/X.yaml"));
+        for schema in ["provider-operation", "verification"] {
+            assert!(
+                package_paths.contains(
+                    &format!("dependencies/sibling/packets/{schema}.schema.json").as_str()
+                )
+            );
+        }
         let harness_path = package
             .harness
             .as_ref()

--- a/crates/runx-runtime/src/registry/publish_package/files/packet.rs
+++ b/crates/runx-runtime/src/registry/publish_package/files/packet.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 
 use super::insert_source_file;
 use crate::LoadedSkillPackage;
-use crate::packet_schemas::{PacketSchemaCatalog, packet_schema_directories};
+use crate::packet_schemas::{
+    PacketSchemaCatalog, declared_runner_packet_ids, declared_tool_packet_ids,
+    packet_schema_directories,
+};
 use crate::registry::RegistryPackageFile;
 use crate::registry::publish_package::RegistryPublishPackageError;
 
@@ -14,7 +17,18 @@ pub(super) fn append_declared_packet_schemas(
     cwd: &Path,
     packet_ids: &std::collections::BTreeSet<String>,
 ) -> Result<(), RegistryPublishPackageError> {
-    if packet_ids.is_empty() {
+    // Bundles retain the full manifest, including runners outside the selected execution closure.
+    let mut required_packet_ids = packet_ids.clone();
+    required_packet_ids.extend(loaded.resolved_input_packet_schemas.keys().cloned());
+    for manifest in loaded.package.profiles.values() {
+        for runner in manifest.runners.values() {
+            required_packet_ids.extend(declared_runner_packet_ids(runner));
+        }
+    }
+    for package_tool in loaded.package.tools.values() {
+        required_packet_ids.extend(declared_tool_packet_ids(&package_tool.tool));
+    }
+    if required_packet_ids.is_empty() {
         return Ok(());
     }
     let workspace = crate::resolve_runx_workspace_base(env, cwd);
@@ -41,7 +55,7 @@ pub(super) fn append_declared_packet_schemas(
         .map_err(|error| {
             RegistryPublishPackageError::invalid(format!("packet schema catalog failed: {error}"))
         })?;
-    for packet_id in packet_ids {
+    for packet_id in &required_packet_ids {
         let Some(schema) = loaded
             .resolved_input_packet_schemas
             .get(packet_id)


### PR DESCRIPTION
Dependency bundles retained every runner in the manifest but packaged only packet schemas encountered through the selected execution closure. A sibling selected through its default runner could therefore become unloadable after publication when another runner required a workspace-provided input schema.

Include the already-resolved input schemas and the packet declarations of all retained runners and tools. Reuse the existing contract helpers and schema catalog, with the existing conflict and package-size checks. This runs only when preparing registry packages; execution and resume paths are unchanged.

The native issue was identified in #397. This isolates that repair from its skill changes and extends the existing sibling-bundle test instead of adding a duplicate fixture. The test proves both input and output schemas are packaged and replays the staged bundle.

Validation: the extended regression failed before the fix and passed afterward; all 542 runtime library tests and all-feature runtime Clippy passed. The full local fast gate passed (263 fast tests plus CLI release smoke), and all 1,732 native tests passed with none skipped. Workspace documentation tests also passed. Required source CI passed, including the official skill audit and harness sweep.
