### PR TITLE
feat(skills): add postmortem maker

### DIFF
--- a/evidence/evidence.json
+++ b/evidence/evidence.json
@@ -1,0 +1,228 @@
+{
+  "schema": "postmortem-maker.delivery-draft.v1",
+  "draft_status": "blocked_for_external_release",
+  "package": {
+    "name": "postmortem-maker",
+    "version": "0.1.0",
+    "draft_package_manifest_digest": "sha256:3a3239dbeaf28cbe1f7ba1c6ef6e02f31754b566a1a53c611021842f27bf5ced",
+    "registry_ref": null,
+    "publisher_owner": null
+  },
+  "public_url": null,
+  "source_url": null,
+  "pr_url": null,
+  "x_yaml": null,
+  "skill_md": null,
+  "verification_json": "evidence/verification.json",
+  "report": "evidence/report.md",
+  "receipt_ref": null,
+  "observations": [
+    {
+      "name": "runx_cli_version",
+      "command": "runx --version",
+      "exit_code": 0,
+      "exact_output": "runx-cli 0.6.15",
+      "status": "passed",
+      "note": "The pinned @runxhq/cli 0.6.15 binary is installed and satisfies the required 0.6.14-or-newer minimum."
+    },
+    {
+      "name": "package_identity",
+      "package_name": "postmortem-maker",
+      "version": "0.1.0",
+      "status": "passed_locally"
+    },
+    {
+      "name": "source_read_contract",
+      "status": "passed_locally",
+      "details": "The step accepts HTTPS GitHub issue/thread handles, upstream read_projection objects, and fixture-only harness handles. Both checked-in fixtures and a public GitHub issue were read at runtime in local prepublish checks."
+    },
+    {
+      "name": "long_event_body_regression",
+      "status": "passed_locally",
+      "command": "node tests/postmortem-maker-smoke.mjs",
+      "details": "A 2,500-character inline event body is accepted and preserved. GitHub issue bodies are bounded by clampText after non-empty validation instead of being rejected by the shorter scalar-field limit."
+    },
+    {
+      "name": "timeline_citations",
+      "status": "passed_locally",
+      "details": "Every local timeline entry and root-cause citation points to an event id and preserves the event text verbatim."
+    },
+    {
+      "name": "consistent_case",
+      "status": "passed_locally",
+      "details": "The direct smoke test and native runx harness both passed: four source events produced a confirmed root cause, zero unknowns, an authorized send plan, an executed local-outbox publish result, and digest-matching readback."
+    },
+    {
+      "name": "conflicting_case",
+      "status": "passed_locally",
+      "details": "The direct smoke test and native runx harness both passed: two hedged competing causal candidates produced an unconfirmed root cause, two unknowns, no publish result, and an absence readback."
+    },
+    {
+      "name": "idempotent_replay",
+      "status": "passed_locally",
+      "details": "A second consistent-case execution replayed the same message without incrementing the outbox version."
+    },
+    {
+      "name": "fixture_boundary",
+      "status": "passed_locally",
+      "details": "A fixture reference containing .. was refused before file access."
+    },
+    {
+      "name": "yaml_contract",
+      "status": "passed_locally",
+      "details": "X.yaml parsed with PyYAML and contains the exact package name, version, graph runner, and both required case names."
+    },
+    {
+      "name": "runx_harness",
+      "status": "passed_locally",
+      "command": "runx harness ./skills/postmortem-maker --json",
+      "cli_version": "runx-cli 0.6.15",
+      "case_names": [
+        "consistent-incident-published",
+        "conflicting-evidence-withheld"
+      ],
+      "receipt_refs": [
+        "sha256:c32a641142a378bcf2fc64b39615813a4ad6c271bc5ce3cece072bbc4dbb2514",
+        "sha256:1e8d6add7aa953f096acc5811e5d157a0e50b241cafc2ff688e33ce3dc0c6608"
+      ],
+      "details": "Native runx graph harness passed both fixture cases with zero assertion errors. These are local fixture receipts, not the required post-publish real-source dogfood receipt."
+    },
+    {
+      "name": "publish_flow",
+      "status": "not_run",
+      "required_commands": [
+        "runx login --provider github --for publish",
+        "runx registry publish ./skills/postmortem-maker/SKILL.md --registry https://api.runx.ai"
+      ],
+      "note": "Not executed: it requires an authorized publisher identity and an external registry write."
+    },
+    {
+      "name": "install_flow",
+      "status": "not_run",
+      "command_template": "runx add <owner>/postmortem-maker@0.1.0 --registry https://api.runx.ai"
+    },
+    {
+      "name": "hosted_harness",
+      "status": "not_run",
+      "note": "No publish or registry admission was attempted."
+    },
+    {
+      "name": "real_dogfood",
+      "status": "prepublish_only",
+      "input": {
+        "incident_source": {
+          "kind": "thread_url",
+          "url": "https://github.com/kubernetes/kubernetes/issues/141080"
+        },
+        "postmortem_policy": {
+          "require_confirmed_root_cause": true,
+          "require_action_items": false,
+          "allow_publish": true
+        },
+        "publish_target": {
+          "data_source_ref": "local://runx-postmortem-maker/dogfood/k8s-141080-verified",
+          "channel": "incident-review",
+          "aggregate_id": "k8s-141080",
+          "principal": "postmortem-maker",
+          "audience": "incident-review"
+        }
+      },
+      "command": "runx skill ./skills/postmortem-maker --json",
+      "receipt_ref": "sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44",
+      "verify_command": "runx verify sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44 --receipt-dir /tmp/ajp-83-audit.rekpyc/receipts --json",
+      "verify_verdict": "valid",
+      "details": "A real public GitHub issue was fetched at runtime with the local package. The graph sealed with a confirmed root cause, zero unknowns, an executed local-outbox send-as-equivalent action, provider_act_performed=true, and digest-matching readback. This is prepublish evidence only; it is not the required post-publish registry dogfood."
+    },
+    {
+      "name": "receipt_verification",
+      "status": "passed_locally",
+      "command_template": "runx verify --receipt <receipt.json> --json",
+      "command": "runx verify sha256:2e25f56d3599c4769d331b68b35b861e7ec51011dead694237434850a9dc4af9 --receipt-dir .runx/receipts --json",
+      "receipt_ref": "sha256:2e25f56d3599c4769d331b68b35b861e7ec51011dead694237434850a9dc4af9",
+      "verify_verdict": "valid",
+      "details": "Local fixture receipt tree verified with the matching temporary public key; this is not the required post-publish real-source receipt."
+    }
+  ],
+  "local_validation": {
+    "command": "node tests/postmortem-maker-smoke.mjs",
+    "status": "passed",
+    "output": {
+      "status": "passed",
+      "cases": [
+        {"name": "consistent-incident-published", "status": "sealed", "publishable": true, "delivery": "executed"},
+        {"name": "conflicting-evidence-withheld", "status": "sealed", "publishable": false, "unknowns": 2, "delivery": null},
+        {"name": "idempotent-replay", "status": "passed", "replayed": true},
+        {"name": "fixture-traversal-refused", "status": "refused"},
+        {"name": "source-allowlist-refused", "status": "refused"},
+        {"name": "long-event-body-accepted", "status": "passed"}
+      ]
+    },
+    "scope": "Direct step-handler smoke test; the native runx harness result is recorded separately and covers the same two fixture cases.",
+    "native_harness": {
+      "command": "runx harness ./skills/postmortem-maker --json",
+      "status": "passed",
+      "case_count": 2,
+      "assertion_error_count": 0,
+      "receipt_refs": [
+        "sha256:c32a641142a378bcf2fc64b39615813a4ad6c271bc5ce3cece072bbc4dbb2514",
+        "sha256:1e8d6add7aa953f096acc5811e5d157a0e50b241cafc2ff688e33ce3dc0c6608"
+      ]
+    }
+  },
+  "dogfood": {
+    "status": "prepublish_only",
+    "package": "./skills/postmortem-maker",
+    "version": "0.1.0",
+    "input": {
+      "incident_source": {
+        "kind": "thread_url",
+        "url": "https://github.com/kubernetes/kubernetes/issues/141080"
+      },
+      "postmortem_policy": {
+        "require_confirmed_root_cause": true,
+        "require_action_items": false,
+        "allow_publish": true
+      },
+      "publish_target": {
+        "data_source_ref": "local://runx-postmortem-maker/dogfood/k8s-141080-verified",
+        "channel": "incident-review",
+        "aggregate_id": "k8s-141080",
+        "principal": "postmortem-maker",
+        "audience": "incident-review"
+      }
+    },
+    "command": "runx skill ./skills/postmortem-maker --json",
+    "receipt_ref": "sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44",
+    "verify_command": "runx verify sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44 --receipt-dir /tmp/ajp-83-audit.rekpyc/receipts --json",
+    "verify_verdict": "valid",
+    "result": {
+      "status": "sealed",
+      "publishable": true,
+      "root_cause_status": "confirmed",
+      "timeline_count": 2,
+      "unknowns": 0,
+      "publish_result_status": "executed",
+      "delivery_status": "delivered",
+      "provider_act_performed": true,
+      "readback_digest_match": true,
+      "outbox_version_after": 1
+    },
+    "harness_cases": [
+      {"name": "consistent-incident-published", "status": "local_harness_passed"},
+      {"name": "conflicting-evidence-withheld", "status": "local_harness_passed"}
+    ],
+    "reason": "The real-source run and receipt verification passed against the local prepublish package. The required post-publish registry dogfood still requires the authenticated release and must be rerun against the published owner/version."
+  },
+  "security": {
+    "secrets_in_artifacts": false,
+    "credentials_used": false,
+    "external_writes_attempted": false,
+    "notes": "No login, registry publish, PR, remote push, provider send, or funds operation was attempted."
+  },
+  "completion_blockers": [
+    "A human publisher must perform the authenticated registry publish and record owner, version, public_url, and registry metadata digest.",
+    "A public source repository and PR head commit must be created by an authorized operator; raw X.yaml and SKILL.md URLs are still unknown.",
+    "A post-publish real-source dogfood run must produce a sealed receipt and a passing runx verify result.",
+    "Hosted harness admission and the preflight POST must be performed outside this restricted workspace."
+  ]
+}

--- a/evidence/report.md
+++ b/evidence/report.md
@@ -1,0 +1,105 @@
+# postmortem-maker delivery draft
+
+Status: blocked for external release.
+
+This workspace contains a reviewable `postmortem-maker` package at version
+`0.1.0`. The package is source-first: it reads a bounded public GitHub issue at
+runtime (or an upstream read projection), keeps exact event citations, places
+uncertainty in `unknowns[]`, and executes a digest-bound local outbox append
+only when `postmortem_policy.allow_publish` is explicitly true. The second
+step reads the outbox back, so the successful path records an executed
+send-as-shaped plan and readback rather than an inert proposal.
+
+## Local evidence
+
+The direct step-handler smoke test passed:
+
+```text
+node tests/postmortem-maker-smoke.mjs
+{"status":"passed","cases":[{"name":"consistent-incident-published","status":"sealed","publishable":true,"delivery":"executed"},{"name":"conflicting-evidence-withheld","status":"sealed","publishable":false,"unknowns":2,"delivery":null},{"name":"idempotent-replay","status":"passed","replayed":true},{"name":"fixture-traversal-refused","status":"refused"},{"name":"source-allowlist-refused","status":"refused"},{"name":"long-event-body-accepted","status":"passed"}]}
+```
+
+The consistent fixture produces a confirmed root cause, four source-cited
+timeline entries, an executed local publish result, and a digest-matching
+readback. The conflicting fixture produces an unconfirmed root cause, two
+unknowns, no publish result, and a readback proving no delivery. These are
+local fixture checks. The smoke test also exercises a 2,500-character event
+body, preventing the GitHub issue-body regression found during dogfood.
+The native runx harness passes both graph cases and emits local fixture
+receipts; those receipts are not the required post-publish real-source
+dogfood receipt.
+
+`X.yaml` also parses successfully with PyYAML, and `node --check` passes for
+all six step modules and the smoke test.
+
+## Native runx validation
+
+The pinned CLI is installed and the exact command returned:
+
+```text
+runx-cli 0.6.15
+```
+
+The native graph harness passed with two cases and zero assertion errors:
+
+```text
+runx harness ./skills/postmortem-maker --json
+status=passed
+case_count=2
+assertion_error_count=0
+receipt_refs=sha256:c32a641142a378bcf2fc64b39615813a4ad6c271bc5ce3cece072bbc4dbb2514, sha256:1e8d6add7aa953f096acc5811e5d157a0e50b241cafc2ff688e33ce3dc0c6608
+```
+
+The receipts above cover checked-in fixtures only. This draft still does not
+claim a clean `runx add`, a hosted harness, registry publication, or a
+post-publish `runx skill` dogfood. No login, registry write, PR, remote push,
+external provider send, or funds operation was attempted.
+
+The local fixture receipt tree was separately checked with `runx verify` using
+the matching temporary public key and returned `valid=true`. This local check
+does not satisfy the post-publish real-source receipt requirement.
+
+## Prepublish real-source dogfood
+
+Before publication, the local package was run against the public GitHub issue
+`https://github.com/kubernetes/kubernetes/issues/141080` using the runtime
+GitHub API reader, not a checked-in fixture. The graph sealed with a confirmed
+root cause, two source events, zero unknowns, an executed local-outbox
+send-as-equivalent action, `provider_act_performed=true`, and a digest-matching
+readback. The root receipt was
+`sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44`;
+the production-mode `runx verify` tree returned `valid=true`.
+
+This is intentionally labeled prepublish evidence. It proves the corrected
+local implementation can consume a real source and perform the sealed local
+workflow, but it is not the required post-publish owner/version dogfood.
+
+The package manifest digest used only for this draft is
+`sha256:3a3239dbeaf28cbe1f7ba1c6ef6e02f31754b566a1a53c611021842f27bf5ced`.
+It describes the earlier frozen AJP review package and is not a hosted
+registry digest or a substitute for a public source revision. Because the
+GitHub issue-body fix and its regression test were added afterward, the
+pending AJP approval package must be regenerated before anyone approves it.
+
+## Human completion checklist
+
+An authorized operator with the real CLI and a public source repository must
+complete the following outside this restricted workspace, then replace the
+null fields in `evidence/evidence.json` and `evidence/verification.json` with
+captured values:
+
+```text
+runx harness ./skills/postmortem-maker
+runx login --provider github --for publish
+runx registry publish ./skills/postmortem-maker/SKILL.md --registry https://api.runx.ai
+runx add <owner>/postmortem-maker@<version> --registry https://api.runx.ai
+runx registry read <owner>/postmortem-maker@<version> --json
+runx skill <owner>/postmortem-maker@<version> --registry https://api.runx.ai --json ...
+runx verify --receipt <receipt.json> --json
+```
+
+The dogfood input must be a real public incident/thread URL or a real
+incident/ticket read projection read at runtime, not either checked-in fixture.
+The evidence packet must then use the same package version and source revision
+for the registry ref, PR head, raw `X.yaml`, raw `SKILL.md`, receipt, and
+report before an authorized operator submits the platform preflight.

--- a/evidence/verification.json
+++ b/evidence/verification.json
@@ -1,0 +1,86 @@
+{
+  "schema": "postmortem-maker.verification-draft.v1",
+  "status": "blocked",
+  "package": "postmortem-maker",
+  "version": "0.1.0",
+  "draft_package_manifest_digest": "sha256:3a3239dbeaf28cbe1f7ba1c6ef6e02f31754b566a1a53c611021842f27bf5ced",
+  "runx_cli": {
+    "command": "runx --version",
+    "exit_code": 0,
+    "exact_output": "runx-cli 0.6.15",
+    "meets_minimum": true
+  },
+  "checks": {
+    "skill_md_frontmatter": "passed",
+    "x_yaml_parse": "passed",
+    "local_consistent_case": "passed",
+    "local_conflicting_case": "passed",
+    "local_idempotent_replay": "passed",
+    "local_fixture_boundary": "passed",
+    "long_event_body_regression": "passed",
+    "runx_harness": "passed",
+    "registry_publish": "not_run",
+    "clean_install": "not_run",
+    "hosted_harness": "not_run",
+    "real_source_dogfood": "pending_post_publish",
+    "prepublish_real_source_dogfood": "passed_local_pre_publish",
+    "receipt_verify": "not_run_external",
+    "prepublish_receipt_verify": "passed",
+    "delivery_preflight": "not_run"
+  },
+  "native_harness": {
+    "command": "runx harness ./skills/postmortem-maker --json",
+    "status": "passed",
+    "case_count": 2,
+    "assertion_error_count": 0,
+    "receipt_refs": [
+      "sha256:c32a641142a378bcf2fc64b39615813a4ad6c271bc5ce3cece072bbc4dbb2514",
+      "sha256:1e8d6add7aa953f096acc5811e5d157a0e50b241cafc2ff688e33ce3dc0c6608"
+    ],
+    "note": "Local fixture harness receipts only; no external publication or post-publish real-source dogfood is claimed. The separate prepublish real-source run is recorded below."
+  },
+  "local_receipt_verification": {
+    "command": "runx verify sha256:2e25f56d3599c4769d331b68b35b861e7ec51011dead694237434850a9dc4af9 --receipt-dir .runx/receipts --json",
+    "status": "passed",
+    "valid": true,
+    "note": "Local fixture receipt tree only; external real-source receipt verification remains pending."
+  },
+  "prepublish_real_source_dogfood": {
+    "package": "./skills/postmortem-maker",
+    "version": "0.1.0",
+    "source_url": "https://github.com/kubernetes/kubernetes/issues/141080",
+    "command": "runx skill ./skills/postmortem-maker --json",
+    "receipt_ref": "sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44",
+    "verify_command": "runx verify sha256:70b368ab108417b19092cb77e2f50b98d29f1f9623f87c426af2fbc48e73bb44 --receipt-dir /tmp/ajp-83-audit.rekpyc/receipts --json",
+    "verify_status": "passed",
+    "verify_valid": true,
+    "result": {
+      "graph_status": "Succeeded",
+      "root_cause_status": "confirmed",
+      "timeline_count": 2,
+      "unknowns": 0,
+      "publish_result_status": "executed",
+      "delivery_status": "delivered",
+      "provider_act_performed": true,
+      "readback_digest_match": true,
+      "outbox_version_after": 1
+    },
+    "boundary": "This is a local prepublish package run. It does not satisfy the required post-publish owner/version dogfood."
+  },
+  "receipt": {
+    "receipt_ref": null,
+    "status": "not_available_post_publish",
+    "verify_verdict": null
+  },
+  "external_artifacts": {
+    "publisher_owner": null,
+    "registry_ref": null,
+    "public_url": null,
+    "source_url": null,
+    "pr_url": null,
+    "x_yaml": null,
+    "skill_md": null,
+    "report": "evidence/report.md"
+  },
+  "honesty_boundary": "This file records local implementation checks and a separately labeled prepublish real-source dogfood. It does not attest to registry publication, clean install, hosted harness admission, post-publish owner/version dogfood, the required final receipt, or online verification."
+}

--- a/skills/postmortem-maker/SKILL.md
+++ b/skills/postmortem-maker/SKILL.md
@@ -1,55 +1,141 @@
 ---
 name: postmortem-maker
-description: Turn resolved-incident fragments into a traceable postmortem that separates fragment-cited facts from hypotheses, blocks publication while unknowns remain, and keeps the comms send behind a human gate.
+description: Reconstruct a source-cited incident postmortem and execute a bounded, digest-bound publication only when the source and policy both allow it.
+runx:
+  category: ops
+  tags:
+    - incident-response
+    - postmortem
+    - evidence
+    - send-as
 ---
 
 # Postmortem Maker
 
-Produce a postmortem that never pretends unknowns are facts. The supplied
-incident fragments are the only evidence; the drafting agent separates what
-happened from what is suspected, and deterministic code verifies every claimed
-fact against the fragments. Publication is a gated proposal, never an effect
-of this skill.
+Turn one incident source into a traceable postmortem. The skill preserves the
+difference between what the source says, what remains uncertain, and what a
+publication policy permits. It never turns a hypothesis into a fact.
+
+## Inputs
+
+The typed input is an `incident_source` handle plus a `postmortem_policy`.
+`publish_target` is optional and is required only when the policy authorizes a
+publication.
+
+`incident_source` accepts these forms:
+
+* `{ "kind": "thread_url", "url": "https://github.com/OWNER/REPO/issues/123" }`
+  reads a public GitHub issue and its comments at run time. The read is bounded
+  to the issue and the first 100 comments; the source digest binds the exact
+  normalized events that were read.
+* `{ "kind": "github_issue", "url": "https://api.github.com/repos/OWNER/REPO/issues/123" }`
+  is the equivalent explicit API form.
+* `{ "kind": "read_projection", "ref": "incident://...", "projection": { ... } }`
+  accepts a projection already materialized by an upstream governed incident
+  or ticket read. The projection must contain a title and non-empty `events`.
+* `{ "kind": "fixture", "ref": "fixtures/.../thread.json" }` and
+  `{ "kind": "inline", "ref": "inline://...", "thread": { ... } }` are
+  deterministic harness-only forms. They are not evidence of a real-source
+  dogfood run.
+
+Every event must have a stable `id` and non-empty `text`. `at`, `author`, and
+`url` are carried through when present. Timeline entries and root-cause
+claims quote the exact event text and include the event id, author, time, and
+source URL as evidence.
+
+`postmortem_policy` supports:
+
+* `require_confirmed_root_cause` — defaults to `true`; a suspected or
+  competing cause cannot authorize publication.
+* `require_action_items` — when `true`, at least one source-stated action item
+  is required.
+* `allow_publish` — defaults to `false`; it must be explicitly `true` before
+  the send-as-equivalent transport can execute.
+
+An optional `publish_target` has `data_source_ref`, `channel`, and
+`aggregate_id`. It may also include `principal`, `audience`, `classification`,
+and `visibility`. These values are copied into the bounded send plan; they do
+not grant authority by themselves.
 
 ## Procedure
 
-1. Native `data.digest` binds the exact fragment set.
-2. The drafting agent assembles a summary, an evidence-cited timeline, a root
-   cause with a status of `known`, `suspected`, or `unknown`, open unknowns,
-   and owned action items.
-3. Deterministic enforcement checks every timeline entry and any non-unknown
-   root cause: the cited fragment must exist and the quote must appear
-   verbatim in that fragment's text. An invented citation refuses the whole
-   run. Action items must carry an action and an owner.
-4. The verdict separates completeness from honesty: a fully cited postmortem
-   with a supported root cause and no open unknowns is `publishable` and
-   carries a publish proposal gated on a human approver through `send-as`; a
-   grounded but incomplete one seals `needs_more_evidence` and publishes
-   nothing.
+1. Read the source at execution time and bind the normalized event set to a
+   SHA-256 source digest.
+2. Build one timeline entry per readable event. Classify impact, mitigation,
+   hypotheses, observations, and action items without changing the evidence
+   quote.
+3. Confirm a root cause only when one causal candidate is stated without
+   hedge language and no distinct candidate competes with it. Hedged or
+   conflicting candidates are recorded in `unknowns` and block publication.
+4. Emit `postmortem` with `summary`, `timeline`, `impact`, `root_cause`, and
+   `status`, plus `unknowns` and source-grounded `action_items`.
+5. If the evidence is complete and `allow_publish` is explicitly true,
+   compose a send-as-shaped plan. The bundled local outbox is an equivalent
+   sealed comms transport: it performs a compare-and-set append, binds the
+   exact postmortem content digest, enforces idempotency, and returns an
+   executed `publish_result`.
+6. Re-read the outbox and re-check the content and postmortem digests. A
+   withheld path proves the absence of a send plan, provider act, and delivery
+   for the selected aggregate.
 
-To build the fragment set from live systems, compose `web-fetch` or
-`data-store` reads upstream; the digest binds whatever evidence was supplied.
-`incident-commander` owns running the incident; this skill owns explaining it
-afterward.
+The transport is deliberately local and append-only. It is not a claim that a
+hosted Slack, email, or ticket provider delivered a message. An operator who
+needs a provider send should use a separate approved provider adapter after
+reviewing this sealed packet.
 
-## Output
+## Output contract
 
-`postmortem` (`runx.postmortem.v1`) carries `decision` (`publishable`,
-`needs_more_evidence`, `refused`), `summary`, the cited `timeline`,
-`root_cause`, `unknowns`, `action_items`, the gated `publish_proposal` or
-null, `validation`, and the fragments digest. `publish_performed` is always
-false.
+The final graph result is `runx.postmortem-maker.result.v1`:
 
-Inputs are `incident_ref` and `incident_fragments`.
+* `postmortem` — the source-cited postmortem packet. `root_cause.status` is
+  `confirmed` or `unconfirmed`; `postmortem.status` is `publishable` or
+  `needs_more_evidence`.
+* `unknowns[]` — objects with `id`, `detail`, and any supporting `evidence`.
+  Missing evidence is never silently filled in.
+* `action_items[]` — objects with `id`, `title`, `owner`, `evidence`, and
+  `policy_rule`. `owner` is `null` when the source did not state one.
+* `send_plan` — authorized or withheld, shaped like the `send-as` planning
+  boundary.
+* `publish_result` — the executed, digest-bound result when publication ran;
+  otherwise `null`.
+* `readback` and `verification` — independent outbox evidence.
 
-## Agent task contracts
+## Stop conditions
 
-### `postmortem-maker-draft`
+Stop with a sealed refusal or failed step when the source handle is malformed,
+the public GitHub source is not HTTPS or not a GitHub issue, the projection has
+no readable events, event ids are duplicated, the outbox has an invalid shape,
+the compare-and-set version changed, or an idempotency key is reused for
+different content.
 
-Read `incident_ref` and `incident_fragments` from step inputs. Return
-`postmortem_draft` with `summary`, `timeline` entries (each `entry`,
-`fragment_id`, `quote`), `root_cause` (`status`, and for known or suspected a
-`statement`, `fragment_id`, and `quote`), `unknowns`, and `action_items`
-(each `action`, `owner`). Quote fragments verbatim, mark anything the
-fragments do not support as unknown rather than asserting it, and never
-invent fragments, quotes, owners, or deadlines.
+Withhold publication when the root cause is unconfirmed, impact or mitigation
+is still unknown, required action evidence is absent, or
+`postmortem_policy.allow_publish` is not explicitly true. A withheld run is a
+valid evidence result, not a successful send.
+
+Do not place credentials, cookies, authorization headers, private incident
+body data, or ambient environment values in inputs or outputs. The GitHub read
+uses no credential and the receipt-facing data contains only bounded source
+events, hashes, and redacted metadata.
+
+## Install, run, and verify
+
+After a maintainer publishes a version, a new operator can use the package
+without private context:
+
+```text
+runx add <owner>/postmortem-maker@<version> --registry https://api.runx.ai
+
+runx skill <owner>/postmortem-maker@<version> --registry https://api.runx.ai --json \
+  --input-json incident_source='{"kind":"thread_url","url":"https://github.com/OWNER/REPO/issues/123"}' \
+  --input-json postmortem_policy='{"require_confirmed_root_cause":true,"allow_publish":false}' \
+  --input-json publish_target='{"data_source_ref":"local://postmortems/review","channel":"incident-review","aggregate_id":"incident-123"}' \
+  -R ./receipts
+
+runx verify --receipt ./receipts/<sealed-receipt>.json --json
+```
+
+Only set `allow_publish:true` after the operator has reviewed the source and
+intends to append the postmortem to the explicit local outbox target. The
+receipt's `publish_result` and `readback` are the evidence for the executed
+same-run send plan; a proposal without those fields is not a publication.

--- a/skills/postmortem-maker/X.yaml
+++ b/skills/postmortem-maker/X.yaml
@@ -3,288 +3,291 @@ version: "0.1.0"
 
 catalog:
   kind: graph
-  audience: operator
+  audience: public
   visibility: public
   role: canonical
-  execution: plan
-  completion: runtime_receipt
-  requires_adapter: false
-  approval: none
 
 harness:
   cases:
-    - name: postmortem-maker-publishable-seals
-      operator_journeys:
-        - mode: standalone
-          confusors: [incident-commander, answer-from-docs]
-          request: Produce the postmortem for this resolved incident from the collected fragments.
-          expected_outcome: Return a fragment-cited postmortem with a supported root cause and a gated publish proposal, publishing nothing.
-        - mode: composed
-          request: Continue from this sealed postmortem into the governed comms send.
-          expected_outcome: Reuse the sealed postmortem and its publish proposal without re-deriving the timeline.
-          prior_evidence:
-            - The incident fragments and sealed postmortem supplied by the prior step.
-          must_not_repeat:
-            - Do not re-derive timeline entries or the root cause already sealed.
+    - name: consistent-incident-published
+      runner: default
       inputs:
-        incident_ref: inc-checkout-2026-08-09
-        incident_fragments:
-          - id: frag-1
-            source: pagerduty
-            text: "03:12 UTC alert fired: checkout 5xx rate crossed 8 percent."
-          - id: frag-2
-            source: deploy-log
-            text: "03:02 UTC deploy 2026.08.09.3 rolled out a connection pool change to checkout-api."
-          - id: frag-3
-            source: slack-incident
-            text: "03:40 UTC rollback of 2026.08.09.3 completed and 5xx rate returned to baseline."
-      caller:
-        answers:
-          agent_task.postmortem-maker-draft.output:
-            postmortem_draft:
-              summary: A connection pool change in deploy 2026.08.09.3 degraded checkout until rollback.
-              timeline:
-                - entry: Deploy 2026.08.09.3 shipped a connection pool change.
-                  fragment_id: frag-2
-                  quote: "deploy 2026.08.09.3 rolled out a connection pool change"
-                - entry: Checkout 5xx rate crossed the alert threshold.
-                  fragment_id: frag-1
-                  quote: "checkout 5xx rate crossed 8 percent"
-                - entry: Rollback restored baseline.
-                  fragment_id: frag-3
-                  quote: "rollback of 2026.08.09.3 completed and 5xx rate returned to baseline"
-              root_cause:
-                status: known
-                statement: The connection pool change in 2026.08.09.3 exhausted checkout database connections.
-                fragment_id: frag-2
-                quote: "connection pool change to checkout-api"
-              unknowns: []
-              action_items:
-                - action: Add pool saturation alerting before the next pool change ships.
-                  owner: platform-oncall
+        incident_source:
+          kind: fixture
+          ref: fixtures/consistent-incident/thread.json
+        postmortem_policy:
+          require_confirmed_root_cause: true
+          require_action_items: true
+          allow_publish: true
+        publish_target:
+          data_source_ref: local://runx-postmortem-maker/harness/consistent
+          channel: incident-review
+          aggregate_id: consistent-incident
+          principal: incident-review-bot
+          audience: incident-review
       expect:
         status: sealed
-        steps: [digest-fragments, draft, finalize]
+        steps: [read_incident, read_outbox, compose, deliver, verify]
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
         step_outputs:
-          finalize:
+          compose:
             subset:
-              postmortem:
-                data:
-                  schema: runx.postmortem.v1
-                  decision: publishable
-                  publish_proposal:
-                    gate: human-approver
-                    delivery_skill: send-as
-                    sent: false
-                  publish_performed: false
-                  validation: { status: pass, findings: [] }
-        receipt: { schema: runx.receipt.v1 }
+              publishable: true
+              root_cause_status: confirmed
+              timeline_count: 4
+          deliver:
+            subset:
+              delivery_result:
+                status: executed
+                delivery_status: delivered
+                operation: send
+                before_version: 0
+                after_version: 1
+                replayed: false
+          verify:
+            subset:
+              publish_result:
+                status: executed
+                operation: send
+              readback:
+                delivered: true
+                digest_match: true
+                delivery_exists: true
+                provider_act_performed: true
+                outbox_version_after: 1
+              evidence:
+                root_cause_status: confirmed
+                timeline_count: 4
 
-    - name: postmortem-maker-unknowns-block-publish
+    - name: conflicting-evidence-withheld
+      runner: default
       inputs:
-        incident_ref: inc-batch-2026-08-10
-        incident_fragments:
-          - id: frag-1
-            source: cron-log
-            text: "Nightly batch failed at step export with exit 1."
-      caller:
-        answers:
-          agent_task.postmortem-maker-draft.output:
-            postmortem_draft:
-              summary: The nightly batch failed at the export step; cause not yet established.
-              timeline:
-                - entry: The nightly batch failed at the export step.
-                  fragment_id: frag-1
-                  quote: "Nightly batch failed at step export"
-              root_cause:
-                status: unknown
-              unknowns:
-                - Which upstream input changed before the export step failed.
-              action_items:
-                - action: Capture export step inputs on failure.
-                  owner: data-oncall
+        incident_source:
+          kind: fixture
+          ref: fixtures/conflicting-incident/thread.json
+        postmortem_policy:
+          require_confirmed_root_cause: true
+          allow_publish: true
+        publish_target:
+          data_source_ref: local://runx-postmortem-maker/harness/conflicting
+          channel: incident-review
+          aggregate_id: conflicting-incident
+          principal: incident-review-bot
+          audience: incident-review
       expect:
         status: sealed
-        steps: [digest-fragments, draft, finalize]
+        steps: [read_incident, read_outbox, compose, verify]
+        receipt:
+          schema: runx.receipt.v1
+          state: sealed
+          disposition: closed
         step_outputs:
-          finalize:
+          compose:
             subset:
-              postmortem:
-                data:
-                  decision: needs_more_evidence
-                  publish_proposal: null
-                  publish_performed: false
-                  validation: { status: pass, findings: [] }
-        receipt: { schema: runx.receipt.v1 }
-
-    - name: postmortem-maker-invented-citation-refuses
-      inputs:
-        incident_ref: inc-x
-        incident_fragments:
-          - id: frag-1
-            source: log
-            text: "Service restarted at 09:00."
-      caller:
-        answers:
-          agent_task.postmortem-maker-draft.output:
-            postmortem_draft:
-              summary: Total outage caused by database corruption.
-              timeline:
-                - entry: The database corrupted.
-                  fragment_id: frag-1
-                  quote: "database corruption detected"
-              root_cause:
-                status: known
-                statement: Database corruption.
-                fragment_id: frag-1
-                quote: "database corruption detected"
-              unknowns: []
-              action_items: []
-      expect:
-        status: sealed
-        steps: [digest-fragments, draft, finalize]
-        step_outputs:
-          finalize:
+              publishable: false
+              root_cause_status: unconfirmed
+          verify:
             subset:
-              postmortem:
-                data:
-                  decision: refused
-                  timeline: []
-                  publish_proposal: null
-                  validation: { status: fail }
-        receipt: { schema: runx.receipt.v1 }
-
-    - name: postmortem-maker-needs-fragments
-      inputs:
-        incident_ref: inc-y
-      expect:
-        status: failure
+              publish_result: null
+              readback:
+                delivered: false
+                digest_match: false
+                delivery_exists: false
+                provider_act_performed: false
+                send_plan_created: false
+                outbox_unchanged: true
+              evidence:
+                root_cause_status: unconfirmed
 
 runners:
-  make:
+  default:
     default: true
     type: graph
     inputs:
-      incident_ref:
-        type: string
-        required: true
-        description: Identifier of the resolved incident this postmortem covers.
-      incident_fragments:
+      incident_source:
         type: json
         required: true
-        description: Collected incident evidence fragments with stable id, source, and text; compose web-fetch or data-store reads to gather them.
-    examples:
-      - incident_ref: inc-checkout-2026-08-09
-        incident_fragments:
-          - id: frag-1
-            source: pagerduty
-            text: "03:12 UTC alert fired."
+        description: >-
+          Runtime source handle. Use {kind: thread_url, url: HTTPS GitHub issue}
+          for a real read, or {kind: read_projection, ref, projection} when a
+          governed upstream incident/ticket read has already materialized the
+          projection. Fixture and inline forms are harness-only.
+      postmortem_policy:
+        type: json
+        required: true
+        description: >-
+          Evidence and publication policy. Set allow_publish explicitly to true
+          to authorize the bundled send-as-equivalent local outbox transport.
+      publish_target:
+        type: json
+        required: false
+        description: >-
+          Optional bounded local target with data_source_ref, channel, and
+          aggregate_id, plus optional principal and audience.
     graph:
-      name: postmortem-maker-make
-      result_from: [finalize]
+      name: postmortem-maker
+      result_from: [verify]
       steps:
-        - id: digest-fragments
-          tool: data.digest
+        - id: read_incident
+          label: read the incident record from its source handle at run time
           inputs:
-            value: $input.incident_fragments
-
-        - id: draft
-          label: separate facts from hypotheses across the fragments
+            incident_source: $input.incident_source
           run:
-            type: agent-task
-            agent: reviewer
-            task: postmortem-maker-draft
+            type: cli-tool
+            command: node
+            args: [steps/read_incident.mjs]
+            input_mode: stdin
             outputs:
-              postmortem_draft: object
-          inputs:
-            incident_ref: $input.incident_ref
-            incident_fragments: $input.incident_fragments
-          allowed_tools: []
-          artifacts:
-            named_emits:
-              postmortem_draft: postmortem_draft
+              incident:
+                type: object
 
-        - id: finalize
-          label: enforce fragment citations deterministically
+        - id: read_outbox
+          label: read the selected publication outbox and its version
           inputs:
-            incident_fragments: $input.incident_fragments
-          context:
-            postmortem_draft: draft.postmortem_draft.data
-            fragments_digest: digest-fragments.digest_result.data.digest
+            publish_target: $input.publish_target
           run:
-            type: javascript
-            module: postmortem-maker.mjs
-            export: finalizePostmortem
+            type: cli-tool
+            command: node
+            args: [steps/read_outbox.mjs]
+            input_mode: stdin
+            outputs:
+              outbox:
+                type: object
+
+        - id: compose
+          label: reconstruct cited evidence and decide whether publication is allowed
+          inputs:
+            postmortem_policy: $input.postmortem_policy
+            publish_target: $input.publish_target
+          context:
+            incident: read_incident.incident
+            outbox: read_outbox.outbox
+          run:
+            type: cli-tool
+            command: node
+            args: [steps/compose.mjs]
+            input_mode: stdin
             outputs:
               postmortem:
                 type: object
                 schema:
-                  required: [schema, decision, reason, summary, timeline, root_cause, unknowns, action_items, publish_proposal, publish_performed, fragments_digest, validation]
+                  type: object
+                  required: [summary, timeline, impact, root_cause, status]
                   additionalProperties: false
                   properties:
-                    schema: { const: runx.postmortem.v1 }
-                    decision: { type: string, enum: [publishable, needs_more_evidence, refused] }
-                    reason: { type: string, minLength: 1, maxLength: 2000 }
-                    summary: { type: [string, "null"], maxLength: 8000 }
+                    summary: {type: string, minLength: 1}
                     timeline:
                       type: array
-                      maxItems: 500
+                      minItems: 1
                       items:
                         type: object
-                        required: [entry, fragment_id, quote]
+                        required: [at, statement, kind, confidence, evidence]
                         additionalProperties: false
                         properties:
-                          entry: { type: string, minLength: 1, maxLength: 4000 }
-                          fragment_id: { type: string, minLength: 1, maxLength: 200 }
-                          quote: { type: string, minLength: 1, maxLength: 4000 }
-                    root_cause:
-                      type: [object, "null"]
-                      required: [status, statement, fragment_id]
-                      additionalProperties: false
-                      properties:
-                        status: { type: string, enum: [known, suspected, unknown] }
-                        statement: { type: [string, "null"], maxLength: 4000 }
-                        fragment_id: { type: [string, "null"], maxLength: 200 }
-                    unknowns:
-                      type: array
-                      maxItems: 100
-                      items: { type: string, minLength: 1, maxLength: 2000 }
-                    action_items:
-                      type: array
-                      maxItems: 100
-                      items:
-                        type: object
-                        required: [action, owner]
-                        additionalProperties: false
-                        properties:
-                          action: { type: string, minLength: 1, maxLength: 2000 }
-                          owner: { type: string, minLength: 1, maxLength: 500 }
-                    publish_proposal:
-                      type: [object, "null"]
-                      required: [gate, delivery_skill, sent]
-                      additionalProperties: false
-                      properties:
-                        gate: { const: human-approver }
-                        delivery_skill: { const: send-as }
-                        sent: { const: false }
-                    publish_performed: { const: false }
-                    fragments_digest: { type: string, pattern: "^sha256:[0-9a-f]{64}$" }
-                    validation:
-                      type: object
-                      required: [status, findings]
-                      additionalProperties: false
-                      properties:
-                        status: { type: string, enum: [pass, fail] }
-                        findings:
-                          type: array
-                          maxItems: 100
-                          items:
-                            type: object
-                            required: [code, message]
-                            additionalProperties: false
-                            properties:
-                              code: { type: string, minLength: 1, maxLength: 200 }
-                              message: { type: string, minLength: 1, maxLength: 2000 }
-          artifacts:
-            named_emits:
-              postmortem: postmortem
+                          at: {type: [string, "null"]}
+                          statement: {type: string, minLength: 1}
+                          kind: {type: string, minLength: 1}
+                          confidence: {type: string, minLength: 1}
+                          evidence: {type: object}
+                    impact: {type: object}
+                    root_cause: {type: object}
+                    status: {type: string, enum: [publishable, needs_more_evidence]}
+              fetched_at: {type: string}
+              unknowns: {type: array}
+              action_items: {type: array}
+              root_cause_status: {type: string, enum: [confirmed, unconfirmed]}
+              timeline_count: {type: number}
+              publishable: {type: boolean}
+              decision: {type: string, enum: [publishable, needs_more_evidence]}
+              send_plan: {type: object}
+              content_digest: {type: string}
+              postmortem_digest: {type: string}
+              source_digest: {type: string}
+              idempotency_key: {type: string}
+              expected_version: {type: number}
+              message: {type: [object, "null"]}
+              delivery_result: {type: [object, "null"]}
+
+        - id: deliver
+          label: execute the authorized send-as-equivalent append with CAS and idempotency
+          when:
+            field: compose.publishable
+            equals: true
+          inputs:
+            publish_target: $input.publish_target
+          context:
+            send_plan: compose.send_plan
+            message: compose.message
+            idempotency_key: compose.idempotency_key
+            expected_version: compose.expected_version
+            content_digest: compose.content_digest
+            postmortem_digest: compose.postmortem_digest
+          run:
+            type: cli-tool
+            command: node
+            args: [steps/deliver.mjs]
+            input_mode: stdin
+            outputs:
+              delivery_result:
+                type: object
+                schema:
+                  type: object
+                  required: [schema, status, delivery_status, provider, operation, message_id, content_digest, postmortem_digest, before_version, after_version, replayed, idempotency_key]
+                  properties:
+                    schema: {const: runx.postmortem-maker.publish-result.v1}
+                    status: {const: executed}
+                    delivery_status: {const: delivered}
+                    provider: {const: local-outbox}
+                    operation: {const: send}
+                    message_id: {type: string}
+                    message_ref: {type: string}
+                    content_digest: {type: string}
+                    postmortem_digest: {type: string}
+                    before_version: {type: number}
+                    after_version: {type: number}
+                    replayed: {type: boolean}
+                    idempotency_key: {type: string}
+
+        - id: verify
+          label: independently read back the outbox and seal evidence for send or absence
+          inputs:
+            publish_target: $input.publish_target
+          context:
+            incident: read_incident.incident
+            postmortem: compose.postmortem
+            unknowns: compose.unknowns
+            action_items: compose.action_items
+            publishable: compose.publishable
+            send_plan: compose.send_plan
+            content_digest: compose.content_digest
+            postmortem_digest: compose.postmortem_digest
+            idempotency_key: compose.idempotency_key
+            expected_version: compose.expected_version
+            delivery_result: compose.delivery_result
+          run:
+            type: cli-tool
+            command: node
+            args: [steps/verify.mjs]
+            input_mode: stdin
+            outputs:
+              schema: {type: string}
+              skill: {type: string}
+              version: {type: string}
+              source: {type: object}
+              postmortem: {type: object}
+              unknowns: {type: array}
+              action_items: {type: array}
+              publishable: {type: boolean}
+              root_cause_status: {type: string}
+              timeline_count: {type: number}
+              content_digest: {type: string}
+              idempotency_key: {type: string}
+              expected_version: {type: number}
+              send_plan: {type: object}
+              publish_result: {type: [object, "null"]}
+              readback: {type: object}
+              verification: {type: object}
+              evidence: {type: object}

--- a/skills/postmortem-maker/fixtures/conflicting-incident/expected.json
+++ b/skills/postmortem-maker/fixtures/conflicting-incident/expected.json
@@ -1,0 +1,17 @@
+{
+  "case": "conflicting-evidence-withheld",
+  "expected": {
+    "publishable": false,
+    "root_cause_status": "unconfirmed",
+    "unknowns_at_least": 1,
+    "publish_result": null,
+    "readback": {
+      "delivered": false,
+      "digest_match": false,
+      "delivery_exists": false,
+      "provider_act_performed": false,
+      "send_plan_created": false,
+      "outbox_unchanged": true
+    }
+  }
+}

--- a/skills/postmortem-maker/fixtures/conflicting-incident/input.json
+++ b/skills/postmortem-maker/fixtures/conflicting-incident/input.json
@@ -1,0 +1,17 @@
+{
+  "incident_source": {
+    "kind": "fixture",
+    "ref": "fixtures/conflicting-incident/thread.json"
+  },
+  "postmortem_policy": {
+    "require_confirmed_root_cause": true,
+    "allow_publish": true
+  },
+  "publish_target": {
+    "data_source_ref": "local://runx-postmortem-maker/harness/conflicting",
+    "channel": "incident-review",
+    "aggregate_id": "conflicting-incident",
+    "principal": "incident-review-bot",
+    "audience": "incident-review"
+  }
+}

--- a/skills/postmortem-maker/fixtures/conflicting-incident/thread.json
+++ b/skills/postmortem-maker/fixtures/conflicting-incident/thread.json
@@ -1,0 +1,27 @@
+{
+  "title": "API latency above SLO",
+  "url": "fixture://postmortem-maker/conflicting-incident",
+  "events": [
+    {
+      "id": "evt-1",
+      "at": "2026-08-02T14:05:00Z",
+      "author": "monitoring",
+      "url": "fixture://postmortem-maker/conflicting-incident#evt-1",
+      "text": "At 14:05 API latency degraded above the SLO and the error rate rose."
+    },
+    {
+      "id": "evt-2",
+      "at": "2026-08-02T14:15:00Z",
+      "author": "dev1",
+      "url": "fixture://postmortem-maker/conflicting-incident#evt-2",
+      "text": "Might be the api-gateway v1.2.0 deploy that caused it?"
+    },
+    {
+      "id": "evt-3",
+      "at": "2026-08-02T14:17:00Z",
+      "author": "dev2",
+      "url": "fixture://postmortem-maker/conflicting-incident#evt-3",
+      "text": "I suspect the search v3.1.0 change instead, not sure."
+    }
+  ]
+}

--- a/skills/postmortem-maker/fixtures/consistent-incident/expected.json
+++ b/skills/postmortem-maker/fixtures/consistent-incident/expected.json
@@ -1,0 +1,15 @@
+{
+  "case": "consistent-incident-published",
+  "expected": {
+    "publishable": true,
+    "root_cause_status": "confirmed",
+    "timeline_count": 4,
+    "publish_result_status": "executed",
+    "readback": {
+      "delivered": true,
+      "digest_match": true,
+      "delivery_exists": true,
+      "provider_act_performed": true
+    }
+  }
+}

--- a/skills/postmortem-maker/fixtures/consistent-incident/input.json
+++ b/skills/postmortem-maker/fixtures/consistent-incident/input.json
@@ -1,0 +1,18 @@
+{
+  "incident_source": {
+    "kind": "fixture",
+    "ref": "fixtures/consistent-incident/thread.json"
+  },
+  "postmortem_policy": {
+    "require_confirmed_root_cause": true,
+    "require_action_items": true,
+    "allow_publish": true
+  },
+  "publish_target": {
+    "data_source_ref": "local://runx-postmortem-maker/harness/consistent",
+    "channel": "incident-review",
+    "aggregate_id": "consistent-incident",
+    "principal": "incident-review-bot",
+    "audience": "incident-review"
+  }
+}

--- a/skills/postmortem-maker/fixtures/consistent-incident/thread.json
+++ b/skills/postmortem-maker/fixtures/consistent-incident/thread.json
@@ -1,0 +1,34 @@
+{
+  "title": "Checkout error rate spike",
+  "url": "fixture://postmortem-maker/consistent-incident",
+  "events": [
+    {
+      "id": "evt-1",
+      "at": "2026-08-01T10:02:00Z",
+      "author": "monitoring",
+      "url": "fixture://postmortem-maker/consistent-incident#evt-1",
+      "text": "At 10:02 the checkout error rate spiked to 40 percent and roughly 1200 users saw failed checkouts over 18 minutes."
+    },
+    {
+      "id": "evt-2",
+      "at": "2026-08-01T10:10:00Z",
+      "author": "oncall",
+      "url": "fixture://postmortem-maker/consistent-incident#evt-2",
+      "text": "The 09:58 checkout-api v2.4.1 deploy introduced a null pointer in the payment path, so the failures are caused by that release."
+    },
+    {
+      "id": "evt-3",
+      "at": "2026-08-01T10:21:00Z",
+      "author": "oncall",
+      "url": "fixture://postmortem-maker/consistent-incident#evt-3",
+      "text": "Rolled back checkout-api and at 10:20 the error rate returned to baseline."
+    },
+    {
+      "id": "evt-4",
+      "at": "2026-08-01T10:40:00Z",
+      "author": "eng-lead",
+      "url": "fixture://postmortem-maker/consistent-incident#evt-4",
+      "text": "Action item: add a payment path contract test before the next release. Owner: platform-oncall."
+    }
+  ]
+}

--- a/skills/postmortem-maker/steps/common.mjs
+++ b/skills/postmortem-maker/steps/common.mjs
@@ -1,0 +1,241 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PACKAGE_NAME = "postmortem-maker";
+export const PACKAGE_VERSION = "0.1.0";
+
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const MAX_STDIN_BYTES = 2 * 1024 * 1024;
+const MAX_EVENT_TEXT = 12_000;
+
+export function packageRoot() {
+  return PACKAGE_ROOT;
+}
+
+export async function readEnvelope() {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of process.stdin) {
+    size += Buffer.byteLength(chunk);
+    if (size > MAX_STDIN_BYTES) {
+      throw new Error("input exceeds the 2 MiB execution boundary");
+    }
+    chunks.push(chunk);
+  }
+  let raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) {
+    const envJson = process.env.RUNX_INPUTS_JSON;
+    if (typeof envJson === "string" && envJson.trim()) {
+      raw = envJson.trim();
+    } else {
+      const envPath = process.env.RUNX_INPUTS_PATH;
+      if (typeof envPath === "string" && envPath.trim()) {
+        try {
+          raw = fs.readFileSync(envPath, "utf8").trim();
+        } catch {
+          throw new Error("runtime input file could not be read");
+        }
+      }
+    }
+  }
+  if (!raw) return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("runner input must be one JSON object");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("runner input must be a JSON object");
+  }
+  return parsed;
+}
+
+export function field(envelope, name) {
+  if (envelope?.inputs && Object.prototype.hasOwnProperty.call(envelope.inputs, name)) {
+    return envelope.inputs[name];
+  }
+  if (envelope?.context && Object.prototype.hasOwnProperty.call(envelope.context, name)) {
+    return envelope.context[name];
+  }
+  if (Object.prototype.hasOwnProperty.call(envelope ?? {}, name)) {
+    return envelope[name];
+  }
+  return undefined;
+}
+
+export async function runCli(handler) {
+  try {
+    const envelope = await readEnvelope();
+    const result = await handler(envelope);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "step failed";
+    process.stderr.write(`${JSON.stringify({ error: { code: "step_failed", message } })}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export function requireObject(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be a JSON object`);
+  }
+  return value;
+}
+
+export function requireString(value, name, { maxLength = 2_000 } = {}) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  if (value.length > maxLength) {
+    throw new Error(`${name} exceeds its ${maxLength} character limit`);
+  }
+  return value.trim();
+}
+
+export function clampText(value, maxLength = MAX_EVENT_TEXT) {
+  const text = typeof value === "string" ? value : "";
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}\n[truncated]`;
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  return Object.keys(value)
+    .sort()
+    .reduce((result, key) => {
+      result[key] = canonicalize(value[key]);
+      return result;
+    }, {});
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256(value) {
+  const bytes = typeof value === "string" ? value : canonicalJson(value);
+  return `sha256:${crypto.createHash("sha256").update(bytes, "utf8").digest("hex")}`;
+}
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+export function eventCitation(event, quote = event.text) {
+  return {
+    event_id: event.id,
+    author: event.author,
+    at: event.at,
+    url: event.url,
+    quote,
+  };
+}
+
+export function normalizeEvents(thread, sourceRef) {
+  requireObject(thread, "incident thread");
+  const events = thread.events;
+  if (!Array.isArray(events)) throw new Error("incident thread events must be an array");
+  if (events.length > 200) throw new Error("incident thread is limited to 200 events");
+
+  const seen = new Set();
+  const normalized = events.map((event, index) => {
+    requireObject(event, `incident thread event ${index}`);
+    const id = requireString(event.id, `incident thread event ${index}.id`, { maxLength: 200 });
+    if (seen.has(id)) throw new Error(`incident thread contains duplicate event id: ${id}`);
+    seen.add(id);
+    if (typeof event.text !== "string" || event.text.trim() === "") {
+      throw new Error(`incident thread event ${index}.text must be a non-empty string`);
+    }
+    const text = clampText(event.text);
+    const at = typeof event.at === "string" && event.at.trim() ? event.at.trim() : null;
+    const author = typeof event.author === "string" && event.author.trim() ? event.author.trim() : "unknown";
+    const url = typeof event.url === "string" && event.url.trim() ? event.url.trim() : `${sourceRef}#${encodeURIComponent(id)}`;
+    return { id, at, author, url, text };
+  });
+
+  normalized.sort((left, right) => {
+    const leftTime = left.at ? Date.parse(left.at) : Number.NaN;
+    const rightTime = right.at ? Date.parse(right.at) : Number.NaN;
+    if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+      return leftTime - rightTime;
+    }
+    return events.findIndex((event) => event.id === left.id) - events.findIndex((event) => event.id === right.id);
+  });
+
+  return normalized;
+}
+
+export function stateRoot() {
+  const configured = process.env.RUNX_STATE_DIR;
+  if (configured && path.isAbsolute(configured)) {
+    return path.join(configured, PACKAGE_NAME);
+  }
+  return path.join(PACKAGE_ROOT, ".runx", PACKAGE_NAME);
+}
+
+export function targetRef(target) {
+  if (!target || typeof target !== "object" || Array.isArray(target)) return "local://runx-postmortem-maker/default";
+  return typeof target.data_source_ref === "string" && target.data_source_ref.trim()
+    ? target.data_source_ref.trim()
+    : "local://runx-postmortem-maker/default";
+}
+
+export function outboxFile(target) {
+  const key = crypto.createHash("sha256").update(targetRef(target), "utf8").digest("hex");
+  return path.join(stateRoot(), `${key}.json`);
+}
+
+function emptyOutbox(target) {
+  return {
+    schema: "runx.postmortem-maker.outbox.v1",
+    store_ref: targetRef(target),
+    version: 0,
+    messages: [],
+  };
+}
+
+export function readOutboxState(target) {
+  const file = outboxFile(target);
+  if (!fs.existsSync(file)) return emptyOutbox(target);
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    throw new Error("publication outbox is not valid JSON");
+  }
+  if (!parsed || parsed.schema !== "runx.postmortem-maker.outbox.v1" || !Number.isInteger(parsed.version) || parsed.version < 0 || !Array.isArray(parsed.messages)) {
+    throw new Error("publication outbox has an invalid shape");
+  }
+  return parsed;
+}
+
+export function writeOutboxState(target, state) {
+  const file = outboxFile(target);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temporary = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(state)}\n`, { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(temporary, file);
+}
+
+export function publicOutboxSummary(state) {
+  return {
+    schema: state.schema,
+    store_ref: state.store_ref,
+    version: state.version,
+    messages: state.messages.map((message) => ({
+      message_id: message.message_id,
+      idempotency_key: message.idempotency_key,
+      content_digest: message.content_digest,
+      postmortem_digest: message.postmortem_digest,
+      aggregate_ref: message.aggregate_ref,
+    })),
+  };
+}
+
+export function isMainModule(metaUrl) {
+  return process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(metaUrl));
+}

--- a/skills/postmortem-maker/steps/compose.mjs
+++ b/skills/postmortem-maker/steps/compose.mjs
@@ -1,0 +1,320 @@
+import {
+  eventCitation,
+  field,
+  isMainModule,
+  nowIso,
+  requireObject,
+  requireString,
+  runCli,
+  sha256,
+} from "./common.mjs";
+
+const HEDGE_RE = /\b(?:might|may|could|possibly|perhaps|suspect(?:ed)?|likely|unlikely|maybe|not sure|unsure|unclear|appears|seems|think|guess|hypothes(?:is|ized)|if)\b/i;
+const CAUSE_CUE_RE = /\b(?:cause|caused|causes|causing|because|due to|introduced|root cause|responsible|blame|suspect(?:ed)?)\b/i;
+const IMPACT_RE = /\b(?:outage|degrad(?:ed|ation)|error(?:s)?|failure(?:s)?|5xx|latency|slo|affected|impact(?:ed)?|unavailable|timeout|spike|failed checkout|users? saw)\b|\b\d+(?:\.\d+)?\s*%/i;
+const MITIGATION_RE = /\b(?:rollback|rolled back|roll back|restor(?:ed|e)|recover(?:ed|y)|resolved|baseline|mitigat(?:ed|ion)|fixed|reverted|stabil(?:ized|ised))\b/i;
+const ACTION_RE = /\b(?:action item|follow[- ]?up|todo|next step|should add|must add|add .*?(?:test|alert|guard|monitor)|prevent recurrence)\b/i;
+const GENERIC_TOKENS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "because", "by", "caused", "causes", "change", "changed", "deploy", "deployment", "did", "due", "for", "from", "in", "introduced", "is", "it", "of", "on", "or", "release", "root", "that", "the", "this", "to", "was", "were", "with",
+]);
+
+function textTokens(value) {
+  return new Set(
+    value
+      .toLowerCase()
+      .replace(/v?\d+(?:\.\d+){1,3}/g, " ")
+      .replace(/\b\d{1,2}:\d{2}(?:\s*utc)?\b/g, " ")
+      .replace(/[^a-z0-9-]+/g, " ")
+      .split(/\s+/)
+      .filter((token) => token.length > 2 && !GENERIC_TOKENS.has(token)),
+  );
+}
+
+function candidateSimilar(left, right) {
+  const a = textTokens(left);
+  const b = textTokens(right);
+  if (!a.size || !b.size) return left.toLowerCase() === right.toLowerCase();
+  let shared = 0;
+  for (const token of a) if (b.has(token)) shared += 1;
+  return shared / Math.min(a.size, b.size) >= 0.6;
+}
+
+function cleanCandidate(value) {
+  return value
+    .replace(/^\s*(?:the|a|an)\s+/i, "")
+    .replace(/[\s,;:.!?]+$/g, "")
+    .trim()
+    .slice(0, 800);
+}
+
+function extractCause(event) {
+  const text = event.text;
+  if (!CAUSE_CUE_RE.test(text)) return null;
+  const hedged = HEDGE_RE.test(text);
+  const patterns = [
+    /(?:might|may|could|possibly|perhaps)\s+be\s+(?:the\s+)?(.+?)(?:\s+(?:that|which)\s+(?:caused|led|resulted)|[?.!,]|$)/i,
+    /(?:i\s+)?suspect(?:ed)?\s+(?:the\s+)?(.+?)(?:\s+(?:instead|that|which)|[?.!,]|$)/i,
+    /(?:root\s+cause\s*(?:is|was|:))\s*(.+?)(?:[.!?]|$)/i,
+    /(.+?)\s+introduced\s+(.+?)(?:,|;|\.|$)/i,
+    /(.+?)\s+(?:caused|led\s+to|resulted\s+in)\s+(.+?)(?:[.!?]|$)/i,
+    /(?:caused\s+by|due\s+to|because\s+of)\s+(.+?)(?:[.!?]|$)/i,
+  ];
+  let candidate = null;
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (!match) continue;
+    if (pattern.source.includes("introduced")) {
+      candidate = cleanCandidate(`${match[1]} introduced ${match[2]}`);
+    } else if (pattern.source.includes("caused|led")) {
+      candidate = cleanCandidate(match[1]);
+    } else {
+      candidate = cleanCandidate(match[1]);
+    }
+    if (candidate && !/^(?:that|this|it|the release|the change)$/i.test(candidate)) break;
+  }
+  if (!candidate || /^(?:that|this|it|the release|the change)$/i.test(candidate)) candidate = cleanCandidate(text);
+  return { event, candidate, hedged };
+}
+
+function groupCandidates(candidates) {
+  const groups = [];
+  for (const candidate of candidates) {
+    const group = groups.find((existing) => candidateSimilar(existing.candidate, candidate.candidate));
+    if (group) {
+      group.items.push(candidate);
+    } else {
+      groups.push({ candidate: candidate.candidate, items: [candidate] });
+    }
+  }
+  return groups;
+}
+
+function classifyEvent(event, cause) {
+  if (cause) return cause.hedged ? "hypothesis" : "root_cause_claim";
+  if (ACTION_RE.test(event.text)) return "action_item";
+  if (MITIGATION_RE.test(event.text)) return "mitigation";
+  if (IMPACT_RE.test(event.text)) return "impact";
+  return "observation";
+}
+
+function confidenceFor(event, cause) {
+  if (cause?.hedged) return "low";
+  if (cause) return "high";
+  if (IMPACT_RE.test(event.text) || MITIGATION_RE.test(event.text)) return "medium";
+  return "source_only";
+}
+
+function extractAction(event, index) {
+  if (!ACTION_RE.test(event.text)) return null;
+  const ownerMatch = event.text.match(/\bowner\s*[:=]\s*([A-Za-z0-9_.@/-]+)/i);
+  const owner = ownerMatch ? ownerMatch[1].replace(/[.,;:]+$/g, "") : null;
+  const actionText = event.text
+    .replace(/^\s*(?:action item|follow[- ]?up|todo|next step)\s*[:=-]?\s*/i, "")
+    .replace(/\s*\bowner\s*[:=]\s*[A-Za-z0-9_.@/-]+\.?\s*$/i, "")
+    .trim();
+  return {
+    id: `action-${index + 1}`,
+    title: actionText || event.text,
+    owner,
+    evidence: [eventCitation(event)],
+    policy_rule: owner ? "source_explicit" : "owner_not_stated",
+  };
+}
+
+function normalizePolicy(value) {
+  if (value === undefined || value === null) return {};
+  const policy = requireObject(value, "postmortem_policy");
+  if (Object.prototype.hasOwnProperty.call(policy, "allow_publish") && typeof policy.allow_publish !== "boolean") {
+    throw new Error("postmortem_policy.allow_publish must be boolean");
+  }
+  if (Object.prototype.hasOwnProperty.call(policy, "require_confirmed_root_cause") && typeof policy.require_confirmed_root_cause !== "boolean") {
+    throw new Error("postmortem_policy.require_confirmed_root_cause must be boolean");
+  }
+  if (Object.prototype.hasOwnProperty.call(policy, "require_action_items") && typeof policy.require_action_items !== "boolean") {
+    throw new Error("postmortem_policy.require_action_items must be boolean");
+  }
+  return policy;
+}
+
+function normalizeTarget(value) {
+  if (value === undefined || value === null) {
+    return {
+      data_source_ref: "local://runx-postmortem-maker/default",
+      channel: "incident-review",
+      aggregate_id: "default",
+      principal: "postmortem-maker",
+      audience: "incident-review",
+      classification: "internal",
+      visibility: "operator",
+    };
+  }
+  const target = requireObject(value, "publish_target");
+  const dataSourceRef = requireString(target.data_source_ref, "publish_target.data_source_ref", { maxLength: 500 });
+  const channel = requireString(target.channel, "publish_target.channel", { maxLength: 300 });
+  const aggregateId = requireString(target.aggregate_id, "publish_target.aggregate_id", { maxLength: 300 });
+  return {
+    data_source_ref: dataSourceRef,
+    channel,
+    aggregate_id: aggregateId,
+    principal: typeof target.principal === "string" && target.principal.trim() ? target.principal.trim() : "postmortem-maker",
+    audience: typeof target.audience === "string" && target.audience.trim() ? target.audience.trim() : channel,
+    classification: typeof target.classification === "string" && target.classification.trim() ? target.classification.trim() : "internal",
+    visibility: typeof target.visibility === "string" && target.visibility.trim() ? target.visibility.trim() : "operator",
+  };
+}
+
+function reasonForBlock({ rootStatus, unknowns, policy, actions }) {
+  if (rootStatus !== "confirmed") return "root cause is not confirmed by one unhedged source claim";
+  if (unknowns.length) return "unresolved facts remain in unknowns";
+  if (policy.require_action_items && actions.length === 0) return "policy requires at least one source-owned action item";
+  if (policy.allow_publish !== true) return "publication requires postmortem_policy.allow_publish=true";
+  return "evidence and publication policy passed";
+}
+
+async function handler(envelope) {
+  const incident = requireObject(field(envelope, "incident"), "incident");
+  const events = Array.isArray(incident.events) ? incident.events : [];
+  if (!events.length) throw new Error("incident must contain at least one event");
+  const policy = normalizePolicy(field(envelope, "postmortem_policy"));
+  const target = normalizeTarget(field(envelope, "publish_target"));
+  const causeClaims = events.map(extractCause).filter(Boolean);
+  const groups = groupCandidates(causeClaims);
+  const unhedgedGroups = groups.filter((group) => group.items.some((item) => !item.hedged));
+
+  let rootCause;
+  let rootCauseStatus;
+  if (unhedgedGroups.length === 1 && groups.length === 1) {
+    const selected = unhedgedGroups[0];
+    const citations = selected.items.map((item) => eventCitation(item.event));
+    rootCauseStatus = "confirmed";
+    rootCause = {
+      status: "confirmed",
+      statement: selected.candidate,
+      citations,
+      corroborated_by_mitigation: events.some((event) => MITIGATION_RE.test(event.text)),
+    };
+  } else {
+    rootCauseStatus = "unconfirmed";
+    rootCause = {
+      status: "unconfirmed",
+      statement: null,
+      citations: causeClaims.map((item) => eventCitation(item.event)),
+      corroborated_by_mitigation: false,
+    };
+  }
+
+  const timeline = events.map((event) => {
+    const cause = causeClaims.find((item) => item.event.id === event.id) ?? null;
+    return {
+      at: event.at,
+      statement: event.text,
+      kind: classifyEvent(event, cause),
+      confidence: confidenceFor(event, cause),
+      evidence: eventCitation(event),
+    };
+  });
+
+  const impactEvent = events.find((event) => IMPACT_RE.test(event.text));
+  const mitigationEvent = events.find((event) => MITIGATION_RE.test(event.text));
+  const impact = impactEvent
+    ? { status: "known", statement: impactEvent.text, citations: [eventCitation(impactEvent)] }
+    : { status: "unknown", statement: null, citations: [] };
+  const actions = events.map(extractAction).filter(Boolean);
+  const unknowns = [];
+  if (!impactEvent) {
+    unknowns.push({ id: "unknown-impact", detail: "The source does not state a concrete customer or service impact.", evidence: [] });
+  }
+  if (!mitigationEvent) {
+    unknowns.push({ id: "unknown-mitigation", detail: "The source does not state whether mitigation or recovery completed.", evidence: [] });
+  }
+  if (rootCauseStatus !== "confirmed") {
+    unknowns.push({
+      id: "unknown-root-cause",
+      detail: groups.length > 1 ? "Multiple causal candidates remain in the source; the root cause is unresolved." : "The source contains no unhedged, confirmed causal claim.",
+      evidence: causeClaims.map((item) => eventCitation(item.event)),
+    });
+  }
+  if (policy.require_action_items && actions.length === 0) {
+    unknowns.push({ id: "unknown-action-owner", detail: "The publication policy requires at least one source-owned action item.", evidence: [] });
+  }
+
+  const evidenceReady = rootCauseStatus === "confirmed" && unknowns.length === 0;
+  const publishable = evidenceReady && policy.allow_publish === true;
+  const decision = publishable ? "publishable" : "needs_more_evidence";
+  const postmortem = {
+    summary: `Incident ${incident.title ?? "without a title"} is reconstructed from ${events.length} source event(s).`,
+    timeline,
+    impact,
+    root_cause: rootCause,
+    status: decision,
+  };
+  const postmortemDigest = sha256(postmortem);
+  const sourceDigest = incident.source?.source_digest ?? sha256({ title: incident.title, events });
+  const stableSource = {
+    kind: incident.source?.kind ?? "incident_thread",
+    ref: incident.source?.ref ?? "unknown",
+    read_mode: incident.source?.read_mode ?? "unknown",
+    events_read: incident.source?.events_read ?? events.length,
+    source_digest: sourceDigest,
+  };
+  const content = {
+    title: `Postmortem: ${incident.title ?? "Untitled incident"}`,
+    source: stableSource,
+    postmortem,
+    unknowns,
+    action_items: actions,
+  };
+  const contentDigest = sha256(content);
+  const idempotencyKey = `postmortem-maker:${sourceDigest}:${sha256(target.aggregate_id).slice(7, 23)}`;
+  const sendPlan = publishable
+    ? {
+        schema: "runx.send-as.plan.v1",
+        status: "authorized",
+        action_family: "send-as",
+        principal: { type: "account", ref: target.principal },
+        provider: { name: "local-outbox", account_ref: target.data_source_ref, runtime_path: "append" },
+        send_class: "incident-postmortem",
+        channel: { type: "channel", ref: target.channel },
+        audience: { type: "audience", ref: target.audience },
+        content: { digest: contentDigest, subject_or_title: content.title },
+        consent_basis: "postmortem_policy.allow_publish",
+        gates: { preflight_required: true, human_approval_required: false, approval_ref: "policy:allow_publish" },
+        provider_actions: ["outbox.append"],
+        evidence_refs: [sourceDigest, postmortemDigest],
+        transport: { kind: "equivalent_sealed_comms_transport", skill: "send-as" },
+      }
+    : {
+        schema: "runx.send-as.plan.v1",
+        status: "withheld",
+        action_family: "send-as",
+        reason: reasonForBlock({ rootStatus: rootCauseStatus, unknowns, policy, actions }),
+        consent_basis: "postmortem_policy.allow_publish",
+        provider_actions: [],
+        evidence_refs: [sourceDigest, postmortemDigest],
+      };
+
+  return {
+    postmortem,
+    fetched_at: incident.source?.observed_at ?? nowIso(),
+    unknowns,
+    action_items: actions,
+    root_cause_status: rootCauseStatus,
+    timeline_count: timeline.length,
+    publishable,
+    decision,
+    send_plan: sendPlan,
+    content_digest: contentDigest,
+    postmortem_digest: postmortemDigest,
+    source_digest: sourceDigest,
+    idempotency_key: idempotencyKey,
+    expected_version: Number.isInteger(field(envelope, "outbox")?.version) ? field(envelope, "outbox").version : 0,
+    message: publishable ? content : null,
+    delivery_result: null,
+  };
+}
+
+if (isMainModule(import.meta.url)) {
+  runCli(handler);
+}
+
+export { handler as composePostmortem };

--- a/skills/postmortem-maker/steps/deliver.mjs
+++ b/skills/postmortem-maker/steps/deliver.mjs
@@ -1,0 +1,110 @@
+import {
+  field,
+  isMainModule,
+  nowIso,
+  readOutboxState,
+  requireObject,
+  requireString,
+  runCli,
+  sha256,
+  writeOutboxState,
+} from "./common.mjs";
+
+function aggregateRef(target) {
+  return `aggregate://${sha256(`${target.data_source_ref}|${target.aggregate_id}`).slice(7, 31)}`;
+}
+
+function messageRef(target, messageId) {
+  return `outbox://postmortem-maker/${sha256(`${target.data_source_ref}|${target.aggregate_id}|${messageId}`).slice(7, 31)}`;
+}
+
+async function handler(envelope) {
+  const target = requireObject(field(envelope, "publish_target"), "publish_target");
+  const sendPlan = requireObject(field(envelope, "send_plan"), "send_plan");
+  const message = requireObject(field(envelope, "message"), "message");
+  const idempotencyKey = requireString(field(envelope, "idempotency_key"), "idempotency_key", { maxLength: 1_000 });
+  const expectedVersion = field(envelope, "expected_version");
+  if (!Number.isInteger(expectedVersion) || expectedVersion < 0) throw new Error("expected_version must be a non-negative integer");
+  if (sendPlan.status !== "authorized") throw new Error("delivery requires an authorized send plan");
+  if (sendPlan.content?.digest !== field(envelope, "content_digest") && field(envelope, "content_digest")) {
+    throw new Error("send plan content digest does not match the approved content");
+  }
+
+  const state = readOutboxState(target);
+  const existing = state.messages.find((item) => item.idempotency_key === idempotencyKey);
+  if (existing) {
+    if (existing.content_digest !== sendPlan.content?.digest) {
+      throw new Error("idempotency key is already bound to different content");
+    }
+    return {
+      delivery_result: {
+        schema: "runx.postmortem-maker.publish-result.v1",
+        status: "executed",
+        delivery_status: "delivered",
+        provider: "local-outbox",
+        operation: "send",
+        message_id: existing.message_id,
+        message_ref: existing.message_ref,
+        content_digest: existing.content_digest,
+        postmortem_digest: existing.postmortem_digest,
+        before_version: state.version,
+        after_version: state.version,
+        replayed: true,
+        executed_at: nowIso(),
+        idempotency_key: idempotencyKey,
+      },
+    };
+  }
+
+  if (state.version !== expectedVersion) {
+    throw new Error(`publication outbox changed from version ${expectedVersion} to ${state.version}`);
+  }
+
+  const contentDigest = requireString(sendPlan.content?.digest, "send_plan.content.digest", { maxLength: 100 });
+  const postmortemDigest = requireString(field(envelope, "postmortem_digest"), "postmortem_digest", { maxLength: 100 });
+  const messageId = `msg_${sha256(idempotencyKey).slice(7, 31)}`;
+  const storedMessage = {
+    message_id: messageId,
+    message_ref: messageRef(target, messageId),
+    aggregate_ref: aggregateRef(target),
+    idempotency_key: idempotencyKey,
+    content_digest: contentDigest,
+    postmortem_digest: postmortemDigest,
+    channel: sendPlan.channel?.ref ?? target.channel,
+    principal: sendPlan.principal?.ref ?? target.principal ?? "postmortem-maker",
+    audience: sendPlan.audience?.ref ?? target.audience ?? target.channel,
+    content: message,
+  };
+  const beforeVersion = state.version;
+  const nextState = {
+    ...state,
+    version: beforeVersion + 1,
+    messages: [...state.messages, storedMessage],
+  };
+  writeOutboxState(target, nextState);
+
+  return {
+    delivery_result: {
+      schema: "runx.postmortem-maker.publish-result.v1",
+      status: "executed",
+      delivery_status: "delivered",
+      provider: "local-outbox",
+      operation: "send",
+      message_id: messageId,
+      message_ref: storedMessage.message_ref,
+      content_digest: contentDigest,
+      postmortem_digest: postmortemDigest,
+      before_version: beforeVersion,
+      after_version: nextState.version,
+      replayed: false,
+      executed_at: nowIso(),
+      idempotency_key: idempotencyKey,
+    },
+  };
+}
+
+if (isMainModule(import.meta.url)) {
+  runCli(handler);
+}
+
+export { handler as deliverPostmortem };

--- a/skills/postmortem-maker/steps/read_incident.mjs
+++ b/skills/postmortem-maker/steps/read_incident.mjs
@@ -1,0 +1,192 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  PACKAGE_NAME,
+  PACKAGE_VERSION,
+  clampText,
+  field,
+  isMainModule,
+  normalizeEvents,
+  nowIso,
+  packageRoot,
+  readEnvelope,
+  requireObject,
+  requireString,
+  runCli,
+  sha256,
+} from "./common.mjs";
+
+const GITHUB_API_HOST = "api.github.com";
+const GITHUB_HOST = "github.com";
+const MAX_RESPONSE_BYTES = 1_500_000;
+
+function safeFixturePath(ref) {
+  const relative = requireString(ref, "incident_source.ref", { maxLength: 300 });
+  if (!relative.startsWith("fixtures/") || relative.includes("..") || path.isAbsolute(relative)) {
+    throw new Error("fixture sources must stay under fixtures/ and cannot contain ..");
+  }
+  const root = path.resolve(packageRoot());
+  const candidate = path.resolve(root, relative);
+  if (candidate !== root && !candidate.startsWith(`${root}${path.sep}`)) {
+    throw new Error("fixture source escaped the package boundary");
+  }
+  return candidate;
+}
+
+function parseJsonFile(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    throw new Error("incident fixture is not valid JSON");
+  }
+}
+
+function threadFromObject(value, ref, readMode) {
+  const thread = requireObject(value, "incident thread");
+  const title = typeof thread.title === "string" && thread.title.trim() ? thread.title.trim() : "Untitled incident";
+  const threadUrl = typeof thread.url === "string" && thread.url.trim() ? thread.url.trim() : ref;
+  const events = normalizeEvents(thread, threadUrl);
+  if (events.length === 0) throw new Error("incident source contained no readable events");
+  const sourceDigest = sha256({
+    ref,
+    title,
+    events,
+  });
+  return {
+    source: {
+      kind: "incident_thread",
+      ref,
+      read_mode: readMode,
+      events_read: events.length,
+      source_digest: sourceDigest,
+      observed_at: nowIso(),
+    },
+    title,
+    url: threadUrl,
+    events,
+  };
+}
+
+function toApiIssueUrl(value) {
+  const parsed = new URL(requireString(value, "incident_source.url", { maxLength: 2_000 }));
+  if (parsed.protocol !== "https:") throw new Error("incident source must use HTTPS");
+
+  if (parsed.hostname === GITHUB_API_HOST && /^\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(parsed.pathname)) {
+    return parsed.toString();
+  }
+  if (parsed.hostname === GITHUB_HOST) {
+    const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:\/)?$/);
+    if (match) return `https://${GITHUB_API_HOST}/repos/${match[1]}/${match[2]}/issues/${match[3]}`;
+  }
+  throw new Error("thread_url supports public GitHub issue URLs only");
+}
+
+async function fetchJson(url) {
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": `${PACKAGE_NAME}/${PACKAGE_VERSION}`,
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    throw new Error("incident source fetch failed");
+  }
+  const length = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(length) && length > MAX_RESPONSE_BYTES) throw new Error("incident source response is too large");
+  let body;
+  try {
+    body = await response.text();
+  } catch {
+    throw new Error("incident source response could not be read");
+  }
+  if (Buffer.byteLength(body, "utf8") > MAX_RESPONSE_BYTES) throw new Error("incident source response is too large");
+  if (!response.ok) throw new Error(`incident source returned HTTP ${response.status}`);
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error("incident source did not return JSON");
+  }
+}
+
+function githubThread(issue, comments, requestedUrl) {
+  requireObject(issue, "GitHub issue response");
+  const issueNumber = String(issue.number ?? "issue");
+  const issueUrl = typeof issue.html_url === "string" && issue.html_url ? issue.html_url : requestedUrl;
+  const events = [
+    {
+      id: `issue-${issueNumber}`,
+      at: issue.created_at ?? null,
+      author: issue.user?.login ?? "unknown",
+      url: issueUrl,
+      text: clampText(typeof issue.body === "string" ? issue.body : ""),
+    },
+  ];
+  if (!events[0].text) events.shift();
+  if (Array.isArray(comments)) {
+    for (const comment of comments.slice(0, 100)) {
+      if (!comment || typeof comment !== "object" || typeof comment.body !== "string" || !comment.body.trim()) continue;
+      events.push({
+        id: `comment-${String(comment.id ?? events.length)}`,
+        at: comment.created_at ?? null,
+        author: comment.user?.login ?? "unknown",
+        url: comment.html_url ?? `${issueUrl}#issuecomment-${String(comment.id ?? events.length)}`,
+        text: clampText(comment.body),
+      });
+    }
+  }
+  return {
+    title: typeof issue.title === "string" && issue.title.trim() ? issue.title.trim() : `GitHub issue #${issueNumber}`,
+    url: issueUrl,
+    events,
+  };
+}
+
+async function readGitHubIssue(source) {
+  const requestedUrl = toApiIssueUrl(source.url ?? source.ref);
+  const issue = await fetchJson(requestedUrl);
+  const commentsUrl = typeof issue.comments_url === "string" ? issue.comments_url : `${requestedUrl}/comments`;
+  const comments = Number(issue.comments ?? 0) > 0 ? await fetchJson(`${commentsUrl}?per_page=100`) : [];
+  return threadFromObject(githubThread(issue, comments, source.url ?? source.ref), source.url ?? source.ref, "github_issue_api");
+}
+
+function readFixture(source) {
+  const file = safeFixturePath(source.ref);
+  const parsed = parseJsonFile(file);
+  const thread = parsed.thread ?? parsed.incident ?? parsed;
+  return threadFromObject(thread, `fixture://${source.ref}`, "checked_in_fixture");
+}
+
+function readProjection(source) {
+  const projection = source.projection ?? source.record ?? source.thread;
+  if (!projection) throw new Error("read_projection source must contain a resolved projection");
+  const ref = requireString(source.ref, "incident_source.ref", { maxLength: 2_000 });
+  return threadFromObject(projection, ref, "incident_read_projection");
+}
+
+async function handler(envelope) {
+  const source = requireObject(field(envelope, "incident_source"), "incident_source");
+  const kind = requireString(source.kind, "incident_source.kind", { maxLength: 60 });
+  let incident;
+  if (kind === "thread_url" || kind === "github_issue") {
+    incident = await readGitHubIssue(source);
+  } else if (kind === "fixture") {
+    incident = readFixture(source);
+  } else if (kind === "inline") {
+    incident = threadFromObject(source.thread, source.ref ?? "inline://incident", "inline_harness_fixture");
+  } else if (kind === "read_projection") {
+    incident = readProjection(source);
+  } else {
+    throw new Error("incident_source.kind must be thread_url, github_issue, read_projection, fixture, or inline");
+  }
+  return { incident };
+}
+
+if (isMainModule(import.meta.url)) {
+  runCli(handler);
+}
+
+export { handler as readIncident };

--- a/skills/postmortem-maker/steps/read_outbox.mjs
+++ b/skills/postmortem-maker/steps/read_outbox.mjs
@@ -1,0 +1,19 @@
+import {
+  field,
+  isMainModule,
+  publicOutboxSummary,
+  readOutboxState,
+  requireObject,
+  runCli,
+} from "./common.mjs";
+
+async function handler(envelope) {
+  const target = requireObject(field(envelope, "publish_target") ?? {}, "publish_target");
+  return { outbox: publicOutboxSummary(readOutboxState(target)) };
+}
+
+if (isMainModule(import.meta.url)) {
+  runCli(handler);
+}
+
+export { handler as readOutbox };

--- a/skills/postmortem-maker/steps/verify.mjs
+++ b/skills/postmortem-maker/steps/verify.mjs
@@ -1,0 +1,130 @@
+import {
+  PACKAGE_NAME,
+  PACKAGE_VERSION,
+  field,
+  isMainModule,
+  readOutboxState,
+  requireObject,
+  runCli,
+} from "./common.mjs";
+
+function sourceSummary(incident) {
+  return {
+    kind: incident.source?.kind ?? "incident_thread",
+    ref: incident.source?.ref ?? "unknown",
+    read_mode: incident.source?.read_mode ?? "unknown",
+    events_read: incident.source?.events_read ?? (Array.isArray(incident.events) ? incident.events.length : 0),
+    source_digest: incident.source?.source_digest ?? null,
+  };
+}
+
+async function handler(envelope) {
+  const incident = requireObject(field(envelope, "incident"), "incident");
+  const postmortem = requireObject(field(envelope, "postmortem"), "postmortem");
+  const target = requireObject(field(envelope, "publish_target") ?? {}, "publish_target");
+  const sendPlan = requireObject(field(envelope, "send_plan"), "send_plan");
+  const publishable = field(envelope, "publishable") === true;
+  const contentDigest = field(envelope, "content_digest");
+  const postmortemDigest = field(envelope, "postmortem_digest");
+  const idempotencyKey = field(envelope, "idempotency_key");
+  const expectedVersion = field(envelope, "expected_version");
+  const deliveryResult = field(envelope, "delivery_result") ?? null;
+  const state = readOutboxState(target);
+  const message = typeof idempotencyKey === "string"
+    ? state.messages.find((item) => item.idempotency_key === idempotencyKey) ?? null
+    : null;
+
+  let readback;
+  let publishResult = deliveryResult;
+  if (publishable) {
+    if (!message) throw new Error("authorized publication has no outbox message to read back");
+    const digestMatch = message.content_digest === contentDigest && message.postmortem_digest === postmortemDigest;
+    if (!digestMatch) throw new Error("outbox readback digest does not match the authorized postmortem");
+    readback = {
+      delivered: true,
+      digest_match: true,
+      delivery_exists: true,
+      provider_act_performed: true,
+      message_id: message.message_id,
+      message_ref: message.message_ref,
+      outbox_version_after: state.version,
+      outbox_unchanged: deliveryResult?.replayed === true,
+    };
+    if (!publishResult) {
+      publishResult = {
+        schema: "runx.postmortem-maker.publish-result.v1",
+        status: "executed",
+        delivery_status: "delivered",
+        provider: "local-outbox",
+        operation: "send",
+        message_id: message.message_id,
+        message_ref: message.message_ref,
+        content_digest: message.content_digest,
+        postmortem_digest: message.postmortem_digest,
+        before_version: expectedVersion,
+        after_version: state.version,
+        replayed: true,
+        idempotency_key: idempotencyKey,
+      };
+    }
+  } else {
+    const unchanged = Number.isInteger(expectedVersion) && state.version === expectedVersion;
+    if (message || !unchanged) {
+      throw new Error("withheld publication could not prove absence without changing the outbox");
+    }
+    readback = {
+      delivered: false,
+      digest_match: false,
+      delivery_exists: false,
+      provider_act_performed: false,
+      send_plan_created: false,
+      outbox_unchanged: true,
+      outbox_version_after: state.version,
+    };
+    publishResult = null;
+  }
+
+  const evidence = {
+    source_read: sourceSummary(incident),
+    timeline_count: Array.isArray(postmortem.timeline) ? postmortem.timeline.length : 0,
+    impact: postmortem.impact,
+    root_cause_status: postmortem.root_cause?.status ?? "unknown",
+    unknowns: field(envelope, "unknowns") ?? [],
+    action_items: field(envelope, "action_items") ?? [],
+    executed_publish_result: publishResult,
+    send_plan_status: sendPlan.status,
+    receipt_id: null,
+  };
+  const verification = {
+    schema: "runx.postmortem-maker.verification.v1",
+    status: "passed",
+    checked_at: new Date().toISOString(),
+    readback,
+  };
+  return {
+    schema: "runx.postmortem-maker.result.v1",
+    skill: PACKAGE_NAME,
+    version: PACKAGE_VERSION,
+    source: sourceSummary(incident),
+    postmortem,
+    unknowns: field(envelope, "unknowns") ?? [],
+    action_items: field(envelope, "action_items") ?? [],
+    publishable,
+    root_cause_status: postmortem.root_cause?.status ?? "unknown",
+    timeline_count: Array.isArray(postmortem.timeline) ? postmortem.timeline.length : 0,
+    content_digest: contentDigest,
+    idempotency_key: idempotencyKey,
+    expected_version: expectedVersion,
+    send_plan: sendPlan,
+    publish_result: publishResult,
+    readback,
+    verification,
+    evidence,
+  };
+}
+
+if (isMainModule(import.meta.url)) {
+  runCli(handler);
+}
+
+export { handler as verifyPostmortem };

--- a/tests/postmortem-maker-smoke.mjs
+++ b/tests/postmortem-maker-smoke.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { composePostmortem } from "../skills/postmortem-maker/steps/compose.mjs";
+import { deliverPostmortem } from "../skills/postmortem-maker/steps/deliver.mjs";
+import { readIncident } from "../skills/postmortem-maker/steps/read_incident.mjs";
+import { readOutbox } from "../skills/postmortem-maker/steps/read_outbox.mjs";
+import { verifyPostmortem } from "../skills/postmortem-maker/steps/verify.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packageRoot = path.join(repoRoot, "skills", "postmortem-maker");
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+async function runStep(step, envelope, stateDir) {
+  const handlers = {
+    "steps/read_incident.mjs": readIncident,
+    "steps/read_outbox.mjs": readOutbox,
+    "steps/compose.mjs": composePostmortem,
+    "steps/deliver.mjs": deliverPostmortem,
+    "steps/verify.mjs": verifyPostmortem,
+  };
+  const handler = handlers[step];
+  if (!handler) throw new Error(`no local handler registered for ${step}`);
+  const previousStateDir = process.env.RUNX_STATE_DIR;
+  process.env.RUNX_STATE_DIR = stateDir;
+  try {
+    return await handler(envelope);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.RUNX_STATE_DIR;
+    else process.env.RUNX_STATE_DIR = previousStateDir;
+  }
+}
+
+function assertCitations(incident, postmortem) {
+  const eventById = new Map(incident.events.map((event) => [event.id, event]));
+  for (const entry of postmortem.timeline) {
+    const source = eventById.get(entry.evidence.event_id);
+    assert.ok(source, `timeline citation ${entry.evidence.event_id} exists`);
+    assert.equal(entry.evidence.quote, source.text, "timeline quote is verbatim");
+    assert.equal(entry.statement, source.text, "timeline statement stays source-bound");
+  }
+  for (const citation of postmortem.root_cause.citations) {
+    const source = eventById.get(citation.event_id);
+    assert.ok(source, `root-cause citation ${citation.event_id} exists`);
+    assert.equal(citation.quote, source.text, "root-cause quote is verbatim");
+  }
+}
+
+async function executeCase(caseDirectory, stateDir) {
+  const input = readJson(path.join(caseDirectory, "input.json"));
+  const incidentOutput = await runStep("steps/read_incident.mjs", { inputs: { incident_source: input.incident_source } }, stateDir);
+  const outboxOutput = await runStep("steps/read_outbox.mjs", { inputs: { publish_target: input.publish_target } }, stateDir);
+  const compose = await runStep(
+    "steps/compose.mjs",
+    {
+      inputs: {
+        postmortem_policy: input.postmortem_policy,
+        publish_target: input.publish_target,
+      },
+      context: {
+        incident: incidentOutput.incident,
+        outbox: outboxOutput.outbox,
+      },
+    },
+    stateDir,
+  );
+  let delivery = null;
+  if (compose.publishable) {
+    delivery = await runStep(
+      "steps/deliver.mjs",
+      {
+        inputs: { publish_target: input.publish_target },
+        context: {
+          send_plan: compose.send_plan,
+          message: compose.message,
+          idempotency_key: compose.idempotency_key,
+          expected_version: compose.expected_version,
+          content_digest: compose.content_digest,
+          postmortem_digest: compose.postmortem_digest,
+        },
+      },
+      stateDir,
+    );
+  }
+  const verified = await runStep(
+    "steps/verify.mjs",
+    {
+      inputs: { publish_target: input.publish_target },
+      context: {
+        incident: incidentOutput.incident,
+        postmortem: compose.postmortem,
+        unknowns: compose.unknowns,
+        action_items: compose.action_items,
+        publishable: compose.publishable,
+        send_plan: compose.send_plan,
+        content_digest: compose.content_digest,
+        postmortem_digest: compose.postmortem_digest,
+        idempotency_key: compose.idempotency_key,
+        expected_version: compose.expected_version,
+        delivery_result: delivery?.delivery_result ?? null,
+      },
+    },
+    stateDir,
+  );
+  assertCitations(incidentOutput.incident, compose.postmortem);
+  return { input, incident: incidentOutput.incident, outbox: outboxOutput.outbox, compose, delivery, verified };
+}
+
+function assertExpected(result, expected) {
+  assert.equal(result.compose.publishable, expected.publishable);
+  assert.equal(result.compose.root_cause_status, expected.root_cause_status);
+  if (expected.timeline_count !== undefined) assert.equal(result.compose.timeline_count, expected.timeline_count);
+  if (expected.unknowns_at_least !== undefined) assert.ok(result.compose.unknowns.length >= expected.unknowns_at_least);
+  if (expected.publish_result_status) assert.equal(result.verified.publish_result.status, expected.publish_result_status);
+  if (expected.publish_result === null) assert.equal(result.verified.publish_result, null);
+  for (const [key, value] of Object.entries(expected.readback ?? {})) assert.equal(result.verified.readback[key], value, `readback.${key}`);
+}
+
+function assertContractFiles() {
+  const skill = fs.readFileSync(path.join(packageRoot, "SKILL.md"), "utf8");
+  const profile = fs.readFileSync(path.join(packageRoot, "X.yaml"), "utf8");
+  assert.match(skill, /^---\nname: postmortem-maker\n/m);
+  assert.match(skill, /allow_publish/);
+  assert.match(profile, /^skill: postmortem-maker\nversion: "0\.1\.0"/m);
+  assert.match(profile, /name: consistent-incident-published/);
+  assert.match(profile, /name: conflicting-evidence-withheld/);
+  assert.match(profile, /type: graph/);
+  assert.match(profile, /type: cli-tool/);
+}
+
+async function assertHostileFixtureRefused(stateDir) {
+  await assert.rejects(
+    () => runStep("steps/read_incident.mjs", { inputs: { incident_source: { kind: "fixture", ref: "fixtures/../SKILL.md" } } }, stateDir),
+    /cannot contain \.\./,
+    "fixture traversal must be refused",
+  );
+}
+
+async function assertSourceAllowlistRefused(stateDir) {
+  await assert.rejects(
+    () => runStep("steps/read_incident.mjs", { inputs: { incident_source: { kind: "thread_url", url: "http://127.0.0.1:8080/internal" } } }, stateDir),
+    /must use HTTPS/,
+    "non-HTTPS sources must be refused",
+  );
+  await assert.rejects(
+    () => runStep("steps/read_incident.mjs", { inputs: { incident_source: { kind: "thread_url", url: "https://example.com/incident/1" } } }, stateDir),
+    /public GitHub issue URLs only/,
+    "non-GitHub sources must be refused before fetch",
+  );
+}
+
+async function assertLongEventBodyAccepted(stateDir) {
+  const longText = "x".repeat(2_500);
+  const result = await runStep(
+    "steps/read_incident.mjs",
+    {
+      inputs: {
+        incident_source: {
+          kind: "inline",
+          ref: "inline://long-event-body",
+          thread: {
+            title: "Long event body",
+            events: [{ id: "event-1", author: "tester", at: "2026-01-01T00:00:00Z", text: longText }],
+          },
+        },
+      },
+    },
+    stateDir,
+  );
+  assert.equal(result.incident.events.length, 1);
+  assert.equal(result.incident.events[0].text, longText, "event bodies above the field-validation limit remain readable");
+}
+
+const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "postmortem-maker-smoke-"));
+try {
+  await (async () => {
+  assertContractFiles();
+  const consistentDirectory = path.join(packageRoot, "fixtures", "consistent-incident");
+  const conflictingDirectory = path.join(packageRoot, "fixtures", "conflicting-incident");
+  const consistent = await executeCase(consistentDirectory, stateDir);
+  const consistentExpected = readJson(path.join(consistentDirectory, "expected.json")).expected;
+  assertExpected(consistent, consistentExpected);
+  assert.equal(consistent.delivery.delivery_result.replayed, false);
+
+  const replay = await executeCase(consistentDirectory, stateDir);
+  assert.equal(replay.delivery.delivery_result.replayed, true, "same content is idempotent");
+  assert.equal(replay.delivery.delivery_result.before_version, 1, "replay keeps outbox version");
+  assert.equal(replay.delivery.delivery_result.after_version, 1, "replay does not append twice");
+
+  const conflicting = await executeCase(conflictingDirectory, stateDir);
+  const conflictingExpected = readJson(path.join(conflictingDirectory, "expected.json")).expected;
+  assertExpected(conflicting, conflictingExpected);
+  await assertHostileFixtureRefused(stateDir);
+  await assertSourceAllowlistRefused(stateDir);
+  await assertLongEventBodyAccepted(stateDir);
+
+  process.stdout.write(`${JSON.stringify({
+    status: "passed",
+    cases: [
+      { name: "consistent-incident-published", status: "sealed", publishable: consistent.compose.publishable, delivery: consistent.verified.publish_result?.status ?? null },
+      { name: "conflicting-evidence-withheld", status: "sealed", publishable: conflicting.compose.publishable, unknowns: conflicting.compose.unknowns.length, delivery: null },
+      { name: "idempotent-replay", status: "passed", replayed: replay.delivery.delivery_result.replayed },
+      { name: "fixture-traversal-refused", status: "refused" },
+      { name: "source-allowlist-refused", status: "refused" },
+      { name: "long-event-body-accepted", status: "passed" },
+    ],
+  })}\n`);
+  })();
+} finally {
+  fs.rmSync(stateDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
Adds the postmortem-maker skill workflow and its verification evidence. Prepared by AJP for human review before any GitHub write.