### PR TITLE
docs(skill): fix credentials guide link in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -245,7 +245,7 @@ Consequential run pattern:
 - doctrine: <https://runx.ai/doctrine>
 - catalog: <https://runx.ai/x>
 - source: <https://github.com/runxhq/runx>
-- credentials: <https://github.com/runxhq/runx/blob/main/oss/docs/credentials.md>
+- credentials: <https://github.com/runxhq/runx/blob/main/docs/credentials.md>
 
 Open source. Apache-2.0 licensed. Self-hostable. Works with local agents and hosted
 surfaces because the skill contract, authority model, and receipts are portable.


### PR DESCRIPTION
Fixes #447

## Summary

- Correct the credentials link in the public `SKILL.md`.
- Point it to the existing `docs/credentials.md` guide.

The previous `oss/docs/credentials.md` URL returned 404, while the replacement URL returns 200.

## Verification

- `git diff --check`
- `tsc -p tsconfig.typecheck.json --noEmit`
- Verified the old and replacement URLs over HTTPS (`404` → `200`).